### PR TITLE
Improve coverage defaults

### DIFF
--- a/defaults-coverage.sh
+++ b/defaults-coverage.sh
@@ -1,8 +1,8 @@
 package: defaults-coverage
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O2"
-  CFLAGS: "-fPIC -g -O2"
+  CXXFLAGS: "-fPIC -g -O2 -fprofile-arcs -ftest-coverage"
+  CFLAGS: "-fPIC -g -O2 -fprofile-arcs -ftest-coverage"
   CMAKE_BUILD_TYPE: Coverage
 ---
 # This file is included in any build recipe and it's only used to set


### PR DESCRIPTION
Explicitly mention coverage options so that also externals which
use CXXFLAGS and CFLAGS are built with gcov information.