### PR TITLE
Disable AliEn-Runtime on POWER8

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s-alice%(defaults_upper)s"
 tag: alice/v5-34-30
 source: https://github.com/alisw/root
 requires: 
-  - AliEn-Runtime
+  - AliEn-Runtime:(?!.*ppc64)
   - GSL
 env:
   ROOTSYS: "$ROOT_ROOT"
@@ -64,7 +64,7 @@ export ROOTSYS=$BUILDDIR
   --with-ssl-shared=yes \
   --enable-mysql
 
-./bin/root-config --features | grep -q alien
+${ALIEN_RUNTIME_ROOT:+./bin/root-config --features | grep -q alien}
 ./bin/root-config --features | grep -q opengl
 
 make ${JOBS+-j$JOBS}


### PR DESCRIPTION
- Do not build AliEn-Runtime
- Do not check for Alien support in root if AliEn-Runtime was not
  included as a dependency.