### PR TITLE
Force build architecture to core2 on x86-64

### DIFF
--- a/gmp.sh
+++ b/gmp.sh
@@ -4,7 +4,12 @@ source: https://github.com/alisw/GMP.git
 tag: v6.0.0
 ---
 #!/bin/sh
+case $ARCHITECTURE in
+  *x86-64) BUILD=core2 ;;
+  *) BUILD=generic ;;
+esac
 $SOURCEDIR/configure --enable-static --prefix=$INSTALLROOT \
+            --build=$BUILD \
             --disable-shared --enable-cxx --with-pic
 
 make ${JOBS+-j $JOBS}


### PR DESCRIPTION
This is to avoid that GMP does too aggresive choices when compiled on
AMD, failing to work when is then used on Corei7 or other Intel CPUs.

This will hopefully fix fix the error:

```
checking for double-to-integer conversion bug... yes or failed to exec (exit status is 132)
configure: error: double-to-integer conversion is incorrect.
You need to use another compiler (or lower the optimization level).
```

and similar compilation errors which are seen at random during the builds of
MPFR / FastJet. The joys of cloud computing.