### PR TITLE
Fix FastJet compilation error

### DIFF
--- a/gmp.sh
+++ b/gmp.sh
@@ -4,8 +4,8 @@ source: https://github.com/alisw/GMP.git
 tag: v6.0.0
 ---
 #!/bin/sh
-$SOURCEDIR/configure --disable-static --prefix=$INSTALLROOT \
-            --enable-shared --enable-cxx
+$SOURCEDIR/configure --enable-static --prefix=$INSTALLROOT \
+            --disable-shared --enable-cxx --with-pic
 
 make ${JOBS+-j $JOBS}
 make install

--- a/mpfr.sh
+++ b/mpfr.sh
@@ -10,9 +10,11 @@ build_requires:
 #!/bin/sh
 rsync -a $SOURCEDIR/ ./
 autoreconf -ivf
-./configure --disable-static \
+./configure --enable-static \
+            --disable-shared \
             --prefix=$INSTALLROOT \
-            --with-gmp=$GMP_ROOT
+            --with-gmp=$GMP_ROOT \
+            --with-pic
 
 make ${JOBS+-j $JOBS}
 make install


### PR DESCRIPTION
GMP is known to have troubles relocating when compiled as a shared
library.

This changes our build to use archive libraries for both GMP and MPFR so
that the problem does not happen when we reuse artifacts of a previous
build which was removed.