### PR TITLE
Add direct dependency on libpng / freetype in python-modules

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -2,6 +2,8 @@ package: Python-modules
 version: "1.0"
 requires:
   - Python
+  - FreeType
+  - libpng
 env:
   SSL_CERT_FILE: "$(export PYTHONPATH=$PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH; export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print certifi.where()\")"
 prepend_path:


### PR DESCRIPTION
This is needed because the indirect dependency on python gets dropped
when python comes from the system.