### PR TITLE
AliEn-Runtime bumped to v2-19-xrd2

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -1,5 +1,5 @@
 package: AliEn-Runtime
-version: v2-19-xrd1
+version: v2-19-xrd2
 source: https://gitlab.cern.ch/dberzano/AliEn-antidot.git
 prepend_path:
   LD_LIBRARY_PATH: "$ALIEN_RUNTIME_ROOT/api/lib"


### PR DESCRIPTION
This tag compiles on Ubuntu 14.04 and all SLC platforms.