### PR TITLE
Require system GSL version to be in range [1.16, 2.0)

### DIFF
--- a/gsl.sh
+++ b/gsl.sh
@@ -8,7 +8,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"gsl/gsl_version.h\"\n# if (GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION < 116)\n#error \"Cannot use system's gsl.\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
+  printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116) || (GSL_V >= 200)\n#error \"Cannot use system's gsl.\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
 ---
 #!/bin/bash -e
 rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR


### PR DESCRIPTION
The current stable version of GSL is 2.1. With this installed on my
system (OSX 10.10), ROOT does not compile due to incompatible GSL headers.

This change adds the extra requirement that system GSL is less than v2.0 when preferring system packages.
