### PR TITLE
Add autotools requirement on slc5.

### DIFF
--- a/libatomic_ops.sh
+++ b/libatomic_ops.sh
@@ -2,6 +2,8 @@ package: libatomic_ops
 version: v1.0
 source: https://github.com/igprof/libatomic_ops
 tag: master
+requires:
+  - autotools:slc5.*
 ---
 #!/bin/sh
 


### PR DESCRIPTION
libatomic_ops (required by igprof) needs a newer version of autotools
to compile on older distributions.