### PR TITLE
add test for Rivet

### DIFF
--- a/rivet-test.sh
+++ b/rivet-test.sh
@@ -1,0 +1,47 @@
+package: Rivet-test
+version: v1
+force_rebuild: 1
+requires:
+  - ThePEG
+  - Rivet
+---
+#!/bin/bash
+cat > DIPSYpp_HepMC.in <<\EOF
+read Tune27.in
+cd /DIPSY
+cp EventHandler LHCEventHandler
+set LHCEventHandler:WFL stdProton
+set LHCEventHandler:WFR stdProton
+set LHCEventHandler:ConsistencyLevel 0
+set LHCEventHandler:XSecFn:CheckOffShell false
+set LHCEventHandler:CascadeHandler NULL
+set LHCEventHandler:HadronizationHandler NULL
+set LHCEventHandler:DecayHandler NULL
+create ThePEG::FixedCMSLuminosity LHCLumi
+set LHCEventHandler:LuminosityFunction LHCLumi
+cp Generator LHCGenerator
+set LHCGenerator:EventHandler LHCEventHandler
+set LHCEventHandler:EffectivePartonMode Colours
+set LHCGenerator:EventHandler:DecayHandler /Defaults/Handlers/StandardDecayHandler
+set LHCGenerator:EventHandler:HadronizationHandler Frag8
+set LHCEventHandler:WFL Proton
+set LHCEventHandler:WFR Proton
+set LHCEventHandler:EventFiller:SoftRemove NoValence
+set LHCGenerator:EventHandler:LuminosityFunction:Energy 7000
+create ThePEG::HepMCFile HepMCFile HepMCAnalysis.so
+set LHCGenerator:AnalysisHandlers 0 HepMCFile
+set HepMCFile:Filename DIPSYpp.hepmc
+set HepMCFile:PrintEvent 10000000000
+set HepMCFile:Format GenEvent
+set HepMCFile:Units GeV_mm
+saverun DIPSYpp LHCGenerator
+EOF
+
+setupThePEG -r $THEPEG_ROOT/lib/ThePEG/ThePEGDefaults.rpo \
+            -I $THEPEG_ROOT/share/Ariadne \
+            DIPSYpp_HepMC.in
+runThePEG DIPSYpp.run -N100 --tics
+
+rivet -a ALICE_2010_S8625980 DIPSYpp.hepmc
+
+rivet-cmphistos Rivet.yoda


### PR DESCRIPTION
first draft for testing Rivet using ThePEG for producing an input HepMC file 
(this includes testing the python installation, we refrain from running rivet-mkhtml to avoid requiring latex)

@ktf: there is still a problem with rivet-cmphistos as the PYTHONPATH is not set when Rivet is run from the test. When I load the environment interactively, it works fine. Am I overlooking something obvious?