### PR TITLE
Build MathMore in ROOT (also requires GSL).

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -4,6 +4,7 @@ source: https://github.com/alisw/root
 requires: 
   - CMake
   - AliEn
+  - GSL
 env:
   ROOTSYS: \$INSTALLROOT
 ---
@@ -37,6 +38,7 @@ export ROOTSYS=$BUILDDIR
   --enable-soversion \
   --enable-builtin-freetype \
   --enable-builtin-pcre \
+  --enable-mathmore \
   ${ENABLE_COCOA+--enable-cocoa} \
   --disable-bonjour \
   ${DISABLE_FINK+--disable-fink} \


### PR DESCRIPTION
This is not required by AliRoot, but needed by one of the FairRoot tests. We agreed with @dberzano and @pzhristov that is in any case something good to have and has the advantage that we keep production aliroot and fairroot builds in sync.