### PR TITLE
PYTHIA8DATA to find XML data files at runtime

### DIFF
--- a/pythia.sh
+++ b/pythia.sh
@@ -6,6 +6,8 @@ requires:
   - HepMC
   - boost
 tag: alice/v8211pre
+env:
+  PYTHIA8DATA: "$PYTHIA_ROOT/share/Pythia8/xmldoc"
 ---
 #!/bin/bash -e
 rsync -a $SOURCEDIR/ ./
@@ -42,6 +44,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 lhapdf/$LHAPDF_VERSION-$LHAPDF_REVISION boost/$BOOST_VERSION-$BOOST_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
 # Our environment
 setenv PYTHIA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv PYTHIA8DATA \$::env(PYTHIA_ROOT)/share/Pythia8/xmldoc
 prepend-path PATH \$::env(PYTHIA_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib
 EoF


### PR DESCRIPTION
If not present ThePEG uses the original unrelocated build path.

Improved version of #153.