### PR TITLE
Use old AliEn builds on OSX

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -12,6 +12,19 @@ requires:
   - CMake
 ---
 #!/bin/bash -e
+case $ARCHITECTURE in 
+  osx*)
+    # The new build recipe does not work on mac. Working it around using the
+    # old installer.
+    curl -O -fSsL --insecure http://alien.cern.ch/alien-installer
+    chmod +x alien-installer
+    ./alien-installer -install-dir "$INSTALLROOT/alien" -batch -notorrent -type compile -no-certificate-check
+    rsync -av $INSTALLROOT/alien/ $INSTALLROOT/
+    exit 0
+  ;;
+esac
+
+
 rsync -a --cvs-exclude $SOURCEDIR/ $BUILDDIR/
 cd $BUILDDIR
 ./bootstrap

--- a/root.sh
+++ b/root.sh
@@ -4,6 +4,7 @@ source: https://github.com/alisw/root
 requires: 
   - AliEn-Runtime
   - GSL
+  - libxml2:osx.*
 env:
   ROOTSYS: "$ROOT_ROOT"
 incremental_recipe: |
@@ -53,8 +54,8 @@ export ROOTSYS=$BUILDDIR
   ${WITH_CLANG+--with-clang} \
   --disable-shadowpw \
   --disable-astiff \
-  --with-xml-incdir=$ALIEN_RUNTIME_ROOT/include/libxml2 \
-  --with-xml-libdir=$ALIEN_RUNTIME_ROOT/lib \
+  --with-xml-incdir=${LIBXML2_ROOT:-$ALIEN_RUNTIME_ROOT}/include/libxml2 \
+  --with-xml-libdir=${LIBXML2_ROOT:-$ALIEN_RUNTIME_ROOT}/lib \
   --disable-globus \
   --with-ssl-libdir=$ALIEN_RUNTIME_ROOT/lib \
   --with-ssl-incdir=$ALIEN_RUNTIME_ROOT/include \


### PR DESCRIPTION
This is due to the fact that the new AliEn-runtime does not actually
work on OSX. This works around the problem by using the old recipe.

Since the old recipe did not bring in libxml2, we use our own libxml2 on
OSX. See also #81.