### PR TITLE
Allow system Boost / ZeroMQ in FairRoot

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -8,7 +8,7 @@ build_requires:
  - "bz2"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost.\"\n#endif\nint main(){}" | gcc -lboost_thread -L$(brew --prefix boost)/lib -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
 ---
 #!/bin/bash -e
 

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,5 +1,5 @@
 package: FairRoot
-version: master
+version: dev
 source: https://github.com/FairRootGroup/FairRoot
 tag: master
 requires:

--- a/zeromq.sh
+++ b/zeromq.sh
@@ -5,7 +5,7 @@ tag: master
 requires:
   - sodium
   - "GCC-Toolchain:(?!osx)"
-prefer_system: osx.*
+prefer_system: (?!slc5.*)
 prefer_system_check: |
   printf "#include \"zmq.h\"\n" | gcc -I$(brew --prefix zeromq)/include -xc++ - -c -M 2>&1
 ---


### PR DESCRIPTION
FairRoot is now able to correctly pick up Boost and ZeroMQ when they
come from the system, so we now allow it. Notice this requires switching
to the dev branch of FairRoot.