### PR TITLE
Use old recipe for slc6 / slc7 / ubuntu

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -13,7 +13,7 @@ build_requires:
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in 
-  osx*)
+  osx*|slc[67]*|ubuntu*)
     # The new build recipe does not work on mac. Working it around using the
     # old installer.
     curl -O -fSsL --insecure http://alien.cern.ch/alien-installer


### PR DESCRIPTION
This is needed because the new one does not compile anymore and
bails out with a message:

```
DEBUG:AliRoot:0: + make install
DEBUG:AliRoot:0: ../../..//autodetect.sh: 32: shift: can't shift that many
```