### PR TITLE
ThePEG and dependencies

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -8,7 +8,7 @@ prepend_path:
 env:
   GSHELL_ROOT: "$ALIEN_RUNTIME_ROOT/api"
   GSHELL_NO_GCC: "1"
-requires:
+build_requires:
   - CMake
 ---
 #!/bin/bash -e
@@ -63,7 +63,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 CMake/$CMAKE_VERSION-$CMAKE_REVISION
+module load BASE/1.0
 # Our environment
 setenv ALIEN_RUNTIME_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_BASEDIR)/lib

--- a/autotools.sh
+++ b/autotools.sh
@@ -1,22 +1,26 @@
 package: autotools
 version: v1.1.0
-source: https://github.com/star-externals/autotools
+source: https://github.com/alisw/autotools
 tag: star/v1.1.0
 ---
-#!/bin/sh
-export PATH=$INSTALLROOT/bin:$PATH
-rsync -a $SOURCEDIR/ $BUILDDIR/
+#!/bin/bash
+export PATH=$INSTALLROOT/bin:$BUILDDIR/fooutils:$PATH
+rsync -a --delete $SOURCEDIR/ $BUILDDIR/
 pushd m4
   ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-  make ${JOBS+-j $JOBS} && make install
+  make ${JOBS+-j $JOBS}
+  make install
 popd
 pushd autoconf
   ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-  make ${JOBS+-j $JOBS} && make install
+  make ${JOBS+-j $JOBS}
+  make install
 popd
 pushd automake
+  ./bootstrap.sh
   ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-  make ${JOBS+-j $JOBS} && make install
+  make ${JOBS+-j $JOBS}
+  make install
 popd
 pushd libtool
   # Update for AArch64 support
@@ -25,9 +29,11 @@ pushd libtool
   curl -L -k -s -o ./libltdl/config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
   chmod +x ./libltdl/config/config.{sub,guess}
   ./configure --disable-dependency-tracking --prefix $INSTALLROOT --enable-ltdl-install
-  make ${JOBS+-j $JOBS} && make install
+  make ${JOBS+-j $JOBS}
+  make install
 popd
 pushd gettext
+  ./autogen.sh
   ./configure --prefix $INSTALLROOT \
               --without-xz \
               --without-bzip2 \
@@ -41,14 +47,16 @@ pushd gettext
               --disable-java \
               --disable-dependency-tracking \
               --disable-silent-rules
-  make ${JOBS+-j $JOBS} && make install
+  make ${JOBS+-j $JOBS}
+  make install
 popd
 pushd pkg-config
-    ./configure --disable-debug \
-                --prefix=$INSTALLROOT \
-                --disable-host-tool \
-                --with-internal-glib
-  make ${JOBS+-j $JOBS} && make install
+  ./configure --disable-debug \
+              --prefix=$INSTALLROOT \
+              --disable-host-tool \
+              --with-internal-glib
+  make ${JOBS+-j $JOBS}
+  make install
 popd
 
 # Fix perl location, required on /usr/bin/perl

--- a/cgal.sh
+++ b/cgal.sh
@@ -2,9 +2,10 @@ package: cgal
 version: "v4.4"
 requires:
   - boost
-  - CMake
   - GMP
   - MPFR
+build_requires:
+  - CMake
 ---
 #!/bin/bash -e
 PKGID=33524
@@ -73,7 +74,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION CMake/$CMAKE_VERSION-$CMAKE_REVISION GMP/$GMP_VERSION-$GMP_REVISION MPFR/$MPFR_VERSION-$MPFR_REVISION
+module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION GMP/$GMP_VERSION-$GMP_REVISION MPFR/$MPFR_VERSION-$MPFR_REVISION
 # Our environment
 setenv CGAL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(CGAL_ROOT)/bin

--- a/crmc.sh
+++ b/crmc.sh
@@ -1,22 +1,21 @@
 package: CRMC
 version: v1.5.4
 requires:
+  - CMake
   - boost
   - HepMC
 ---
 #!/bin/bash -ex
 
-ARCHIVE="crmc-${PKGVERSION#v}-src.tgz"
-URL="http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/crmc/${ARCHIVE}"
+ARCHIVE="crmc-${PKGVERSION:1}-src.tgz"
+URL="http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/crmc/$ARCHIVE"
 
 cd $SOURCEDIR
-curl -O "${URL}"
-tar xz --strip-components 2 -f ${ARCHIVE}
+curl -O $URL
+tar xz --strip-components 2 -f $ARCHIVE
 
 cd $BUILDDIR
-
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
-
 make ${JOBS+-j $JOBS} all
 make install
 
@@ -33,7 +32,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
+module load BASE/1.0 CMake/$CMAKE_VERSION-$CMAKE_REVISION boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
 # Our environment
 setenv CRMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(CRMC_ROOT)/bin

--- a/freetype.sh
+++ b/freetype.sh
@@ -1,0 +1,35 @@
+package: FreeType
+version: v2.6
+requires:
+ - zlib
+---
+#!/bin/bash -ex
+URL="http://download.savannah.gnu.org/releases/freetype/freetype-${PKGVERSION:1}.tar.gz"
+curl -L -o freetype.tgz $URL
+tar xzf freetype.tgz
+rm -f freetype.tgz
+cd freetype-${PKGVERSION:1}
+./configure --prefix=$INSTALLROOT \
+            --with-zlib=$ZLIB_ROOT
+make ${JOBS:+-j$JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 zlib/$ZLIB_VERSION-$ZLIB_REVISION
+# Our environment
+setenv FREETYPE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH $::env(FREETYPE_ROOT)/bin
+prepend-path LD_LIBRARY_PATH $::env(FREETYPE_ROOT)/lib
+EoF

--- a/hepmc.sh
+++ b/hepmc.sh
@@ -1,7 +1,7 @@
 package: HepMC
 version: "v2.06.09"
 source: https://github.com/alisw/hepmc
-requires:
+build_requires:
   - CMake
 ---
 #!/bin/bash -e
@@ -28,7 +28,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 CMake/$CMAKE_VERSION-$CMAKE_REVISION
+module load BASE/1.0
 # Our environment
 setenv HEPMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(HEPMC_ROOT)/bin

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -34,9 +34,9 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 yaml-cpp/$YAML_CPP_VERSION-$YAML_CPP_REVISION boost/$BOOST_VERSION-$BOOST_REVISION autotools/$AUTOTOOLS_VERSION-$AUTOTOOLS_REVISION
+module load BASE/1.0
 # Our environment
-setenv LHAPDF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH $::env(LHAPDF_ROOT)/bin
-prepend-path LD_LIBRARY_PATH $::env(LHAPDF_ROOT)/lib
+setenv LHAPDF5_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH $::env(LHAPDF5_ROOT)/bin
+prepend-path LD_LIBRARY_PATH $::env(LHAPDF5_ROOT)/lib
 EoF

--- a/libpng.sh
+++ b/libpng.sh
@@ -1,8 +1,9 @@
 package: libpng
 version: v1.6.18
 requires:
- - CMake
  - zlib
+build_requires:
+ - CMake
 ---
 #!/bin/bash -ex
 URL="http://downloads.sourceforge.net/libpng/libpng-${PKGVERSION:1}.tar.gz"
@@ -33,7 +34,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 zlib/$ZLIB_VERSION-$ZLIB_REVISION CMake/$CMAKE_VERSION-$CMAKE_REVISION
+module load BASE/1.0 zlib/$ZLIB_VERSION-$ZLIB_REVISION
 # Our environment
 setenv LIBPNG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(LIBPNG_ROOT)/bin

--- a/libpng.sh
+++ b/libpng.sh
@@ -1,0 +1,41 @@
+package: libpng
+version: v1.6.18
+requires:
+ - CMake
+ - zlib
+---
+#!/bin/bash -ex
+URL="http://downloads.sourceforge.net/libpng/libpng-${PKGVERSION:1}.tar.gz"
+curl -L -o libpng.tgz $URL
+tar xzf libpng.tgz
+rm -f libpng.tgz
+mv libpng-${PKGVERSION:1} src
+mkdir build
+cd build
+cmake ../src -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLROOT \
+             -DBUILD_SHARED_LIBS=YES \
+             -DZLIB_ROOT:PATH=$ZLIB_ROOT \
+             -DCMAKE_SKIP_RPATH=YES \
+             -DSKIP_INSTALL_FILES=1
+make ${JOBS:+-j$JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 zlib/$ZLIB_VERSION-$ZLIB_REVISION CMake/$CMAKE_VERSION-$CMAKE_REVISION
+# Our environment
+setenv LIBPNG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH $::env(LIBPNG_ROOT)/bin
+prepend-path LD_LIBRARY_PATH $::env(LIBPNG_ROOT)/lib
+EoF

--- a/mpfr.sh
+++ b/mpfr.sh
@@ -4,6 +4,7 @@ source: https://github.com/alisw/MPFR.git
 tag: v3.1.3
 requires:
   - GMP
+build_requires:
   - autotools
 ---
 #!/bin/sh

--- a/o2.sh
+++ b/o2.sh
@@ -3,7 +3,7 @@ version: master
 requires:
   - FairRoot
   - AliRoot
-  - pythia8
+  - pythia
   - pythia6
 source: https://github.com/AliceO2Group/AliceO2
 tag: dev
@@ -24,7 +24,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
       -DZMQ_DIR=$ZEROMQ_ROOT \
       -DZMQ_INCLUDE_DIR=$ZEROMQ_ROOT/include \
       -DALIROOT=$ALIROOT_ROOT \
-      -DPYTHIA8_INCLUDE_DIR=$PYTHIA8_ROOT/include
+      -DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include
 
 if [[ $GIT_TAG == master ]]; then
   CONTINUE_ON_ERROR=true

--- a/pythia.sh
+++ b/pythia.sh
@@ -1,4 +1,4 @@
-package: pythia8
+package: pythia
 version: "v8210"
 source: https://github.com/alisw/pythia8
 requires:
@@ -41,7 +41,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 lhapdf5/$LHAPDF5_VERSION-$LHAPDF5_REVISION boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
 # Our environment
-setenv PYTHIA8_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(PYTHIA8_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(PYTHIA8_ROOT)/lib
+setenv PYTHIA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(PYTHIA_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib
 EoF

--- a/pythia8.sh
+++ b/pythia8.sh
@@ -2,7 +2,7 @@ package: pythia8
 version: "v8210"
 source: https://github.com/alisw/pythia8
 requires:
-  - lhapdf
+  - lhapdf5
   - HepMC
   - boost
 tag: alice/v8210
@@ -24,3 +24,24 @@ fi
 
 make ${JOBS+-j $JOBS}
 make install
+chmod a+x $INSTALLROOT/bin/pythia8-config
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 lhapdf5/$LHAPDF5_VERSION-$LHAPDF5_REVISION boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
+# Our environment
+setenv PYTHIA8_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(PYTHIA8_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(PYTHIA8_ROOT)/lib
+EoF

--- a/python.sh
+++ b/python.sh
@@ -1,0 +1,108 @@
+package: Python
+version: v2.7.10
+requires:
+ - AliEn-Runtime
+ - zlib
+ - FreeType
+ - libpng
+---
+#!/bin/bash -ex
+# Note: depends on AliEn-Runtime for OpenSSL.
+
+URL="https://www.python.org/ftp/python/${PKGVERSION:1}/Python-${PKGVERSION:1}.tgz"
+curl -L -o python.tgz $URL
+tar xzf python.tgz
+rm -f python.tgz
+
+cd Python-${PKGVERSION:1}
+
+# The only way to pass externals to Python
+LDFLAGS=
+CPPFLAGS=
+for ext in $ALIEN_RUNTIME_ROOT $ALIEN_RUNTIME_ROOT/api $ZLIB_ROOT $FREETYPE_ROOT $LIBPNG_ROOT; do
+  [[ -e $ext/include && $ext/lib ]]
+  LDFLAGS="-L $ext/lib $LDFLAGS"
+  CPPFLAGS="-I $ext/include $CPPFLAGS"
+done
+export LDFLAGS
+export CPPFLAGS
+
+./configure --prefix=$INSTALLROOT \
+            --enable-shared \
+            --with-system-expat \
+            --with-system-ffi \
+            --enable-unicode=ucs4
+make -j ${JOBS:+-j$JOBS}
+make install
+
+# Install pip
+cd $BUILDDIR
+export PATH=$INSTALLROOT/bin:$PATH
+export LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH
+curl -kSsL -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+python get-pip.py
+
+# Install extra packages with pip
+pip install "numpy==1.9.2"
+
+# Install matplotlib (very tricky)
+MATPLOTLIB_VER="1.4.3"
+MATPLOTLIB_URL="http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-${MATPLOTLIB_VER}/matplotlib-${MATPLOTLIB_VER}.tar.gz"
+curl -Lo matplotlib.tgz $MATPLOTLIB_URL
+tar xzf matplotlib.tgz
+cd matplotlib-$MATPLOTLIB_VER
+cat > setup.cfg <<EOF
+[directories]
+basedirlist  = $PWD/fake_freetype_root,$FREETYPE_ROOT,$LIBPNG_ROOT,$ZLIB_ROOT,/usr/X11R6
+
+[gui_support]
+gtk = False
+gtkagg = False
+tkagg = False
+wxagg = False
+macosx = False
+EOF
+
+# Disable pkg-config: it messes with FreeType detection
+cat > pkg-config <<EOF
+#!/bin/bash
+exit 1
+EOF
+chmod +x pkg-config
+export PATH=$PWD:$PATH
+
+# matplotlib wants include files in <PackageRoot>/include, but this is not the
+# case for FreeType: let's fix it
+mkdir fake_freetype_root
+ln -nfs $FREETYPE_ROOT/include/freetype2 fake_freetype_root/include
+
+python setup.py build
+python setup.py install
+
+# Remove useless stuff
+rm -rvf $INSTALLROOT/share \
+       $INSTALLROOT/lib/python*/test
+find $INSTALLROOT/lib/python* \
+     -mindepth 2 -maxdepth 2 -type d -and \( -name test -or -name tests \) \
+     -exec rm -rvf '{}' \;
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION zlib/$ZLIB_VERSION-$ZLIB_REVISION
+# Our environment
+setenv PYTHON_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH $::env(PYTHON_ROOT)/bin
+prepend-path LD_LIBRARY_PATH $::env(PYTHON_ROOT)/lib
+EoF

--- a/rivet.sh
+++ b/rivet.sh
@@ -6,7 +6,6 @@ requires:
   - fastjet
   - HepMC
   - boost
-  - cgal
 ---
 #!/bin/bash -e
 Url="http://www.hepforge.org/archive/rivet/Rivet-${PKGVERSION}.tar.bz2"
@@ -30,31 +29,21 @@ make -j$JOBS
 make install -j$JOBS
 
 # Modulefile
-ModuleDir="${INSTALLROOT}/etc/Modules/modulefiles/${PKGNAME}"
-mkdir -p "$ModuleDir"
-cat > "${ModuleDir}/${PKGVERSION}-${PKGREVISION}" <<EoF
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
 #%Module1.0
 proc ModulesHelp { } {
   global version
-  puts stderr "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 }
-set version $PKGVERSION-$PKGREVISION
-module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION HepMC/v2.06.09
+module load BASE/1.0 GSL/$GSL_VERSION-$GSL_REVISION YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION boost/$BOOST_VERSION-$BOOST_REVISION
 # Our environment
-if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
-  puts stderr "Note: overriding base package $PKGNAME \$version"
-  set prefix \$ModulesCurrentModulefile
-  for {set i 0} {\$i < 5} {incr i} {
-    set prefix [file dirname \$prefix]
-  }
-  setenv YODA_BASEDIR \$prefix
-} else {
-  setenv YODA_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
-}
-prepend-path LD_LIBRARY_PATH \$::env(YODA_BASEDIR)/lib
-prepend-path PATH \$::env(YODA_BASEDIR)/bin
-set pythonpath [exec rivet-config --pythonpath]
-prepend-path PYTHONPATH \$pythonpath
+setenv RIVET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(RIVET_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(RIVET_ROOT)/lib
 EoF

--- a/thepeg-test.sh
+++ b/thepeg-test.sh
@@ -1,0 +1,42 @@
+package: ThePEG-test
+version: v1
+force_rebuild: 1
+requires:
+  - ThePEG
+---
+#!/bin/bash
+cat > DIPSYpp_HepMC.in <<\EOF
+read Tune27.in
+cd /DIPSY
+cp EventHandler LHCEventHandler
+set LHCEventHandler:WFL stdProton
+set LHCEventHandler:WFR stdProton
+set LHCEventHandler:ConsistencyLevel 0
+set LHCEventHandler:XSecFn:CheckOffShell false
+set LHCEventHandler:CascadeHandler NULL
+set LHCEventHandler:HadronizationHandler NULL
+set LHCEventHandler:DecayHandler NULL
+create ThePEG::FixedCMSLuminosity LHCLumi
+set LHCEventHandler:LuminosityFunction LHCLumi
+cp Generator LHCGenerator
+set LHCGenerator:EventHandler LHCEventHandler
+set LHCEventHandler:EffectivePartonMode Colours
+set LHCGenerator:EventHandler:DecayHandler /Defaults/Handlers/StandardDecayHandler
+set LHCGenerator:EventHandler:HadronizationHandler Frag8
+set LHCEventHandler:WFL Proton
+set LHCEventHandler:WFR Proton
+set LHCEventHandler:EventFiller:SoftRemove NoValence
+set LHCGenerator:EventHandler:LuminosityFunction:Energy 7000
+create ThePEG::HepMCFile HepMCFile HepMCAnalysis.so
+set LHCGenerator:AnalysisHandlers 0 HepMCFile
+set HepMCFile:Filename /tmp/DIPSYpp.hepmc
+set HepMCFile:PrintEvent 10000000000
+set HepMCFile:Format GenEvent
+set HepMCFile:Units GeV_mm
+saverun DIPSYpp LHCGenerator
+EOF
+
+setupThePEG -r $THEPEG_ROOT/lib/ThePEG/ThePEGDefaults.rpo \
+            -I $THEPEG_ROOT/share/Ariadne \
+            DIPSYpp_HepMC.in
+runThePEG DIPSYpp.run -N100 --tics

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -4,7 +4,7 @@ source: https://github.com/alisw/thepeg
 tag: "alice/v2015-03-18"
 requires:
   - Rivet
-  - pythia8
+  - pythia
   - HepMC
 build_requires:
   - autotools
@@ -36,7 +36,7 @@ export LDFLAGS="-L$LHAPDF5_ROOT/lib"
   --without-javagui \
   --prefix="$INSTALLROOT" \
   --with-gsl="$GSL_ROOT" \
-  --with-pythia8="$PYTHIA8_ROOT" \
+  --with-pythia8="$PYTHIA_ROOT" \
   --with-hepmc="$HEPMC_ROOT" \
   --with-rivet="$RIVET_ROOT" \
   --with-lhapdf="$LHAPDF5_ROOT" \
@@ -59,7 +59,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 pythia8/$PYTHIA8_VERSION-$PYTHIA8_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
+module load BASE/1.0 pythia/$PYTHIA_VERSION-$PYTHIA_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
 # Our environment
 setenv THEPEG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv ThePEG_INSTALL_PATH \$::env(THEPEG_ROOT)/lib/ThePEG

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -4,13 +4,15 @@ source: https://github.com/alisw/thepeg
 tag: "alice/v2015-03-18"
 requires:
   - Rivet
-  - GSL
-  - fastjet
   - pythia8
   - HepMC
-  - lhapdf5
-  - cgal
-  - boost
+build_requires:
+  - autotools
+prepend_path:
+  LD_LIBRARY_PATH: "$THEPEG_ROOT/lib/ThePEG"
+  DYLD_LIBRARY_PATH: "$THEPEG_ROOT/lib/ThePEG"
+env:
+  ThePEG_INSTALL_PATH: "$THEPEG_ROOT/lib/ThePEG"
 ---
 #!/bin/bash -e
 
@@ -19,22 +21,14 @@ export LIBRARY_PATH="${LHAPDF5_ROOT}/lib:${CGAL_ROOT}/lib:${BOOST_ROOT}/lib:${LI
 export LHAPATH="${LHAPDF5_ROOT}/share/lhapdf"
 export PERLLIB=/usr/share/perl5
 
-rsync -a $SOURCEDIR/ ./
+rsync -a --delete $SOURCEDIR/ ./
 
 sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/Config/interfaces.pl.in
 sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.am
 sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.in
 
-# not required for Ubuntu but to be checked if needed
-# when we can build and test on SLC 5:
-#find . \
-#  -name configure.ac -or \
-#  -name aclocal.m4 -or \
-#  -name configure -or \
-#  -name Makefile.am -or \
-#  -name Makefile.in \
-#  -exec touch '{}' \;
-#autoreconf -ivf
+autoreconf -ivf
+export LDFLAGS="-L$LHAPDF5_ROOT/lib"
 ./configure \
   --disable-silent-rules \
   --enable-shared \
@@ -47,35 +41,28 @@ sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/sr
   --with-rivet="$RIVET_ROOT" \
   --with-lhapdf="$LHAPDF5_ROOT" \
   --with-fastjet="$FASTJET_ROOT" \
-  --enable-unitchecks
-make -j$JOBS C_INCLUDE_PATH="${GSL_ROOT}/include" CPATH="${GSL_ROOT}/include"
-make install -j$JOBS
+  --enable-unitchecks 2>&1 | tee -a thepeg_configure.log
+grep -q 'Cannot build TheP8I without a working Pythia8 installation.' thepeg_configure.log && false
+make ${JOBS:+-j$JOBS} C_INCLUDE_PATH="${GSL_ROOT}/include" CPATH="${GSL_ROOT}/include"
+make install
 
 # Modulefile
-ModuleDir="${INSTALLROOT}/etc/Modules/modulefiles/${PKGNAME}"
-mkdir -p "$ModuleDir"
-cat > "${ModuleDir}/${PKGVERSION}-${PKGREVISION}" <<EoF
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
 #%Module1.0
 proc ModulesHelp { } {
   global version
-  puts stderr "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 }
-set version $PKGVERSION-$PKGREVISION
-module-whatis "Module for loading $PKGNAME $PKGVERSION-$PKGREVISION for the ALICE environment"
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 lhapdf5/$LHAPDF5_VERSION-$LHAPDF5_REVISION pythia/$PYTHIA_VERSION-$PYTHIA_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION GSL/$GSL_VERSION-$GSL_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
+module load BASE/1.0 pythia8/$PYTHIA8_VERSION-$PYTHIA8_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION Rivet/$RIVET_VERSION-$RIVET_REVISION
 # Our environment
-if { [info exists ::env(OVERRIDE_BASE)] && \$::env(OVERRIDE_BASE) == 1 } then {
-  puts stderr "Note: overriding base package $PKGNAME \$version"
-  set prefix \$ModulesCurrentModulefile
-  for {set i 0} {\$i < 5} {incr i} {
-    set prefix [file dirname \$prefix]
-  }
-  setenv THEPEG_BASEDIR \$prefix
-} else {
-  setenv THEPEG_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
-}
-prepend-path LD_LIBRARY_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
-prepend-path PATH \$::env(THEPEG_ROOT)/bin
+setenv THEPEG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv ThePEG_INSTALL_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
+prepend-path PATH \$::env(THEPEG_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
 EoF


### PR DESCRIPTION
@qgp: this should fix #80 and correct many small-to-large issues of #84.

@ktf: this autotools recipe has been tested with all SLCs and Ubuntu, but the original source code had to be modified, so I have created [alisw/autotools](https://github.com/alisw/autotools). I have realized that maybe star-externals is yours so we can just merge the changes there and drop ALICE's autotools.

This is the dependency plot for ThePEG (the dependency from AliEn-Runtime is because of openssl, it will go away as soon as we clean AliEn up).

![dep_thepeg](https://cloud.githubusercontent.com/assets/825677/9951851/b4f89718-5dcc-11e5-8b6e-8ad290745052.png)

@qgp: could you tell if the dependency tree is correct (at least for the Physics-related components)?