### PR TITLE
AliPhysics tests

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -6,7 +6,7 @@ source: http://git.cern.ch/pub/AliPhysics
 tag: master
 env:
   ALICE_PHYSICS: "$ALIPHYSICS_ROOT"
-incremental_recipe: make ${JOBS:+-j$JOBS} && make install
+incremental_recipe: make ${JOBS:+-j$JOBS} install
 ---
 #!/bin/bash -e
 cmake "$SOURCEDIR" \
@@ -20,10 +20,12 @@ cmake "$SOURCEDIR" \
       ${GMP_ROOT:+-DGMP="$GMP_ROOT"} \
       -DALIROOT="$ALIROOT_ROOT"
 
+# note: ctest returns 0 in case no test is found
 if [[ $GIT_TAG == master ]]; then
-  make -k ${JOBS+-j $JOBS} install || true
+  make -k ${JOBS+-j $JOBS} install && ctest --output-on-failure || true
 else
   make ${JOBS+-j $JOBS} install
+  ctest --output-on-failure
 fi
 
 # Modulefile

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -14,11 +14,8 @@ rsync -a --delete --cvs-exclude $SOURCEDIR/ ./
 
 # FastJet
 pushd fastjet
-  case $ARCHITECTURE in
-    slc*) LINUX_CXXFLAGS="-Wl,--no-as-needed" ;;
-  esac
-  
-  export CXXFLAGS="$LINUX_CXXFLAGS -L$GMP_ROOT/lib -lgmp -L$MPFR_ROOT/lib -lmpfr -L$BOOST_ROOT/lib -lboost_thread -lboost_system -L$CGAL_ROOT/lib -I$BOOST_ROOT/include -I$CGAL_ROOT/include -I$GMP_ROOT/include -I$MPFR_ROOT/include -DCGAL_DO_NOT_USE_MPZF -O2 -g"
+  [[ "${ARCHITECTURE:0:3}" != osx ]] && EXTRA_CXXFLAGS='-Wl,--no-as-needed'
+  export CXXFLAGS="$EXTRA_CXXFLAGS -L$GMP_ROOT/lib -lgmp -L$MPFR_ROOT/lib -lmpfr -L$BOOST_ROOT/lib -lboost_thread -lboost_system -L$CGAL_ROOT/lib -lCGAL -I$BOOST_ROOT/include -I$CGAL_ROOT/include -I$GMP_ROOT/include -I$MPFR_ROOT/include -DCGAL_DO_NOT_USE_MPZF -O2 -g"
   export CFLAGS="$CXXFLAGS"
   export CPATH="$BOOST_ROOT/include:$CGAL_ROOT/include:$GMP_ROOT/include:$MPFR_ROOT/include"
   export C_INCLUDE_PATH="$BOOST_ROOT/include:$CGAL_ROOT/include:$GMP_ROOT/include:$MPFR_ROOT/include"


### PR DESCRIPTION
* Run `ctest` after AliPhysics build. Tests library loading. Build fails if tests fail.
* Old AliPhysics versions without tests unaffected: `ctest` returns 0 in case no test is found.
* FastJet explicitly links CGAL. This is the right thing to do (and makes the tests pass too).