### PR TITLE
Package names and SLC6 fix

### DIFF
--- a/alien.sh
+++ b/alien.sh
@@ -1,4 +1,4 @@
-package: alien
+package: AliEn
 version: v1
 prepend_path:
   - "LD_LIBRARY_PATH": "$ALIEN_ROOT/alien/api/lib"

--- a/aliroot-test.sh
+++ b/aliroot-test.sh
@@ -1,9 +1,9 @@
-package: aliroot-test
+package: AliRoot-test
 version: v1
 force_rebuild: 1
 requires:
-  - aliroot
-  - geant3
+  - AliRoot
+  - GEANT3
 ---
 #!/bin/sh
 export ALICE_ROOT=$ALIROOT_ROOT

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -1,7 +1,7 @@
-package: aliroot
+package: AliRoot
 version: v5-06-28
 requires:
-  - root
+  - ROOT
 env:
   ALICE_ROOT: \$INSTALLROOT
 source: http://git.cern.ch/pub/AliRoot

--- a/clhep.sh
+++ b/clhep.sh
@@ -1,4 +1,4 @@
-package: clhep 
+package: CLHEP
 version: "2.2.0.8"
 source: https://github.com/alisw/clhep
 tag: CLHEP_2_2_0_8

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,4 +1,4 @@
-package: cmake
+package: CMake
 version: v2.8.12
 source: https://github.com/Kitware/CMake
 requires:

--- a/dds.sh
+++ b/dds.sh
@@ -1,4 +1,4 @@
-package: dds
+package: DDS
 version: master
 source: https://github.com/FairRootGroup/DDS
 requires:

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,12 +1,12 @@
-package: fairroot
+package: FairRoot
 version: master
 source: https://github.com/FairRootGroup/FairRoot
 tag: master
 requires:
   - pythia6
-  - geant3
-  - geant4
-  - zeromq
+  - GEANT3
+  - GEANT4
+  - ZeroMQ
   - boost
 ---
 #!/bin/sh

--- a/geant3.sh
+++ b/geant3.sh
@@ -1,7 +1,7 @@
-package: geant3
+package: GEANT3
 version: v2-0
 requires:
-  - root
+  - ROOT
 source: http://root.cern.ch/git/geant3.git
 tag: v2-0
 prepend_path:

--- a/geant4.sh
+++ b/geant4.sh
@@ -1,8 +1,8 @@
-package: geant4
+package: GEANT4
 version: v4.10.01.p02
 source: http://github.com/alisw/geant4
 requires:
-  - clhep
+  - CLHEP
 tag: v4.10.01.p02
 ---
 #!/bin/sh

--- a/geant4.sh
+++ b/geant4.sh
@@ -1,6 +1,6 @@
 package: GEANT4
 version: v4.10.01.p02
-source: http://github.com/alisw/geant4
+source: https://github.com/alisw/geant4
 requires:
   - CLHEP
 tag: v4.10.01.p02

--- a/gsl.sh
+++ b/gsl.sh
@@ -1,12 +1,11 @@
 package: GSL
-version: "v1.16"
+version: "1.16"
 ---
 #!/bin/bash -e
-VerWithoutV=${PKGVERSION:1}
-Url="ftp://ftp.gnu.org/gnu/gsl/gsl-${VerWithoutV}.tar.gz"
+Url="ftp://ftp.gnu.org/gnu/gsl/gsl-${PKGVERSION}.tar.gz"
 curl -o gsl.tar.gz "$Url"
 tar xzf gsl.tar.gz
-cd gsl-$VerWithoutV
+cd gsl-$PKGVERSION
 ./configure --prefix="$INSTALLROOT"
 make -j$JOBS
 make install -j$JOBS

--- a/igprof.sh
+++ b/igprof.sh
@@ -1,4 +1,4 @@
-package: igprof
+package: IgProf
 version: master
 source: https://github.com/igprof/igprof
 tag: master

--- a/o2.sh
+++ b/o2.sh
@@ -1,7 +1,7 @@
-package: o2
+package: O2
 version: master
 requires:
-  - fairroot
+  - FairRoot
 source: https://github.com/AliceO2Group/AliceO2
 tag: master
 ---

--- a/pcre.sh
+++ b/pcre.sh
@@ -1,4 +1,4 @@
-package: pcre
+package: PCRE
 version: master
 source: https://github.com/ktf/pcre
 tag: master

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,13 +1,12 @@
 package: Rivet
-version: "v2.2.1"
+version: "2.2.1"
 requires:
   - GSL
   - YODA
   - fastjet
 ---
 #!/bin/bash -e
-VerWithoutV=${PKGVERSION:1}
-Url="http://www.hepforge.org/archive/rivet/Rivet-${VerWithoutV}.tar.bz2"
+Url="http://www.hepforge.org/archive/rivet/Rivet-${PKGVERSION}.tar.bz2"
 
 # External dependencies. TODO: build them instead.
 Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
@@ -16,7 +15,7 @@ Cgal="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/cgal/v4.4"
 
 curl -Lo rivet.tar.bz2 "$Url"
 tar xjf rivet.tar.bz2
-cd Rivet-$VerWithoutV
+cd Rivet-$PKGVERSION
 export LDFLAGS="-L$Cgal/lib -L$Boost/lib ${LDFLAGS}"
 export LD_LIBRARY_PATH="${Cgal}/lib:${Boost}/lib:${LD_LIBRARY_PATH}"
 ./configure \

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: v5-34-30
-source: http://github.com/root-mirror/root
+source: https://github.com/root-mirror/root
 tag: v5-34-30
 requires: 
   - CMake

--- a/root.sh
+++ b/root.sh
@@ -1,10 +1,10 @@
-package: root
+package: ROOT
 version: v5-34-30
 source: http://github.com/root-mirror/root
 tag: v5-34-30
 requires: 
-  - cmake
-  - alien
+  - CMake
+  - AliEn
 ---
 #!/bin/sh -e
 

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,16 +1,15 @@
 package: YODA
-version: "v1.4.0"
+version: "1.4.0"
 ---
 #!/bin/bash -e
-VerWithoutV=${PKGVERSION:1}
-Url="http://www.hepforge.org/archive/yoda/YODA-${VerWithoutV}.tar.bz2"
+Url="http://www.hepforge.org/archive/yoda/YODA-${PKGVERSION}.tar.bz2"
 
 # TODO: deps from CVMFS must disappear
 Boost="/cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/boost/v1_53_0"
 
 curl -Lo yoda.tar.bz2 "$Url"
 tar xjf yoda.tar.bz2
-cd YODA-$VerWithoutV
+cd YODA-$PKGVERSION
 ./configure --prefix="$INSTALLROOT" --with-boost="$Boost"
 make -j$JOBS
 make install -j$JOBS

--- a/zeromq.sh
+++ b/zeromq.sh
@@ -1,4 +1,4 @@
-package: zeromq
+package: ZeroMQ
 version: master
 source: https://github.com/ktf/libzmq
 tag: master


### PR DESCRIPTION
Package names now follow upstream (*i.e.* Predrag's) convention on CVMFS.

There is also a mysterious(!) fix for SLC6. Without the fix I could not run `git clone --bare` on our SLC6 containers...