### PR TITLE
Fix yaml headers for YODA, Rivet

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -7,7 +7,7 @@ requires:
   - HepMC
   - boost
 prepend_path:
-  PYTHONPATH: $RIVET_ROOT/lib/python2.7/site-packages:$PYTHONPATH
+  PYTHONPATH: $RIVET_ROOT/lib/python2.7/site-packages
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in

--- a/yoda.sh
+++ b/yoda.sh
@@ -4,7 +4,7 @@ requires:
   - boost
   - Python
 prepend_path:
-  PYTHONPATH: "$(yoda-config --pythonpath)"
+  PYTHONPATH: $YODA_ROOT/lib/python2.7/site-packages
 ---
 #!/bin/bash -e
 Url="http://www.hepforge.org/archive/yoda/YODA-${PKGVERSION:1}.tar.bz2"


### PR DESCRIPTION
- Rivet: remove appended $PYTHONPATH
- YODA: replace $(yoda-config ...) with explicit path

@ktf: I had copied the line with PYTHONPATH from python-modules.sh (https://github.com/ktf/alidist/blob/python-split/python-modules.sh), also there still is the second PYTHONPATH appended again.