### PR TITLE
Allow to compile AliROOT with system ROOT

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -20,6 +20,7 @@ incremental_recipe: |
 #!/bin/bash -e
 cmake $SOURCEDIR                                                  \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                         \
+      ${ROOT_ROOT:--DROOTSYS=$(root-config --prefix)}             \
       ${ROOT_ROOT:+-DROOTSYS=$ROOT_ROOT}                          \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"} \
       ${ALIEN_RUNTIME_ROOT:+-DALIEN=$ALIEN_RUNTIME_ROOT}          \


### PR DESCRIPTION
Only works if you specify --disable ROOT