### PR TITLE
Change AliRoot version string.

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -1,5 +1,5 @@
 package: AliRoot
-version: v5-06-35
+version: "%(commit_hash)s"
 requires:
   - ROOT
 env:


### PR DESCRIPTION
Now uses commit hash to differentiate different builds.