### PR TITLE
Fix wrong CFLAGS in root6 defaults

### DIFF
--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -2,7 +2,7 @@ package: defaults-root6
 version: v1
 env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++11"
-  CFLAGS: "-fPIC -g -O2 -std=c++11"
+  CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 ---
 # This file is included in any build recipe and it's only used to set


### PR DESCRIPTION
`-std=c++11` is not a valid flag for CFLAGS.