### PR TITLE
Fix broken builds on SLC6 (maybe others)

### DIFF
--- a/freetype.sh
+++ b/freetype.sh
@@ -10,7 +10,8 @@ tar xzf freetype.tgz
 rm -f freetype.tgz
 cd freetype-${PKGVERSION:1}
 ./configure --prefix=$INSTALLROOT \
-            --with-zlib=$ZLIB_ROOT
+            ${ZLIB_ROOT:+--with-zlib=$ZLIB_ROOT}
+
 make ${JOBS:+-j$JOBS}
 make install
 

--- a/gsoap.sh
+++ b/gsoap.sh
@@ -17,12 +17,12 @@ case $ARCHITECTURE in
     [ ! "X$OPENSSL_ROOT" = X ] || OPENSSL_ROOT=`brew --prefix openssl`
   ;;
 esac
-export CFLAGS="-fPIC -I$OPENSSL_ROOT/include -I$ZLIB_ROOT/include -L$OPENSSL_ROOT/lib -L$ZLIB_ROOT/lib"
+export CFLAGS="-fPIC ${OPENSSL_ROOT:+-I$OPENSSL_ROOT/include -L$OPENSSL_ROOT/lib} ${ZLIB_ROOT:+-I$ZLIB_ROOT/include -L$ZLIB_ROOT/lib}"
 export CXXFLAGS="$CFLAGS"
 export CPPFLAGS="$CFLAGS"
 autoreconf -ivf
-./configure --prefix=$INSTALLROOT \
-            --enable-ssl \
+./configure --prefix=$INSTALLROOT                          \
+            --enable-ssl                                   \
             ${OPENSSL_ROOT:+--with-openssl=$OPENSSL_ROOT}
 # Does not build in multicore!
 make

--- a/libpng.sh
+++ b/libpng.sh
@@ -8,11 +8,11 @@ source: git://git.code.sf.net/p/libpng/code
 ---
 #!/bin/bash -ex
 rsync -a $SOURCEDIR/ .
-cmake . \
-    -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLROOT \
-    -DBUILD_SHARED_LIBS=YES \
-    -DZLIB_ROOT:PATH=$ZLIB_ROOT \
-    -DCMAKE_SKIP_RPATH=YES \
+cmake .                                        \
+    -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLROOT   \
+    -DBUILD_SHARED_LIBS=YES                    \
+    ${ZLIB_ROOT:+-DZLIB_ROOT:PATH=$ZLIB_ROOT}  \
+    -DCMAKE_SKIP_RPATH=YES                     \
     -DSKIP_INSTALL_FILES=1
 make ${JOBS:+-j $JOBS}
 make install


### PR DESCRIPTION
- When zlib is picked up from the system we must make sure we do not
  try to pick it up from the (empty) `ZLIB_ROOT`.