### PR TITLE
Fix autotools emacs and termcap problem

### DIFF
--- a/autotools.sh
+++ b/autotools.sh
@@ -7,11 +7,14 @@ prefer_system_check: |
   PATH=$PATH:$(brew --prefix gettext || true)/bin && which autoconf && which m4 && which automake && which makeinfo && which aclocal && which pkg-config && which autopoint && which libtool
 prepend_path:
   PKG_CONFIG_PATH: $(pkg-config --debug 2>&1 | grep 'Scanning directory' | sed -e "s/.*'\(.*\)'/\1/" | xargs echo | sed -e 's/ /:/g')
+build_requires:
+ - termcap
 ---
 #!/bin/bash -e
 
 unset CXXFLAGS
 unset CFLAGS
+export EMACS=no
 
 echo "Building ALICE autotools. To avoid this install autoconf, automake, autopoint, texinfo, pkg-config."
 

--- a/termcap.sh
+++ b/termcap.sh
@@ -1,0 +1,8 @@
+package: termcap
+version: 1.0
+system_requirement_missing: "Please install the ncurses development package on your system (usually ncurses-devel or libncurses-dev)"
+system_requirement: ".*"
+system_requirement_check: |
+  printf "#include <termcap.h>\n" | gcc -xc++ - -c -o /dev/null
+---
+


### PR DESCRIPTION
Checks if termcap is available on the system and compiles autotools with emacs disabled.
Prevents autotools recipe from hanging when checking emacs or failing when trying to compile .elc files.