### PR TITLE
Do not compile dijet when fastjet is disabled

### DIFF
--- a/powheg.sh
+++ b/powheg.sh
@@ -15,7 +15,7 @@ install -d ${INSTALLROOT}/bin
 
 export LIBRARY_PATH="$LD_LIBRARY_PATH"
 
-PROCESSES="dijet hvq W Z"
+PROCESSES="${FASTJET_VERSION:+dijet }hvq W Z"
 for proc in ${PROCESSES}; do
     mkdir ${proc}/{obj,obj-gfortran}
     make -C ${proc}


### PR DESCRIPTION
Dear all,
this patch avoids a crash in the compilation of POWHEG when fastjet is disabled.
Can you please push it?

Thanks in advance,
best regards,
Diego