### PR TITLE
Make the list of boost libraries consistent

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -33,8 +33,6 @@ b2 -q \
    --prefix=$INSTALLROOT \
    --build-dir=build-boost \
    --disable-icu \
-   --without-atomic \
-   --without-chrono \
    --without-container \
    --without-context \
    --without-coroutine \


### PR DESCRIPTION
FairRoot reqires now also boost chrono and atomic to enable building of
FairMQ, which is needed for O2