### PR TITLE
Add missing c++11 support in debug defaults

### DIFF
--- a/defaults-debug.sh
+++ b/defaults-debug.sh
@@ -1,7 +1,7 @@
 package: defaults-debug
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O0"
+  CXXFLAGS: "-fPIC -g -O0 -std=c++11"
   CFLAGS: "-fPIC -g -O0"
   CMAKE_BUILD_TYPE: "DEBUG"
 ---


### PR DESCRIPTION


<!---
@huboard:{"order":0.48876953125,"milestone_order":369,"custom_state":""}
-->
