### PR TITLE
updates for compilation on SLC 5

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -3,12 +3,18 @@ version: v6.1.5
 source: https://github.com/alisw/LHAPDF
 tag: v6.1.5
 requires:
-  - yaml-cpp
+ - yaml-cpp
+ - boost
+ - "autotools:(slc5).*"
 ---
 #!/bin/sh
 # Does not work out of source.
 
 cd $SOURCEDIR
+
+# autoreconf if using our own build of autotools
+[[ -n ${AUTOTOOLS_ROOT} ]] && autoreconf -ivf
+
 ./configure --prefix=$INSTALLROOT \
             --with-boost=${BOOST_ROOT} \
             --with-yaml-cpp=${YAML_CPP_ROOT}

--- a/pythia8.sh
+++ b/pythia8.sh
@@ -4,14 +4,23 @@ source: https://github.com/alisw/pythia8
 requires:
   - LHAPDF
   - HepMC
+  - boost
 tag: alice/v8210
 ---
 #!/bin/sh
 cd $SOURCEDIR
+
 ./configure --prefix=$INSTALLROOT \
             --enable-shared \
             --with-hepmc2=${HEPMC_ROOT} \
-            --with-lhapdf6=${LHAPDF_ROOT}
+            --with-lhapdf6=${LHAPDF_ROOT} \
+            --with-boost=${BOOST_ROOT}
+
+if [[ $ARCHITECTURE =~ "slc5.*" ]]; then
+    ln -s LHAPDF5.h include/Pythia8Plugins/LHAPDF5.cc
+    ln -s LHAPDF6.h include/Pythia8Plugins/LHAPDF6.cc
+    sed -i -e 's#\$(CXX) -x c++ \$< -o \$@ -c -MD -w -I\$(LHAPDF\$\*_INCLUDE) \$(CXX_COMMON)#\$(CXX) -x c++ \$(<:.h=.cc) -o \$@ -c -MD -w -I\$(LHAPDF\$\*_INCLUDE) \$(CXX_COMMON)#' Makefile
+fi
 
 make ${JOBS+-j $JOBS}
 make install

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -6,6 +6,10 @@ requires:
   - boost
 ---
 #!/bin/sh
+if [[ $ARCHITECTURE =~ "slc5.*" ]]; then
+    sed -i -e 's/-Wno-c99-extensions //' $SOURCEDIR/test/CMakeLists.txt
+fi
+
 cmake $SOURCEDIR \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT" \
   -DBUILD_SHARED_LIBS=YES \


### PR DESCRIPTION
Compilation on SLC 5 is a bit tricky, it requires special treatment in several packages, for pythia8 and yaml-cpp patching the build flow.