### PR TITLE
Do not specify FairRoot path via the environment.

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -9,11 +9,11 @@ source: https://github.com/AliceO2Group/AliceO2
 tag: master
 ---
 #!/bin/sh
-export FAIRROOTPATH=$FAIRROOT_ROOT
 export ROOTSYS=$ROOT_ROOT
 
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
       -DCMAKE_MODULE_PATH="$SOURCEDIR/cmake/modules;$FAIRROOT_ROOT/share/fairbase/cmake/modules" \
+      -DFairRoot_DIR=$FAIRROOT_ROOT \
       -DALICEO2_MODULAR_BUILD=ON \
       -DROOTSYS=$ROOTSYS \
       -DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib \


### PR DESCRIPTION
This makes possible to simply cd to the BUILD/<arch>/O2/latest directory and to
type make.