### PR TITLE
Do not use zeromq on linux

### DIFF
--- a/zeromq.sh
+++ b/zeromq.sh
@@ -5,13 +5,13 @@ tag: master
 requires:
   - sodium
   - "GCC-Toolchain:(?!osx)"
-prefer_system: (?!slc5)
+prefer_system: osx.*
 prefer_system_check: |
   printf "#include \"zmq.h\"\n" | gcc -I$(brew --prefix zeromq)/include -xc++ - -c -M 2>&1
 ---
 #!/bin/sh
 cd $SOURCEDIR
-./autogen.sh 
+./autogen.sh
 cd $BUILDDIR
 $SOURCEDIR/configure --prefix=$INSTALLROOT \
                      --disable-dependency-tracking \


### PR DESCRIPTION
The problem is that FairRoot does not allow for system ZeroMQ, so while
we can support it on mac (because we use brew) we have no means to find
where it is to be found on linux.

Once FairRoot properly validates and allows for ZeroMQ to come from the
system, we can drop this.