### PR TITLE
Use numeric version for IgProf version

### DIFF
--- a/igprof.sh
+++ b/igprof.sh
@@ -1,5 +1,5 @@
 package: IgProf
-version: master
+version: 5.9.16-%(commit_hash)s
 source: https://github.com/igprof/igprof
 tag: master
 requires:

--- a/libunwind.sh
+++ b/libunwind.sh
@@ -1,5 +1,5 @@
 package: libunwind
-version: master
+version: 1.1-%(commit_hash)s
 source: https://github.com/igprof/libunwind
 tag: master
 requires:


### PR DESCRIPTION
Debian / Ubuntu packaging complains about using "master" in a version.