### PR TITLE
Enable builtin PCRE.

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -36,6 +36,7 @@ export ROOTSYS=$BUILDDIR
   --enable-roofit \
   --enable-soversion \
   --enable-builtin-freetype \
+  --enable-builtin-pcre \
   ${ENABLE_COCOA+--enable-cocoa} \
   --disable-bonjour \
   ${DISABLE_FINK+--disable-fink} \


### PR DESCRIPTION
PCRE is not there by default on Yosemite, so we enable it (everywhere)
to avoid one extra dependency.