### PR TITLE
Add direct build_requires to GCC-Toolchain

### DIFF
--- a/hepmc.sh
+++ b/hepmc.sh
@@ -3,13 +3,14 @@ version: "v2.06.09"
 source: https://github.com/alisw/hepmc
 build_requires:
   - CMake
+  - GCC-Toolchain
 ---
 #!/bin/bash -e
 
-cmake  $SOURCEDIR \
-       -Dmomentum=GEV \
-       -Dlength=MM \
-       -Dbuild_docs:BOOL=OFF \
+cmake  $SOURCEDIR                           \
+       -Dmomentum=GEV                       \
+       -Dlength=MM                          \
+       -Dbuild_docs:BOOL=OFF                \
        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 make ${JOBS+-j $JOBS}
@@ -28,7 +29,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
 setenv HEPMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(HEPMC_ROOT)/bin


### PR DESCRIPTION
HepMC is missing GCC-Toolchain direct build dependency and relies on
CMake to provide it. When CMake is picked up from the system, it fails
because GCC-Toolchain gets dropped as well.