### PR TITLE
GEANT4: naming convention: dropped initial 4.

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -1,7 +1,7 @@
 package: GEANT4
-version: v4.10.01.p02-alice1
+version: v10.01.p02-alice1
 source: https://github.com/alisw/geant4
-tag: c61ed5a54780a8da922ccf199ca69592189c7e66
+tag: v4.10.01.p02-alice1
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
Same as #34.