### PR TITLE
Explicitely use a CMAKE_BUILD_TYPE in GEANT3 recipe

### DIFF
--- a/geant3.sh
+++ b/geant3.sh
@@ -12,6 +12,7 @@ prepend_path:
 ---
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
                  -DROOTSYS=$ROOT_ROOT \
                  -DCMAKE_SKIP_RPATH=TRUE
 make ${JOBS+-j$JOBS}


### PR DESCRIPTION
Builds of GEANT3 did not use any build type.
Hence, CMake used the default provided by the GEANT3
CMakeList.txt file which is simply set to "O0" without debug information.

By using a CMAKE_BUILD_TYPE in the recipe, we make sure to compile
Geant3 with optimizations.