### PR TITLE
copy SOURCEDIR to BUILDDIR for in-source builds

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -10,7 +10,7 @@ requires:
 #!/bin/sh
 # Does not work out of source.
 
-cd $SOURCEDIR
+rsync -a $SOURCEDIR/ ./
 
 # autoreconf if using our own build of autotools
 [[ -n ${AUTOTOOLS_ROOT} ]] && autoreconf -ivf

--- a/pythia8.sh
+++ b/pythia8.sh
@@ -8,7 +8,7 @@ requires:
 tag: alice/v8210
 ---
 #!/bin/sh
-cd $SOURCEDIR
+rsync -a $SOURCEDIR/ ./
 
 ./configure --prefix=$INSTALLROOT \
             --enable-shared \


### PR DESCRIPTION
Replace cd to source directory by rsync to build directory to avoid clashes of compiles for different architectures.