### PR TITLE
Patching lhapdf5 to avoid format security compilation error.

### DIFF
--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -12,6 +12,7 @@ tar xz --strip-components 1 -f ${ARCHIVE}
 
 cd $BUILDDIR
 rsync -a $SOURCEDIR/ $BUILDDIR/
+sed -i 's/PyErr_Format(PyExc_RuntimeError, mesg)/PyErr_Format(PyExc_RuntimeError,"%s" ,mesg)/g' $BUILDDIR/pyext/lhapdf_wrap.cc
 
 ./configure --prefix=$INSTALLROOT
 


### PR DESCRIPTION
I am trying to compile on Fedora 22 and on Mint 17.1 the O2 software using alibuild. 
On both the systems I got stuck due to a format security error in the compilation of lhapdf5.
This small patch solves this issue for me, but maybe you have cleaner solution.  