### PR TITLE
ThePEG and its dependencies

### DIFF
--- a/fastjet.sh
+++ b/fastjet.sh
@@ -1,0 +1,50 @@
+package: FastJet
+version: "3.0.6_1.012"
+---
+#!/bin/bash -e
+
+VerFJContrib="${PKGVERSION#*_}"
+VerFJ="${PKGVERSION%%_*}"
+
+UrlFJ="http://fastjet.fr/repo/fastjet-${VerFJ}.tar.gz"
+UrlFJContrib="http://fastjet.hepforge.org/contrib/downloads/fjcontrib-${VerFJContrib}.tar.gz"
+
+Boost='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0'
+Cgal='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/cgal/v4.4'
+
+curl -Lo fastjet.tar.gz "$UrlFJ"
+curl -Lo fjcontrib.tar.gz "$UrlFJContrib"
+
+tar xzf fastjet.tar.gz
+tar xzf fjcontrib.tar.gz
+
+export LD_LIBRARY_PATH="${Boost}/lib:${LD_LIBRARY_PATH}"
+export LIBRARY_PATH="${Boost}/lib:${LIBRARY_PATH}"
+
+# Build FastJet
+cd $BUILDDIR/fastjet-$VerFJ
+export CXXFLAGS="-Wl,--no-as-needed -lgmp -L${Boost}/lib -lboost_thread -lboost_system -L${Cgal}/lib -I${Boost}/include -I${Cgal}/include -DCGAL_DO_NOT_USE_MPZF -O2 -g"
+export CFLAGS="${CXXFLAGS}"
+export CPATH="${Boost}/include:${Cgal}/include"
+export C_INCLUDE_PATH="${Boost}/include:${Cgal}/include"
+./configure \
+  --enable-shared \
+  --enable-cgal \
+  --with-cgal="${Cgal}" \
+  --prefix="$INSTALLROOT" \
+  --enable-allcxxplugins
+make -j$JOBS
+make install -j$JOBS
+
+# Build FastJet Contrib
+cd $BUILDDIR/fjcontrib-$VerFJContrib
+./configure \
+  --fastjet-config=$INSTALLROOT/bin/fastjet-config \
+  CXXFLAGS="$CXXFLAGS" \
+  CFLAGS="$CFLAGS" \
+  CPATH="$CPATH" \
+  C_INCLUDE_PATH="$C_INCLUDE_PATH"
+make -j$JOBS
+make install
+make fragile-shared -j$JOBS
+make fragile-shared-install

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -1,4 +1,4 @@
-package: FastJet
+package: fastjet
 version: "3.1.3_1.017"
 ---
 #!/bin/bash -e

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -1,5 +1,5 @@
 package: FastJet
-version: "3.0.6_1.012"
+version: "3.1.3_1.017"
 ---
 #!/bin/bash -e
 

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -1,10 +1,11 @@
 package: fastjet
-version: "3.1.3_1.017"
+version: "v3.1.3_1.017"
 ---
 #!/bin/bash -e
 
-VerFJContrib="${PKGVERSION#*_}"
-VerFJ="${PKGVERSION%%_*}"
+VerWithoutV=${PKGVERSION:1}
+VerFJContrib="${VerWithoutV#*_}"
+VerFJ="${VerWithoutV%%_*}"
 
 UrlFJ="http://fastjet.fr/repo/fastjet-${VerFJ}.tar.gz"
 UrlFJContrib="http://fastjet.hepforge.org/contrib/downloads/fjcontrib-${VerFJContrib}.tar.gz"

--- a/gsl.sh
+++ b/gsl.sh
@@ -1,0 +1,11 @@
+package: GSL
+version: "1.16"
+---
+#!/bin/bash -e
+Url="ftp://ftp.gnu.org/gnu/gsl/gsl-${PKGVERSION}.tar.gz"
+curl -o gsl.tar.gz "$Url"
+tar xzf gsl.tar.gz
+cd gsl-$PKGVERSION
+./configure --prefix="$INSTALLROOT"
+make -j$JOBS
+make install -j$JOBS

--- a/gsl.sh
+++ b/gsl.sh
@@ -9,3 +9,31 @@ cd gsl-$PKGVERSION
 ./configure --prefix="$INSTALLROOT"
 make -j$JOBS
 make install -j$JOBS
+
+# Modulefile
+ModuleDir="${INSTALLROOT}/etc/Modules/modulefiles/${PKGNAME}"
+mkdir -p "$ModuleDir"
+cat > "${ModuleDir}/${PKGVERSION}-${PKGREVISION}" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+}
+set version $PKGVERSION-$PKGREVISION
+module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+# Dependencies
+module load BASE/1.0
+# Our environment
+if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
+  puts stderr "Note: overriding base package $PKGNAME \$version"
+  set prefix \$ModulesCurrentModulefile
+  for {set i 0} {\$i < 5} {incr i} {
+    set prefix [file dirname \$prefix]
+  }
+  setenv GSL_BASEDIR \$prefix
+} else {
+  setenv GSL_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
+}
+prepend-path LD_LIBRARY_PATH \$::env(GSL_BASEDIR)/lib
+prepend-path PATH \$::env(GSL_BASEDIR)/bin
+EoF

--- a/gsl.sh
+++ b/gsl.sh
@@ -1,11 +1,12 @@
 package: GSL
-version: "1.16"
+version: "v1.16"
 ---
 #!/bin/bash -e
-Url="ftp://ftp.gnu.org/gnu/gsl/gsl-${PKGVERSION}.tar.gz"
+VerWithoutV=${PKGVERSION:1}
+Url="ftp://ftp.gnu.org/gnu/gsl/gsl-${VerWithoutV}.tar.gz"
 curl -o gsl.tar.gz "$Url"
 tar xzf gsl.tar.gz
-cd gsl-$PKGVERSION
+cd gsl-$VerWithoutV
 ./configure --prefix="$INSTALLROOT"
 make -j$JOBS
 make install -j$JOBS

--- a/rivet.sh
+++ b/rivet.sh
@@ -3,7 +3,7 @@ version: "2.2.1"
 requires:
   - GSL
   - YODA
-  - FastJet
+  - fastjet
 ---
 #!/bin/bash -e
 Url="http://www.hepforge.org/archive/rivet/Rivet-${PKGVERSION}.tar.bz2"
@@ -41,7 +41,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-$PKGREVISION
 module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
 # Dependencies
-module load BASE/1.0 YODA/$YODA_VERSION-$YODA_REVISION FastJet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION HepMC/v2.06.09
+module load BASE/1.0 YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION HepMC/v2.06.09
 # Our environment
 if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
   puts stderr "Note: overriding base package $PKGNAME \$version"

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,0 +1,27 @@
+package: Rivet
+version: "2.2.1"
+requires:
+  - GSL
+  - YODA
+---
+#!/bin/bash -e
+Url="http://www.hepforge.org/archive/rivet/Rivet-${PKGVERSION}.tar.bz2"
+# TODO: we will build them soon instead of getting them from CVMFS
+Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
+HepMC="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/HepMC/v2.06.09"
+FastJet="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/fastjet/v3.0.6_1.012"
+Cgal="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/cgal/v4.4"
+curl -Lo rivet.tar.bz2 "$Url"
+tar xjf rivet.tar.bz2
+cd Rivet-$PKGVERSION
+export LDFLAGS="-L$Cgal/lib ${LDFLAGS}"
+./configure \
+  --prefix="$INSTALLROOT" \
+  --disable-doxygen \
+  --with-yoda="$YODA_ROOT" \
+  --with-gsl="$GSL_ROOT" \
+  --with-hepmc="$HepMC" \
+  --with-fastjet="$FastJet" \
+  --with-boost="$Boost"
+make -j$JOBS
+make install -j$JOBS

--- a/rivet.sh
+++ b/rivet.sh
@@ -3,25 +3,28 @@ version: "2.2.1"
 requires:
   - GSL
   - YODA
+  - FastJet
 ---
 #!/bin/bash -e
 Url="http://www.hepforge.org/archive/rivet/Rivet-${PKGVERSION}.tar.bz2"
-# TODO: we will build them soon instead of getting them from CVMFS
+
+# External dependencies. TODO: build them instead.
 Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
 HepMC="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/HepMC/v2.06.09"
-FastJet="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/fastjet/v3.0.6_1.012"
 Cgal="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/cgal/v4.4"
+
 curl -Lo rivet.tar.bz2 "$Url"
 tar xjf rivet.tar.bz2
 cd Rivet-$PKGVERSION
-export LDFLAGS="-L$Cgal/lib ${LDFLAGS}"
+export LDFLAGS="-L$Cgal/lib -L$Boost/lib ${LDFLAGS}"
+export LD_LIBRARY_PATH="${Cgal}/lib:${Boost}/lib:${LD_LIBRARY_PATH}"
 ./configure \
   --prefix="$INSTALLROOT" \
   --disable-doxygen \
   --with-yoda="$YODA_ROOT" \
   --with-gsl="$GSL_ROOT" \
   --with-hepmc="$HepMC" \
-  --with-fastjet="$FastJet" \
+  --with-fastjet="$FASTJET_ROOT" \
   --with-boost="$Boost"
 make -j$JOBS
 make install -j$JOBS

--- a/rivet.sh
+++ b/rivet.sh
@@ -28,3 +28,33 @@ export LD_LIBRARY_PATH="${Cgal}/lib:${Boost}/lib:${LD_LIBRARY_PATH}"
   --with-boost="$Boost"
 make -j$JOBS
 make install -j$JOBS
+
+# Modulefile
+ModuleDir="${INSTALLROOT}/etc/Modules/modulefiles/${PKGNAME}"
+mkdir -p "$ModuleDir"
+cat > "${ModuleDir}/${PKGVERSION}-${PKGREVISION}" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+}
+set version $PKGVERSION-$PKGREVISION
+module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+# Dependencies
+module load BASE/1.0 YODA/$YODA_VERSION-$YODA_REVISION FastJet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION HepMC/v2.06.09
+# Our environment
+if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
+  puts stderr "Note: overriding base package $PKGNAME \$version"
+  set prefix \$ModulesCurrentModulefile
+  for {set i 0} {\$i < 5} {incr i} {
+    set prefix [file dirname \$prefix]
+  }
+  setenv YODA_BASEDIR \$prefix
+} else {
+  setenv YODA_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
+}
+prepend-path LD_LIBRARY_PATH \$::env(YODA_BASEDIR)/lib
+prepend-path PATH \$::env(YODA_BASEDIR)/bin
+set pythonpath [exec rivet-config --pythonpath]
+prepend-path PYTHONPATH \$pythonpath
+EoF

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,12 +1,13 @@
 package: Rivet
-version: "2.2.1"
+version: "v2.2.1"
 requires:
   - GSL
   - YODA
   - fastjet
 ---
 #!/bin/bash -e
-Url="http://www.hepforge.org/archive/rivet/Rivet-${PKGVERSION}.tar.bz2"
+VerWithoutV=${PKGVERSION:1}
+Url="http://www.hepforge.org/archive/rivet/Rivet-${VerWithoutV}.tar.bz2"
 
 # External dependencies. TODO: build them instead.
 Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
@@ -15,7 +16,7 @@ Cgal="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/cgal/v4.4"
 
 curl -Lo rivet.tar.bz2 "$Url"
 tar xjf rivet.tar.bz2
-cd Rivet-$PKGVERSION
+cd Rivet-$VerWithoutV
 export LDFLAGS="-L$Cgal/lib -L$Boost/lib ${LDFLAGS}"
 export LD_LIBRARY_PATH="${Cgal}/lib:${Boost}/lib:${LD_LIBRARY_PATH}"
 ./configure \

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -44,3 +44,32 @@ autoreconf -ivf
   --enable-unitchecks
 make -j$JOBS C_INCLUDE_PATH="${GSL_ROOT}/include" CPATH="${GSL_ROOT}/include"
 make install -j$JOBS
+
+# Modulefile
+ModuleDir="${INSTALLROOT}/etc/Modules/modulefiles/${PKGNAME}"
+mkdir -p "$ModuleDir"
+cat > "${ModuleDir}/${PKGVERSION}-${PKGREVISION}" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+}
+set version $PKGVERSION-$PKGREVISION
+module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+# Dependencies
+module load BASE/1.0 lhapdf/v5.9.1 pythia/v8186 HepMC/v2.06.09 FastJet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
+# Our environment
+if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
+  puts stderr "Note: overriding base package $PKGNAME \$version"
+  set prefix \$ModulesCurrentModulefile
+  for {set i 0} {\$i < 5} {incr i} {
+    set prefix [file dirname \$prefix]
+  }
+  setenv THEPEG_BASEDIR \$prefix
+} else {
+  setenv THEPEG_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
+}
+prepend-path LD_LIBRARY_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
+prepend-path PATH \$::env(THEPEG_ROOT)/bin
+setenv ThePEG_INSTALL_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
+EoF

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -5,7 +5,7 @@ tag: "alice/v2015-03-18"
 requires:
   - Rivet
   - GSL
-  - FastJet
+  - fastjet
 ---
 #!/bin/bash -e
 
@@ -57,7 +57,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-$PKGREVISION
 module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
 # Dependencies
-module load BASE/1.0 lhapdf/v5.9.1 pythia/v8186 HepMC/v2.06.09 FastJet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
+module load BASE/1.0 lhapdf/v5.9.1 pythia/v8186 HepMC/v2.06.09 fastjet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
 # Our environment
 if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
   puts stderr "Note: overriding base package $PKGNAME \$version"

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -1,0 +1,46 @@
+package: ThePEG
+version: v20150318
+source: https://github.com/alisw/thepeg
+tag: "alice/v2015-03-18"
+requires:
+  - Rivet
+  - GSL
+  - FastJet
+---
+#!/bin/bash -e
+
+Pythia8='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/pythia/v8186'
+HepMC='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/HepMC/v2.06.09'
+LhaPDF='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/lhapdf/v5.9.1'
+Cgal='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/cgal/v4.4'
+Boost='/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0'
+
+export LD_LIBRARY_PATH="${LhaPDF}/lib:${Cgal}/lib:${Boost}/lib:${LD_LIBRARY_PATH}"
+export LIBRARY_PATH="${LhaPDF}/lib:${Cgal}/lib:${Boost}/lib:${LIBRARY_PATH}"
+export LHAPATH="${LhaPDF}/share/lhapdf/PDFsets"
+
+cd "$SOURCEDIR"
+
+find . \
+  -name configure.ac -or \
+  -name aclocal.m4 -or \
+  -name configure -or \
+  -name Makefile.am -or \
+  -name Makefile.in \
+  -exec touch '{}' \;
+autoreconf -ivf
+./configure \
+  --disable-silent-rules \
+  --enable-shared \
+  --disable-static \
+  --without-javagui \
+  --prefix="$INSTALLROOT" \
+  --with-gsl="$GSL_ROOT" \
+  --with-pythia8="$Pythia8" \
+  --with-hepmc="$HepMC" \
+  --with-rivet="$RIVET_ROOT" \
+  --with-lhapdf="$LhaPDF" \
+  --with-fastjet="$FASTJET_ROOT" \
+  --enable-unitchecks
+make -j$JOBS C_INCLUDE_PATH="${GSL_ROOT}/include" CPATH="${GSL_ROOT}/include"
+make install -j$JOBS

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,0 +1,13 @@
+package: YODA
+version: "1.3.1"
+---
+#!/bin/bash -e
+Url="http://www.hepforge.org/archive/yoda/YODA-${PKGVERSION}.tar.bz2"
+# TODO: will be a dependency
+Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
+curl -Lo yoda.tar.bz2 "$Url"
+tar xjf yoda.tar.bz2
+cd YODA-$PKGVERSION
+./configure --prefix="$INSTALLROOT" --with-boost="$Boost"
+make -j$JOBS
+make install -j$JOBS

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,5 +1,5 @@
 package: YODA
-version: "1.3.1"
+version: "1.4.0"
 ---
 #!/bin/bash -e
 Url="http://www.hepforge.org/archive/yoda/YODA-${PKGVERSION}.tar.bz2"

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,15 +1,16 @@
 package: YODA
-version: "1.4.0"
+version: "v1.4.0"
 ---
 #!/bin/bash -e
-Url="http://www.hepforge.org/archive/yoda/YODA-${PKGVERSION}.tar.bz2"
+VerWithoutV=${PKGVERSION:1}
+Url="http://www.hepforge.org/archive/yoda/YODA-${VerWithoutV}.tar.bz2"
 
 # TODO: deps from CVMFS must disappear
 Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
 
 curl -Lo yoda.tar.bz2 "$Url"
 tar xjf yoda.tar.bz2
-cd YODA-$PKGVERSION
+cd YODA-$VerWithoutV
 ./configure --prefix="$INSTALLROOT" --with-boost="$Boost"
 make -j$JOBS
 make install -j$JOBS

--- a/yoda.sh
+++ b/yoda.sh
@@ -3,11 +3,43 @@ version: "1.3.1"
 ---
 #!/bin/bash -e
 Url="http://www.hepforge.org/archive/yoda/YODA-${PKGVERSION}.tar.bz2"
-# TODO: will be a dependency
+
+# TODO: deps from CVMFS must disappear
 Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
+
 curl -Lo yoda.tar.bz2 "$Url"
 tar xjf yoda.tar.bz2
 cd YODA-$PKGVERSION
 ./configure --prefix="$INSTALLROOT" --with-boost="$Boost"
 make -j$JOBS
 make install -j$JOBS
+
+# Modulefile
+ModuleDir="${INSTALLROOT}/etc/Modules/modulefiles/${PKGNAME}"
+mkdir -p "$ModuleDir"
+cat > "${ModuleDir}/${PKGVERSION}-${PKGREVISION}" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+}
+set version $PKGVERSION-$PKGREVISION
+module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+# Dependencies
+module load BASE/1.0 boost/v1_53_0
+# Our environment
+if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
+  puts stderr "Note: overriding base package $PKGNAME \$version"
+  set prefix \$ModulesCurrentModulefile
+  for {set i 0} {\$i < 5} {incr i} {
+    set prefix [file dirname \$prefix]
+  }
+  setenv YODA_BASEDIR \$prefix
+} else {
+  setenv YODA_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
+}
+prepend-path LD_LIBRARY_PATH \$::env(YODA_BASEDIR)/lib
+prepend-path PATH \$::env(YODA_BASEDIR)/bin
+set pythonpath [exec yoda-config --pythonpath]
+prepend-path PYTHONPATH \$pythonpath
+EoF


### PR DESCRIPTION
This includes:

* YODA
* Rivet
* FastJet
* GSL

All package names are compatible with the current ("legacy"?) naming conventions from CVMFS, *i.e.* capitalization is respected and version numbers have a "v" prepended (*i.e.* `v1.0` instead of `1.0`).

For the moment they have a "hard" dependency on some binaries from CVMFS, this is in the TODO list to amend.