### PR TITLE
Add coverage support

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -11,11 +11,17 @@ incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+  [[ $CMAKE_BUILD_TYPE == COVERAGE ]] && mkdir -p "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/" && rsync -acv --filter='+ */' --filter='+ *.cpp' --filter='+ *.cc' --filter='+ *.h' --filter='+ *.gcno' --filter='- *' "$BUILDDIR/" "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"
 ---
 #!/bin/bash -e
 # Picking up ROOT from the system when our is disabled
 if [ "X$ROOT_ROOT" = X ]; then
   ROOT_ROOT="$(root-config --prefix)"
+fi
+
+# Uses the same setup as AliRoot
+if [[ $CMAKE_BUILD_TYPE == COVERAGE ]]; then
+  source $ALIROOT_ROOT/etc/gcov-setup.sh
 fi
 
 cmake "$SOURCEDIR"                                                 \
@@ -39,6 +45,10 @@ else
     ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
   fi
 fi
+
+[[ $CMAKE_BUILD_TYPE == COVERAGE ]]                                                       \
+  && mkdir -p "$WORK_DIR/${ARCHITECTURE}/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"  \
+  && rsync -acv --filter='+ */' --filter='+ *.c' --filter='+ *.cxx' --filter='+ *.cpp' --filter='+ *.cc' --filter='+ *.hpp' --filter='+ *.h' --filter='+ *.gcno' --filter='- *' "$BUILDDIR/" "$WORK_DIR/${ARCHITECTURE}/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"
 
 # Modulefile
 mkdir -p etc/modulefiles

--- a/aliroot-test.sh
+++ b/aliroot-test.sh
@@ -12,6 +12,11 @@ export ALICE_ROOT=$ALIROOT_ROOT
 echo "`date +%s`:aliroot-test: $x STARTED"
 WORKSPACE=${WORKSPACE:-$BUILDDIR}
 
+# Uses the same setup as AliRoot
+if [[ $CMAKE_BUILD_TYPE == COVERAGE ]]; then
+  source $ALIROOT_ROOT/etc/gcov-setup.sh
+fi
+
 # Despite the fact we shouldn't rely on external variables, here we do to
 # control from the outside (i.e. jenkins) which tests to run.
 #

--- a/defaults-coverage.sh
+++ b/defaults-coverage.sh
@@ -1,9 +1,9 @@
 package: defaults-coverage
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O2"
+  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
   CFLAGS: "-fPIC -g -O2"
-  CMAKE_BUILD_TYPE: Coverage
+  CMAKE_BUILD_TYPE: COVERAGE
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
This should allow us to get code coverage reports by doing:

    git clone http://git.cern.ch/pub/AliRoot
    git clone http://git.cern.ch/pub/AliPhysics
    aliBuild --defaults coverage
    lcov --capture --directory sw/osx_x86-64/profile-data --output-file coverage.info
    genhtml coverage.info --output-directory out

The generated report can be opened at out/index.html