### PR TITLE
Use old recipe for slc6 / slc7 / ubuntu

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -13,7 +13,7 @@ build_requires:
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in 
-  osx*)
+  osx*|slc[67]*|ubuntu*)
     # The new build recipe does not work on mac. Working it around using the
     # old installer.
     curl -O -fSsL --insecure http://alien.cern.ch/alien-installer

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -1,12 +1,11 @@
 package: fastjet
 version: "%(tag_basename)s"
-tag: alice/v3.0.6_1.012
+tag: "alice/v3.1.3_1.017"
 source: https://github.com/alisw/fastjet
 requires:
   - cgal
 ---
 #!/bin/bash -e
-export LD_LIBRARY_PATH="$BOOST_ROOT/lib:$LD_LIBRARY_PATH"
 export LIBRARY_PATH="$BOOST_ROOT/lib:$LIBRARY_PATH"
 
 rsync -a --delete --cvs-exclude $SOURCEDIR/ ./


### PR DESCRIPTION
This is needed because the new one does not compile anymore and
bails out with a message:

```
DEBUG:AliRoot:0: + make install
DEBUG:AliRoot:0: ../../..//autodetect.sh: 32: shift: can't shift that many
```