### PR TITLE
ThePEG v2015-08-11, working JEWEL, CRMC and plenty of LHAPDF fixes

### DIFF
--- a/crmc.sh
+++ b/crmc.sh
@@ -1,5 +1,6 @@
 package: CRMC
-version: v1.5.4
+version: "%(tag_basename)s"
+tag: alice/v1.5.4
 requires:
   - boost
   - HepMC
@@ -8,15 +9,8 @@ build_requires:
 ---
 #!/bin/bash -ex
 
-ARCHIVE="crmc-${PKGVERSION:1}-src.tgz"
-URL="http://service-spi.web.cern.ch/service-spi/external/MCGenerators/distribution/crmc/$ARCHIVE"
-
-cd $SOURCEDIR
-curl -O $URL
-tar xz --strip-components 2 -f $ARCHIVE
-
-cd $BUILDDIR
-cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+cmake $SOURCEDIR \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 make ${JOBS+-j $JOBS} all
 make install
 

--- a/jewel.sh
+++ b/jewel.sh
@@ -1,23 +1,15 @@
 package: JEWEL
-version: v2.0.2
+version: "%(tag_basename)s"
+tag: alice/v2.0.2
+source: https://github.com/alisw/jewel.git
 requires:
   - lhapdf5
 ---
 #!/bin/bash -ex
+rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
+sed -i.deleteme -e 's#^LHAPDF_PATH :=.*#LHAPDF_PATH := ${LHAPDF5_ROOT}/lib#' Makefile
 
-ARCHIVE="jewel-2.0.2.tar.gz"
-URL="https://www.hepforge.org/archive/jewel/${ARCHIVE}"
-
-cd $SOURCEDIR
-curl -O "${URL}"
-tar xz -f ${ARCHIVE}
-
-cd $BUILDDIR
-rsync -a $SOURCEDIR/ $BUILDDIR/
-
-sed -i -e 's#^LHAPDF_PATH :=.*#LHAPDF_PATH := ${LHAPDF5_ROOT}/lib#' Makefile
-
-make
+make ${JOBS:+-j$JOBS}
 
 install -d ${INSTALLROOT}/bin
 install -t ${INSTALLROOT}/bin \
@@ -37,7 +29,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0 lhapdf5/$LHAPDF5_VERSION-$LHAPDF5_REVISION
 # Our environment
 setenv JEWEL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(JEWEL_ROOT)/bin

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -5,6 +5,7 @@ source: https://github.com/alisw/LHAPDF
 requires:
  - yaml-cpp
  - boost
+ - Python
 build_requires:
  - autotools
 env:

--- a/pythia.sh
+++ b/pythia.sh
@@ -1,13 +1,13 @@
 package: pythia
-version: "v8210"
+version: "%(tag_basename)s"
 source: https://github.com/alisw/pythia8
 requires:
-  - lhapdf5
+  - lhapdf
   - HepMC
   - boost
-tag: alice/v8210
+tag: alice/v8211pre
 ---
-#!/bin/sh
+#!/bin/bash -e
 rsync -a $SOURCEDIR/ ./
 
 ./configure --prefix=$INSTALLROOT \
@@ -39,7 +39,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 lhapdf5/$LHAPDF5_VERSION-$LHAPDF5_REVISION boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
+module load BASE/1.0 lhapdf/$LHAPDF_VERSION-$LHAPDF_REVISION boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
 # Our environment
 setenv PYTHIA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(PYTHIA_ROOT)/bin

--- a/python.sh
+++ b/python.sh
@@ -5,6 +5,8 @@ requires:
  - zlib
  - FreeType
  - libpng
+env:
+  SSL_CERT_FILE: "$(export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print certifi.where()\")"
 ---
 #!/bin/bash -ex
 # Note: depends on AliEn-Runtime for OpenSSL.
@@ -45,6 +47,7 @@ python get-pip.py
 
 # Install extra packages with pip
 pip install "numpy==1.9.2"
+pip install "certifi==2015.9.6.2"
 
 # Install matplotlib (very tricky)
 MATPLOTLIB_VER="1.4.3"
@@ -105,4 +108,5 @@ module load BASE/1.0 AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISIO
 setenv PYTHON_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(PYTHON_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(PYTHON_ROOT)/lib
+setenv SSL_CERT_FILE [exec python -c "import certifi; print certifi.where()"]
 EoF

--- a/thepeg-test.sh
+++ b/thepeg-test.sh
@@ -29,7 +29,7 @@ set LHCEventHandler:EventFiller:SoftRemove NoValence
 set LHCGenerator:EventHandler:LuminosityFunction:Energy 7000
 create ThePEG::HepMCFile HepMCFile HepMCAnalysis.so
 set LHCGenerator:AnalysisHandlers 0 HepMCFile
-set HepMCFile:Filename /tmp/DIPSYpp.hepmc
+set HepMCFile:Filename DIPSYpp.hepmc
 set HepMCFile:PrintEvent 10000000000
 set HepMCFile:Format GenEvent
 set HepMCFile:Units GeV_mm

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -1,7 +1,7 @@
 package: ThePEG
-version: v20150318
+version: "%(tag_basename)s"
 source: https://github.com/alisw/thepeg
-tag: "alice/v2015-03-18"
+tag: "alice/v2015-08-11"
 requires:
   - Rivet
   - pythia
@@ -16,19 +16,17 @@ env:
 ---
 #!/bin/bash -e
 
-export LD_LIBRARY_PATH="${LHAPDF5_ROOT}/lib:${CGAL_ROOT}/lib:${BOOST_ROOT}/lib:${LD_LIBRARY_PATH}"
-export LIBRARY_PATH="${LHAPDF5_ROOT}/lib:${CGAL_ROOT}/lib:${BOOST_ROOT}/lib:${LIBRARY_PATH}"
-export LHAPATH="${LHAPDF5_ROOT}/share/lhapdf"
+export LIBRARY_PATH="${LHAPDF_ROOT}/lib:${CGAL_ROOT}/lib:${BOOST_ROOT}/lib:${LIBRARY_PATH}"
 export PERLLIB=/usr/share/perl5
 
-rsync -a --delete $SOURCEDIR/ ./
+rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 
 sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/Config/interfaces.pl.in
 sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.am
 sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.in
 
 autoreconf -ivf
-export LDFLAGS="-L$LHAPDF5_ROOT/lib"
+export LDFLAGS="-L$LHAPDF_ROOT/lib"
 ./configure \
   --disable-silent-rules \
   --enable-shared \
@@ -39,7 +37,7 @@ export LDFLAGS="-L$LHAPDF5_ROOT/lib"
   --with-pythia8="$PYTHIA_ROOT" \
   --with-hepmc="$HEPMC_ROOT" \
   --with-rivet="$RIVET_ROOT" \
-  --with-lhapdf="$LHAPDF5_ROOT" \
+  --with-lhapdf="$LHAPDF_ROOT" \
   --with-fastjet="$FASTJET_ROOT" \
   --enable-unitchecks 2>&1 | tee -a thepeg_configure.log
 grep -q 'Cannot build TheP8I without a working Pythia8 installation.' thepeg_configure.log && false


### PR DESCRIPTION
This should fix #110 (with ported fix from @mpuccio in #109) and #111. See also [ALIROOT-6251](https://alice.its.cern.ch/jira/browse/ALIROOT-6251).

@ktf please do not merge it yet, this might have implications on O2 for the change in Pythia version, we'll discuss it first.

@qgp please have a look at it, especially the PDF sets part (which now correctly fails if PDF sets are not downloaded).