### PR TITLE
Disable shadow password support in root

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -53,6 +53,7 @@ cmake $SOURCEDIR                                                \
       -Dpythia6_nolink=ON                                       \
       -Droofit=ON                                               \
       -Dsoversion=ON                                            \
+      -Dshadowpw=OFF                                            \
       -Dvdt=ON
 
 # Check if essential features are enabled


### PR DESCRIPTION
this fixes a build problem on centos 7

<!---
@huboard:{"order":0.138671875,"milestone_order":370,"custom_state":""}
-->
