### PR TITLE
GSL recipe modifications

### DIFF
--- a/gsl.sh
+++ b/gsl.sh
@@ -8,7 +8,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"gsl/gsl_version.h\"\n# if (GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION < 116)\n#error \"Cannot use system's gsl.\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
+  printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116) || (GSL_V >= 200)\n#error \"Cannot use system's gsl.\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
 ---
 #!/bin/bash -e
 rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR

--- a/gsl.sh
+++ b/gsl.sh
@@ -8,7 +8,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116) || (GSL_V >= 200)\n#error \"Cannot use system's gsl.\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
+  printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116) || (GSL_V >= 200)\n#error \"Cannot use system's gsl.\"\n#endif\nint main(){}" | gcc $(pkg-config gsl --cflags) -xc++ - -o /dev/null
 ---
 #!/bin/bash -e
 rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR


### PR DESCRIPTION
Added requirement that system GSL must be less than version 2.0.
This fixes an error generated while building ROOT on OSX (10.10&10.11) with GSL 2.1 (the current stable version) installed.

Also changed use of `brew` to `pkg-config` to determine proper system gsl cflags.

The use of pkg-config is up for discussion; I'd like to hear why it's not being used. 

