### PR TITLE
Unset SIMPATH when building

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -13,6 +13,12 @@ requires:
 ---
 #!/bin/sh
 
+# Making sure people do not have SIMPATH set when they build fairroot.
+# Unfortunately SIMPATH seems to be hardcoded in a bunch of places in
+# fairroot, so this really should be cleaned up in FairRoot itself for
+# maximum safety.
+unset SIMPATH
+
 case $ARCHITECTURE in
   osx*)
     # If we preferred system tools, we need to make sure we can pick them up.

--- a/o2.sh
+++ b/o2.sh
@@ -11,6 +11,12 @@ incremental_recipe: make ${JOBS:+-j$JOBS} install
 #!/bin/sh
 export ROOTSYS=$ROOT_ROOT
 
+# Making sure people do not have SIMPATH set when they build fairroot.
+# Unfortunately SIMPATH seems to be hardcoded in a bunch of places in
+# fairroot, so this really should be cleaned up in FairRoot itself for
+# maximum safety.
+unset SIMPATH
+
 case $ARCHITECTURE in
   osx*)
     # If we preferred system tools, we need to make sure we can pick them up.


### PR DESCRIPTION
Not particularly good solution (SIMPATH might be picked up at runtime
accidentally) but already two people had this problem, so I try to limit
damage. Should really be cleaned up in O2 and FairRoot themselves.