### PR TITLE
Add support for Clang Static Analyser

### DIFF
--- a/aliroot-csa.sh
+++ b/aliroot-csa.sh
@@ -1,0 +1,32 @@
+package: AliRoot-csa
+version: "%(short_hash)s"
+requires:
+  - ROOT
+  - SAS
+env:
+  ALICE_ROOT: "$ALIROOT_ROOT"
+source: http://git.cern.ch/pub/AliRoot
+write_repo: https://git.cern.ch/reps/AliRoot 
+tag: master
+---
+#!/bin/sh
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+      -DCMAKE_C_COMPILER=`which ccc-analyzer` \
+      -DCMAKE_CXX_COMPILER=`which c++-analyzer`\
+      -DCMAKE_Fortran_COMPILER=`which gfortran` \
+      -DROOTSYS=$ROOT_ROOT \
+      -DALIEN=$ALIEN_ROOT/alien \
+      -DOCDB_INSTALL=PLACEHOLDER
+
+case $ARCHITECTURE in 
+  osx*) SONAME=dylib ;;
+esac
+
+scan-build -load-plugin $SAS_ROOT/lib/libSas.${SONAME:-so} \
+           -enable-checker sas.Performance \
+           -enable-checker sas.CodingConventions.General \
+           -enable-checker core \
+           -enable-checker cplusplus \
+           -enable-checker unix \
+           -o MyReportDir \
+           make -k ${JOBS+-j $JOBS} || true

--- a/clang.sh
+++ b/clang.sh
@@ -2,11 +2,18 @@ package: Clang
 version: "3.6"
 source: https://github.com/alisw/clang
 tag: master
-incremental_recipe: make ${JOBS+-j $JOBS} && make install
 ---
 #!/bin/sh
 cmake $SOURCEDIR \
+  -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"
   
 make ${JOBS+-j $JOBS}
 make install
+case $ARCHITECTURE in
+  osx*)
+    ln -sf /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++ $INSTALLROOT/include
+  ;;
+esac
+find $SOURCEDIR/tools/clang/tools/scan-build -type f -perm +111 -exec cp {} $INSTALLROOT/bin \;
+find $SOURCEDIR/tools/clang/tools/scan-view -type f -perm +111 -exec cp {} $INSTALLROOT/bin \;

--- a/sas.sh
+++ b/sas.sh
@@ -1,6 +1,6 @@
 package: SAS
 version: "0.1.3"
-source: https://github.com/dpiparo/SAS.git
+source: https://github.com/ktf/SAS.git
 tag: master
 requires:
   - Clang

--- a/sas.sh
+++ b/sas.sh
@@ -1,0 +1,14 @@
+package: SAS
+version: "0.1.3"
+source: https://github.com/dpiparo/SAS.git
+tag: master
+requires:
+  - Clang
+---
+#!/bin/sh
+cmake $SOURCEDIR \
+  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT" \
+  -DLLVM_DEV_DIR=$CLANG_ROOT
+  
+make ${JOBS+-j $JOBS}
+make install


### PR DESCRIPTION
Includes @dpiparo SAS.

In order to try it out:

```
git clone https://github.com/alisw/alibuild
git clone https://github.com/alisw/alidist
alibuild/aliBuild -j 20 -d -a osx_x86-64 build AliRoot-csa
```

to develop SAS you can also do:

```
git clone https://github.com/dpiparo/SAS
alibuild/aliBuild -j 20 -d -a osx_x86-64 --devel SAS build AliRoot-csa
```