### PR TITLE
"Preserve module files ..." in o2 recipe too

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -6,7 +6,9 @@ requires:
   - DDS
 source: https://github.com/AliceO2Group/AliceO2
 tag: dev
-incremental_recipe: make ${JOBS:+-j$JOBS} install
+incremental_recipe: |
+  make ${JOBS:+-j$JOBS} install
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/sh
 export ROOTSYS=$ROOT_ROOT
@@ -46,10 +48,8 @@ fi
 make ${CONTINUE_ON_ERROR+-k} ${JOBS+-j $JOBS} install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
 #%Module1.0
 proc ModulesHelp { } {
   global version
@@ -65,3 +65,4 @@ prepend-path PATH \$::env(O2_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(O2_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(O2_ROOT)/lib")
 EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
I am not sure if this is the right branch where to pull this. It solves the isssue that alienv works only after the first aliBuild. I have seen that this was already done for root, aliroot and aliphysics, probably o2 was left out just because it didn't have module files yet.