### PR TITLE
Fix various MPFR issues

### DIFF
--- a/mpfr.sh
+++ b/mpfr.sh
@@ -2,24 +2,17 @@ package: MPFR
 version: v3.1.3
 source: https://github.com/alisw/MPFR.git
 tag: v3.1.3
-requires:
-  - GMP
 build_requires:
   - autotools
+  - GMP
 ---
 #!/bin/sh
 rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
 autoreconf -ivf
-case $ARCHITECTURE in
-  osx*) BUILD="" ;;
-  *x86-64) BUILD="core2" ;;
-  *) BUILD= ;;
-esac
 
 ./configure --prefix=$INSTALLROOT    \
             --disable-shared         \
             --enable-static          \
-            ${BUILD:+--build=$BUILD} \
             --with-gmp=$GMP_ROOT
 
 make ${JOBS+-j $JOBS}


### PR DESCRIPTION
- Let it detect build options from GMP.
- GMP is really a build_requires, not a runtime requires, since we are
  building an archive library. Clients of MPFR should include both GMP and
  MPFR as build_requires.