### PR TITLE
add Rivet directory to PYTHONPATH

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -63,6 +63,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${GSL_VERSION:+GSL/$GSL_VERSION-$GSL_REVISION} YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION ${BOOST_ROOT:+boost/$BOOST_VERSION-$BOOST_REVISION}
 # Our environment
 setenv RIVET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PYTHONPATH \$::env(RIVET_ROOT)/lib/python2.7/site-packages
 prepend-path PATH \$::env(RIVET_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(RIVET_ROOT)/lib
 EoF


### PR DESCRIPTION
Required to make the python-based rivet utilities work.

@ktf: is it ok to use python2.7 hardcodedly in the path?