### PR TITLE
Improve system requirements checks

### DIFF
--- a/sip-check.sh
+++ b/sip-check.sh
@@ -1,15 +1,15 @@
 package: sip-check
 version: 1.0
 system_requirement_missing: |
-  Please make sure you have SIP disabled. 
+  Please make sure you have SIP disabled.
 
-  See: 
+  See:
 
       http://alisw.github.io/alibuild/troubleshooting.html#fastjet-fails-to-compile-on-my-brand-new-mac
-  
+
   for more information.
 system_requirement: "(osx.*)"
 system_requirement_check: |
-  csrutil status | grep disabled
+  (which csrutil && (csrutil status | grep disabled) ) || ! which csrutil
 ---
 

--- a/swig.sh
+++ b/swig.sh
@@ -5,6 +5,7 @@ tag: rel-3.0.7
 build_requires:
   - autotools
   - "GCC-Toolchain:(?!osx)"
+  - yacc-like
 env:
   SWIG_LIB: "$SWIG_ROOT/share/swig/$SWIG_VERSION"
 prefer_system: (?!slc5)


### PR DESCRIPTION
- sip-check now works on older OSX without csrutil
- swig needs bison
- xalienfs needs libperl