### PR TITLE
Separate python from its modules

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/LHAPDF
 requires:
  - yaml-cpp
  - boost
- - Python
+ - Python-modules
 build_requires:
  - autotools
 env:

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -1,0 +1,75 @@
+package: Python-modules
+version: "1.0"
+requires:
+  - Python
+env:
+  SSL_CERT_FILE: "$(export PYTHONPATH=$PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH; export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print certifi.where()\")"
+prepend_path:
+  PYTHONPATH: $PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH
+prefer_system: (?!slc5)
+prefer_system_check:
+  python -c 'import matplotlib; import numpy; import certifi'
+---
+#!/bin/bash -ex
+
+# Install extra packages with pip
+pip install --install-option="--prefix=$INSTALLROOT" "numpy==1.9.2"
+pip install --install-option="--prefix=$INSTALLROOT" "certifi==2015.9.6.2"
+
+# Install matplotlib (very tricky)
+MATPLOTLIB_VER="1.4.3"
+MATPLOTLIB_URL="http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-${MATPLOTLIB_VER}/matplotlib-${MATPLOTLIB_VER}.tar.gz"
+curl -Lo matplotlib.tgz $MATPLOTLIB_URL
+tar xzf matplotlib.tgz
+cd matplotlib-$MATPLOTLIB_VER
+cat > setup.cfg <<EOF
+[directories]
+basedirlist  = ${FREETYPE_ROOT:+$PWD/fake_freetype_root,$FREETYPE_ROOT,}${LIBPNG_ROOT:+$LIBPNG_ROOT,}${ZLIB_ROOT:+$ZLIB_ROOT,}/usr/X11R6,$(freetype-config --prefix),$(libpng-config --prefix)
+
+[gui_support]
+gtk = False
+gtkagg = False
+tkagg = False
+wxagg = False
+macosx = False
+EOF
+
+# matplotlib wants include files in <PackageRoot>/include, but this is not the
+# case for FreeType: let's fix it
+if [[ $FREETYPE_ROOT ]]; then
+  mkdir fake_freetype_root
+  ln -nfs $FREETYPE_ROOT/include/freetype2 fake_freetype_root/include
+fi
+perl -p -i -e "s|'darwin': \['/usr/local/'|'darwin': ['$INSTALLROOT'|g" setupext.py
+
+python setup.py build
+python setup.py install
+
+# Remove useless stuff
+rm -rvf $INSTALLROOT/share \
+       $INSTALLROOT/lib/python*/test
+find $INSTALLROOT/lib/python* \
+     -mindepth 2 -maxdepth 2 -type d -and \( -name test -or -name tests \) \
+     -exec rm -rvf '{}' \;
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${PYTHON_VERSION:+Python/$PYTHON_VERSION-$PYTHON_REVISION} ${ALIEN_RUNTIME_VERSION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION}
+# Our environmen:$PYTHONPATH
+setenv PYTHON_MODULES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH $::env(PYTHON_MODULES_ROOT)/bin
+prepend-path LD_LIBRARY_PATH $::env(PYTHON_MODULES_ROOT)/lib
+prepend-path PYTHONPATH $::env(PYTHON_MODULES_ROOT)/lib/python2.7/site-packages
+setenv SSL_CERT_FILE [exec python -c "import certifi; print certifi.where()"]
+EoF

--- a/python.sh
+++ b/python.sh
@@ -10,7 +10,7 @@ env:
   SSL_CERT_FILE: "$(export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print certifi.where()\")"
 prefer_system: (?!slc5)
 prefer_system_check:
-  python -c 'import matplotlib; import numpy; import certifi ; import sys; sys.exit(1 if sys.version_info < (2, 7) else 0)'
+  python -c 'import sys; sys.exit(1 if sys.version_info < (2, 7) else 0)' && which pip
 ---
 #!/bin/bash -ex
 
@@ -50,38 +50,6 @@ export DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH
 curl -kSsL -o get-pip.py https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 
-# Install extra packages with pip
-pip install "numpy==1.9.2"
-pip install "certifi==2015.9.6.2"
-
-# Install matplotlib (very tricky)
-MATPLOTLIB_VER="1.4.3"
-MATPLOTLIB_URL="http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-${MATPLOTLIB_VER}/matplotlib-${MATPLOTLIB_VER}.tar.gz"
-curl -Lo matplotlib.tgz $MATPLOTLIB_URL
-tar xzf matplotlib.tgz
-cd matplotlib-$MATPLOTLIB_VER
-cat > setup.cfg <<EOF
-[directories]
-basedirlist  = ${FREETYPE_ROOT:+$PWD/fake_freetype_root,$FREETYPE_ROOT,}${LIBPNG_ROOT:+$LIBPNG_ROOT,}${ZLIB_ROOT:+$ZLIB_ROOT,}/usr/X11R6${FREETYPE_ROOT:+,$(freetype-config --prefix)},${LIBPNG_ROOT:+,$(libpng-config --prefix)}
-
-[gui_support]
-gtk = False
-gtkagg = False
-tkagg = False
-wxagg = False
-macosx = False
-EOF
-
-# matplotlib wants include files in <PackageRoot>/include, but this is not the
-# case for FreeType: let's fix it
-if [[ $FREETYPE_ROOT ]]; then
-  mkdir fake_freetype_root
-  ln -nfs $FREETYPE_ROOT/include/freetype2 fake_freetype_root/include
-fi
-
-python setup.py build
-python setup.py install
-
 # Remove useless stuff
 rm -rvf $INSTALLROOT/share \
        $INSTALLROOT/lib/python*/test
@@ -107,5 +75,4 @@ module load BASE/1.0 ${ALIEN_RUNTIME_VERSION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSI
 setenv PYTHON_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(PYTHON_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(PYTHON_ROOT)/lib
-setenv SSL_CERT_FILE [exec python -c "import certifi; print certifi.where()"]
 EoF

--- a/yoda.sh
+++ b/yoda.sh
@@ -2,7 +2,7 @@ package: YODA
 version: "v1.4.0"
 requires:
   - boost
-  - Python
+  - Python-modules
 prepend_path:
   PYTHONPATH: "$(yoda-config --pythonpath)"
 ---
@@ -29,7 +29,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION Python/$PYTHON_VERSION-$PYTHON_REVISION
+module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION ${PYTHON_VERSION:+Python/$PYTHON_VERSION-$PYTHON_REVISION} ${PYTHON_MODULES_VERSION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}
 # Our environment
 setenv YODA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(YODA_ROOT)/bin


### PR DESCRIPTION
This allow us to use the system python and only build the few modules
which might be missing on the system (i.e matplotlib, certifi, bumpy). This also should fix the case in which `freetype` or `libpng` come from the system.

<!---
@huboard:{"order":132.5,"milestone_order":305,"custom_state":""}
-->
