### PR TITLE
Improve release naming

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -1,5 +1,5 @@
 package: AliPhysics
-version: "%(commit_hash)s%(defaults_upper)s"
+version: "%(year)s%(month)s%(day)s-%(short_hash)s%(defaults_upper)s"
 requires:
   - AliRoot
 source: http://git.cern.ch/pub/AliPhysics

--- a/aliroot-test.sh
+++ b/aliroot-test.sh
@@ -1,5 +1,5 @@
 package: AliRoot-test
-version: v1
+version: "%(yeah)s%(month)s%(day)s%(defaults_upper)s"
 force_rebuild: 1
 requires:
   - AliPhysics

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -1,5 +1,5 @@
 package: AliRoot
-version: "%(commit_hash)s%(defaults_upper)s"
+version: "%(year)s%(month)s%(day)s-%(short_hash)s%(defaults_upper)s"
 requires:
   - ROOT
   - fastjet


### PR DESCRIPTION
Now aliphysics / aliroot / aliroot-test builds will include date and
defaults name.