### PR TITLE
Make modulefiles work on OSX (#324)

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -47,6 +47,7 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 # Our environment
 setenv ALIEN_RUNTIME_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_ROOT)/lib")
 prepend-path PATH \$::env(ALIEN_RUNTIME_ROOT)/bin
 prepend-path PERLLIB \$::env(ALIEN_RUNTIME_ROOT)/lib/perl
 setenv GSHELL_ROOT \$::env(ALIEN_RUNTIME_ROOT)

--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -57,5 +57,6 @@ setenv ALIPHYSICS_RELEASE \$::env(ALIPHYSICS_VERSION)
 setenv ALICE_PHYSICS \$::env(BASEDIR)/$PKGNAME/\$::env(ALIPHYSICS_RELEASE)
 prepend-path PATH \$::env(ALICE_PHYSICS)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ALICE_PHYSICS)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALICE_PHYSICS)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -59,5 +59,6 @@ setenv ALIROOT_RELEASE \$::env(ALIROOT_VERSION)
 setenv ALICE_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(ALIROOT_RELEASE)
 prepend-path PATH \$::env(ALICE_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ALICE_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALICE_ROOT)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/boost.sh
+++ b/boost.sh
@@ -69,4 +69,5 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 # Our environment
 setenv BOOST_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(BOOST_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BOOST_ROOT)/lib")
 EoF

--- a/cctools.sh
+++ b/cctools.sh
@@ -35,4 +35,5 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 setenv CCTOOLS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(CCTOOLS_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(CCTOOLS_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(CCTOOLS_ROOT)/lib")
 EoF

--- a/cgal.sh
+++ b/cgal.sh
@@ -86,4 +86,5 @@ module load BASE/1.0 ${BOOST_ROOT:+boost/$BOOST_VERSION-$BOOST_REVISION}
 setenv CGAL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(CGAL_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(CGAL_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(CGAL_ROOT)/lib")
 EoF

--- a/crmc.sh
+++ b/crmc.sh
@@ -40,4 +40,5 @@ module load BASE/1.0 ${BOOST_ROOT:+boost/$BOOST_VERSION-$BOOST_REVISION} HepMC/$
 setenv CRMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(CRMC_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(CRMC_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(CRMC_ROOT)/lib")
 EoF

--- a/dds.sh
+++ b/dds.sh
@@ -38,4 +38,5 @@ module load BASE/1.0 ${BOOST_ROOT:+Boost/$BOOST_VERSION-$BOOST_REVISION}  ${GCC_
 setenv DDS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(DDS_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(DDS_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(DDS_ROOT)/lib")
 EoF

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -62,4 +62,5 @@ module load BASE/1.0 ${BOOST_ROOT:+Boost/$BOOST_VERSION-$BOOST_REVISION} ROOT/$R
 # Our environment
 setenv FAIRROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib")
 EoF

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -78,4 +78,5 @@ setenv FASTJET \$::env(BASEDIR)/$PKGNAME/\$version
 setenv FASTJET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(FASTJET_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(FASTJET_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FASTJET_ROOT)/lib")
 EoF

--- a/freetype.sh
+++ b/freetype.sh
@@ -38,4 +38,5 @@ module load BASE/1.0 ${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
 setenv FREETYPE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(FREETYPE_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(FREETYPE_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(FREETYPE_ROOT)/lib")
 EoF

--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -153,6 +153,8 @@ if { "\$mod_name" == "GCC-Toolchain" } {
 # Our environment
 setenv GCC_TOOLCHAIN_ROOT \$base_path/GCC-Toolchain/\$version
 prepend-path LD_LIBRARY_PATH \$::env(GCC_TOOLCHAIN_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GCC_TOOLCHAIN_ROOT)/lib")
 prepend-path LD_LIBRARY_PATH \$::env(GCC_TOOLCHAIN_ROOT)/lib64
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GCC_TOOLCHAIN_ROOT)/lib64")
 prepend-path PATH \$::env(GCC_TOOLCHAIN_ROOT)/bin
 EoF

--- a/geant3.sh
+++ b/geant3.sh
@@ -39,4 +39,5 @@ setenv GEANT3_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv GEANT3DIR \$::env(GEANT3_ROOT)
 prepend-path PATH \$::env(GEANT3_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(GEANT3_ROOT)/lib64
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT3_ROOT)/lib64")
 EoF

--- a/geant4.sh
+++ b/geant4.sh
@@ -65,4 +65,5 @@ setenv G4NEUTRONXSDATA \$::env(G4INSTALL_DATA)/data/G4NEUTRONXS1.4
 setenv G4SAIDXSDATA \$::env(G4INSTALL_DATA)/data/G4SAIDDATA1.1
 prepend-path PATH \$::env(GEANT4_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib")
 EoF

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -42,4 +42,5 @@ setenv GEANT4_VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv G4VMCINSTALL \$::env(GEANT4_VMC_ROOT)
 prepend-path PATH \$::env(GEANT4_VMC_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(GEANT4_VMC_ROOT)/lib64
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT4_VMC_ROOT)/lib64")
 EoF

--- a/glog.sh
+++ b/glog.sh
@@ -28,5 +28,6 @@ module load BASE/1.0
 # Our environment
 setenv PROTOBUF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(PROTOBUF_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PROTOBUF_ROOT)/lib")
 prepend-path PATH \$::env(PROTOBUF_ROOT)/bin
 EoF

--- a/gmp.sh
+++ b/gmp.sh
@@ -41,4 +41,5 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 # Our environment
 setenv GMP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(GMP_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GMP_ROOT)/lib")
 EoF

--- a/gsl.sh
+++ b/gsl.sh
@@ -38,5 +38,6 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 # Our environment
 setenv GSL_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(GSL_BASEDIR)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GSL_BASEDIR)/lib")
 prepend-path PATH \$::env(GSL_BASEDIR)/bin
 EoF

--- a/hepmc.sh
+++ b/hepmc.sh
@@ -35,4 +35,5 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 setenv HEPMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(HEPMC_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(HEPMC_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(HEPMC_ROOT)/lib")
 EoF

--- a/jemalloc.sh
+++ b/jemalloc.sh
@@ -33,5 +33,6 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 setenv JEMALLOC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(JEMALLOC_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(JEMALLOC_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(JEMALLOC_ROOT)/lib")
 setenv LD_PRELOAD \$::env(JEMALLOC_ROOT)/lib/libjemalloc.so
 EoF

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -70,4 +70,5 @@ setenv LHAPDF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv LHAPATH \$::env(LHAPDF_ROOT)/share/LHAPDF
 prepend-path PATH $::env(LHAPDF_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(LHAPDF_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(LHAPDF_ROOT)/lib")
 EoF

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -44,4 +44,5 @@ setenv LHAPDF5_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv LHAPATH \$::env(LHAPDF5_ROOT)/share/lhapdf
 prepend-path PATH $::env(LHAPDF5_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(LHAPDF5_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(LHAPDF5_ROOT)/lib")
 EoF

--- a/libpng.sh
+++ b/libpng.sh
@@ -38,4 +38,5 @@ module load BASE/1.0 ${ZLIB_ROOT:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
 setenv LIBPNG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(LIBPNG_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(LIBPNG_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(LIBPNG_ROOT)/lib")
 EoF

--- a/mesos-workqueue.sh
+++ b/mesos-workqueue.sh
@@ -41,5 +41,6 @@ module load BASE/1.0
 # Our environment
 setenv MESOS_WORKQUEUE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(MESOS_WORKQUEUE_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(MESOS_WORKQUEUE_ROOT)/lib")
 prepend-path PATH \$::env(MESOS_WORKQUEUE_ROOT)/bin
 EoF

--- a/mesos.sh
+++ b/mesos.sh
@@ -40,5 +40,6 @@ module load BASE/1.0
 # Our environment
 setenv MESOS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(MESOS_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(MESOS_ROOT)/lib")
 prepend-path PATH \$::env(MESOS_ROOT)/bin
 EoF

--- a/mpfr.sh
+++ b/mpfr.sh
@@ -39,4 +39,5 @@ module load BASE/1.0
 # Our environment
 setenv MPFR_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(MPFR_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(MPFR_ROOT)/lib")
 EoF

--- a/o2.sh
+++ b/o2.sh
@@ -63,4 +63,5 @@ module load BASE/1.0 FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION ${DDS_ROOT:+D
 setenv O2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(O2_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(O2_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(O2_ROOT)/lib")
 EoF

--- a/powheg.sh
+++ b/powheg.sh
@@ -41,4 +41,5 @@ setenv POWHEG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv Powheg_INSTALL_PATH \$::env(POWHEG_ROOT)/lib/Powheg
 prepend-path PATH \$::env(POWHEG_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(POWHEG_ROOT)/lib/Powheg
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(POWHEG_ROOT)/lib/Powheg")
 EoF

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -29,5 +29,6 @@ module load BASE/1.0
 # Our environment
 setenv PROTOBUF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(PROTOBUF_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PROTOBUF_ROOT)/lib")
 prepend-path PATH \$::env(PROTOBUF_ROOT)/bin
 EoF

--- a/pythia.sh
+++ b/pythia.sh
@@ -53,4 +53,5 @@ setenv PYTHIA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv PYTHIA8DATA \$::env(PYTHIA_ROOT)/share/Pythia8/xmldoc
 prepend-path PATH \$::env(PYTHIA_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib")
 EoF

--- a/pythia6.sh
+++ b/pythia6.sh
@@ -31,5 +31,6 @@ module load BASE/1.0
 # Our environment
 setenv PYTHIA6_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(PYTHIA6_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PYTHIA6_ROOT)/lib")
 EoF
 

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -72,6 +72,7 @@ module load BASE/1.0 ${PYTHON_VERSION:+Python/$PYTHON_VERSION-$PYTHON_REVISION} 
 setenv PYTHON_MODULES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(PYTHON_MODULES_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(PYTHON_MODULES_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(PYTHON_MODULES_ROOT)/lib")
 prepend-path PYTHONPATH $::env(PYTHON_MODULES_ROOT)/lib/python2.7/site-packages
 setenv SSL_CERT_FILE [exec python -c "import certifi; print certifi.where()"]
 EoF

--- a/python.sh
+++ b/python.sh
@@ -75,4 +75,5 @@ module load BASE/1.0 ${ALIEN_RUNTIME_VERSION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSI
 setenv PYTHON_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(PYTHON_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(PYTHON_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(PYTHON_ROOT)/lib")
 EoF

--- a/rivet.sh
+++ b/rivet.sh
@@ -68,4 +68,5 @@ setenv RIVET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PYTHONPATH \$::env(RIVET_ROOT)/lib/python2.7/site-packages
 prepend-path PATH \$::env(RIVET_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(RIVET_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(RIVET_ROOT)/lib")
 EoF

--- a/root.sh
+++ b/root.sh
@@ -90,5 +90,6 @@ setenv ROOT_BASEDIR \$::env(BASEDIR)/$PKGNAME
 setenv ROOTSYS \$::env(ROOT_BASEDIR)/\$::env(ROOT_RELEASE)
 prepend-path PATH \$::env(ROOTSYS)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ROOTSYS)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ROOTSYS)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/sherpa.sh
+++ b/sherpa.sh
@@ -36,5 +36,7 @@ setenv SHERPA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv SHERPA_INSTALL_PATH \$::env(SHERPA_ROOT)/lib/SHERPA
 prepend-path PATH \$::env(SHERPA_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(SHERPA_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SHERPA_ROOT)/lib")
 prepend-path LD_LIBRARY_PATH \$::env(SHERPA_ROOT)/lib/SHERPA-MC
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SHERPA_ROOT)/lib/SHERPA-MC")
 EoF

--- a/sodium.sh
+++ b/sodium.sh
@@ -31,4 +31,5 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 # Our environment
 setenv SODIUM_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(SODIUM_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(SODIUM_ROOT)/lib")
 EoF

--- a/template-recipe.sh
+++ b/template-recipe.sh
@@ -32,4 +32,5 @@ module load BASE/1.0
 setenv MYGENERATOR_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(MYGENERATOR_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(MYGENERATOR_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(MYGENERATOR_ROOT)/lib")
 EoF

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -75,4 +75,5 @@ setenv THEPEG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv ThePEG_INSTALL_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
 prepend-path PATH \$::env(THEPEG_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(THEPEG_ROOT)/lib/ThePEG
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(THEPEG_ROOT)/lib/ThePEG")
 EoF

--- a/vgm.sh
+++ b/vgm.sh
@@ -32,4 +32,5 @@ module load BASE/1.0 GEANT4/$GEANT4_VERSION-$GEANT4_REVISION ROOT/$ROOT_VERSION-
 # Our environment
 setenv VGM_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(VGM_ROOT)/lib64
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(VGM_ROOT)/lib64")
 EoF

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -45,4 +45,5 @@ module load BASE/1.0 ${BOOST_ROOT:+boost/$BOOST_VERSION-$BOOST_REVISION}
 # Our environment
 setenv YAMLCPP \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(YAMLCPP)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(YAMLCPP)/lib")
 EoF

--- a/yoda.sh
+++ b/yoda.sh
@@ -34,6 +34,7 @@ module load BASE/1.0 boost/$BOOST_VERSION-$BOOST_REVISION ${PYTHON_VERSION:+Pyth
 setenv YODA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(YODA_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(YODA_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(YODA_ROOT)/lib")
 set pythonpath [exec yoda-config --pythonpath]
 prepend-path PYTHONPATH \$pythonpath
 EoF

--- a/zeromq.sh
+++ b/zeromq.sh
@@ -38,4 +38,5 @@ module load BASE/1.0 ${SODIUM_ROOT:+sodium/$SODIUM_VERSION-$SODIUM_REVISION} ${G
 # Our environment
 setenv ZEROMQ_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(ZEROMQ_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ZEROMQ_ROOT)/lib")
 EoF

--- a/zlib.sh
+++ b/zlib.sh
@@ -45,4 +45,5 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
 prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
 EoF


### PR DESCRIPTION
DYLD_LIBRARY_PATH is needed in addition (or in place of) LD_LIBRARY_PATH in some
cases. The solution is not optimal (OSX-compiled software should not need at all
any (DY)LD_LIBRARY_PATH) but it provides an immediate fix for OSX users which
still require SIP disabled.