### PR TITLE
Remove date from Ali* names

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -1,5 +1,5 @@
 package: AliPhysics
-version: "%(year)s%(month)s%(day)s-%(short_hash)s%(defaults_upper)s"
+version: "%(commit_hash)s%(defaults_upper)s"
 requires:
   - AliRoot
 source: http://git.cern.ch/pub/AliPhysics

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -1,5 +1,5 @@
 package: AliRoot
-version: "%(year)s%(month)s%(day)s-%(short_hash)s%(defaults_upper)s"
+version: "%(commit_hash)s%(defaults_upper)s"
 requires:
   - ROOT
   - fastjet


### PR DESCRIPTION
We should, maybe, override the `version:` too in `build-any-ib.sh` when running the IBs instead.