### PR TITLE
Fix OSX builds

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -27,7 +27,7 @@ else
   make install
 fi
 
-cp -r $SOURCEDIR/test $INSTALLROOT/test
+rsync -av $SOURCEDIR/test/ $INSTALLROOT/test
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/gmp.sh
+++ b/gmp.sh
@@ -5,12 +5,17 @@ tag: v6.0.0
 ---
 #!/bin/sh
 case $ARCHITECTURE in
-  *x86-64) BUILD=core2 ;;
-  *) BUILD=generic ;;
+  osx*) CONFIG_OPTS="" ;;
+  *x86-64) CONFIG_OPTS="--build=core2" ;;
+  *) CONFIG_OPTS= ;;
 esac
-$SOURCEDIR/configure --enable-static --prefix=$INSTALLROOT \
-            --build=$BUILD \
-            --disable-shared --enable-cxx --with-pic
+
+$SOURCEDIR/configure --prefix=$INSTALLROOT \
+            --enable-cxx \
+            --enable-static \
+            --disable-shared \
+            --with-pic \
+            $CONFIG_OPTS
 
 make ${JOBS+-j $JOBS}
 make install

--- a/mpfr.sh
+++ b/mpfr.sh
@@ -8,13 +8,19 @@ build_requires:
   - autotools
 ---
 #!/bin/sh
-rsync -a $SOURCEDIR/ ./
+rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
 autoreconf -ivf
-./configure --enable-static \
+case $ARCHITECTURE in
+  osx*) CONFIG_OPTS="" ;;
+  *x86-64) CONFIG_OPTS="--build=core2" ;;
+  *) CONFIG_OPTS= ;;
+esac
+
+./configure --prefix=$INSTALLROOT \
             --disable-shared \
-            --prefix=$INSTALLROOT \
+            --enable-static \
             --with-gmp=$GMP_ROOT \
-            --with-pic
+            $CONFIG_OPTS
 
 make ${JOBS+-j $JOBS}
 make install


### PR DESCRIPTION
Recent changes in GMP and MPFR did not work well on OSX, so we revert to
the old behavior there.