### PR TITLE
Add GMP and MPFR as CGAL dependencies

### DIFF
--- a/autotools.sh
+++ b/autotools.sh
@@ -1,7 +1,7 @@
 package: autotools
-version: v1.0.0
+version: v1.1.0
 source: https://github.com/star-externals/autotools
-tag: star/v1.0.0
+tag: star/v1.1.0
 ---
 #!/bin/sh
 export PATH=$INSTALLROOT/bin:$PATH

--- a/cgal.sh
+++ b/cgal.sh
@@ -3,6 +3,8 @@ version: "v4.4"
 requires:
   - boost
   - CMake
+  - GMP
+  - MPFR
 ---
 #!/bin/bash -e
 PKGID=33524
@@ -15,6 +17,11 @@ cd CGAL-${PKGVERSION:1}
 export LDFLAGS="-L$BOOST_ROOT/lib"
 export LD_LIBRARY_PATH="$BOOST_ROOT/lib:$LD_LIBRARY_PATH"
 export DYLD_LIBRARY_PATH="$BOOST_ROOT/lib:$DYLD_LIBRARY_PATH"
+
+export MPFR_LIB_DIR="${MPFR_ROOT}/lib"
+export MPFR_INC_DIR="${MPFR_ROOT}/include"
+export GMP_LIB_DIR="${GMP_ROOT}/lib"
+export GMP_INC_DIR="${GMP_ROOT}/include"
 
 cmake . \
       -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}" \
@@ -66,7 +73,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION CMake/$CMAKE_VERSION-$CMAKE_REVISION
+module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION CMake/$CMAKE_VERSION-$CMAKE_REVISION GMP/$GMP_VERSION-$GMP_REVISION MPFR/$MPFR_VERSION-$MPFR_REVISION
 # Our environment
 setenv CGAL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(CGAL_ROOT)/bin

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -23,10 +23,10 @@ export LIBRARY_PATH="$BOOST_ROOT/lib:$LIBRARY_PATH"
 
 # FastJet
 cd $BUILDDIR/fastjet-$VerFJ
-export CXXFLAGS="-Wl,--no-as-needed -lgmp -L$BOOST_ROOT/lib -lboost_thread -lboost_system -L$CGAL_ROOT/lib -I$BOOST_ROOT/include -I$CGAL_ROOT/include -DCGAL_DO_NOT_USE_MPZF -O2 -g"
+export CXXFLAGS="-Wl,--no-as-needed -L$GMP_ROOT/lib -lgmp -L$MPFR_ROOT/lib -lmpfr -L$BOOST_ROOT/lib -lboost_thread -lboost_system -L$CGAL_ROOT/lib -I$BOOST_ROOT/include -I$CGAL_ROOT/include -I$GMP_ROOT/include -I$MPFR_ROOT/include -DCGAL_DO_NOT_USE_MPZF -O2 -g"
 export CFLAGS="$CXXFLAGS"
-export CPATH="$BOOST_ROOT/include:$CGAL_ROOT/include"
-export C_INCLUDE_PATH="$BOOST_ROOT/include:$CGAL_ROOT/include"
+export CPATH="$BOOST_ROOT/include:$CGAL_ROOT/include:$GMP_ROOT/include:$MPFR_ROOT/include"
+export C_INCLUDE_PATH="$BOOST_ROOT/include:$CGAL_ROOT/include:$GMP_ROOT/include:$MPFR_ROOT/include"
 ./configure --enable-shared \
             --enable-cgal \
             --with-cgal=$CGAL_ROOT \

--- a/gmp.sh
+++ b/gmp.sh
@@ -1,0 +1,30 @@
+package: GMP
+version: v6.0.0
+source: https://github.com/alisw/GMP.git
+tag: v6.0.0
+---
+#!/bin/sh
+$SOURCEDIR/configure --disable-static --prefix=$INSTALLROOT \
+            --enable-shared --enable-cxx
+
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv GMP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(GMP_ROOT)/lib
+EoF

--- a/mpfr.sh
+++ b/mpfr.sh
@@ -1,0 +1,36 @@
+package: MPFR
+version: v3.1.3
+source: https://github.com/alisw/MPFR.git
+tag: v3.1.3
+requires:
+  - GMP
+  - autotools
+---
+#!/bin/sh
+rsync -a $SOURCEDIR/ ./
+autoreconf -ivf
+./configure --disable-static \
+            --prefix=$INSTALLROOT \
+            --with-gmp=$GMP_ROOT
+
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv MPFR_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(MPFR_ROOT)/lib
+EoF


### PR DESCRIPTION
Without this, they get picked up from the system and do not work in the
SLC7 docker images where gmp-devel is not installed. Notice I also need the new automake in order to compile MPRF.