### PR TITLE
Add support for detector algorithms in AliRoot

### DIFF
--- a/daq.sh
+++ b/daq.sh
@@ -1,0 +1,12 @@
+package: DAQ
+version: v1
+prefer_system: slc6.*
+prefer_system_check: |
+  ! rpm -q date amore daqDA-lib ACT
+---
+#!/bin/bash -e
+# This is a dummy recipe used to track DAQ dependencies installed via RPMs.
+# AliRoot depends on it and will be rebuilt if this package's version changes.
+# For DAQ use: prefer_system_check returns 1 in order to force the creation of
+# this dummy package. For all the other use cases: prefer_system_check returns 0
+# and this dependency will be silently ignored.

--- a/defaults-daq.sh
+++ b/defaults-daq.sh
@@ -1,0 +1,17 @@
+package: defaults-daq
+version: v1
+env:
+  CXXFLAGS: "-fPIC -g -O2 -std=c++98"
+  CFLAGS: "-fPIC -g -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+  ALICE_DAQ: "1"
+  AMORE_CONFIG: /opt/amore/bin/amore-config
+  DATE_CONFIG: /opt/date/.commonScripts/date-config
+  DATE_ENV: /date/setup.sh
+  DAQ_DIM: /opt/dim
+  DAQ_DALIB: /opt/daqDA-lib
+---
+#!/bin/bash -e
+for PKG in date amore daqDA-lib ACT; do
+  yum info $PKG
+done

--- a/root.sh
+++ b/root.sh
@@ -2,13 +2,23 @@ package: ROOT
 version: "%(tag_basename)s-alice%(defaults_upper)s"
 tag: alice/v5-34-30
 source: https://github.com/alisw/root
-requires: 
+requires:
   - AliEn-Runtime:(?!.*ppc64)
   - GSL
   - opengl:(?!osx)
+build_requires:
+  - CMake
 env:
   ROOTSYS: "$ROOT_ROOT"
 incremental_recipe: |
+  if [[ $ALICE_DAQ ]]; then
+    export ROOTSYS=$BUILDDIR && make ${JOBS+-j$JOBS} && make static
+    for S in montecarlo/vmc tree/treeplayer io/xmlparser math/minuit2 sql/mysql; do
+      mkdir -p $INSTALLROOT/$S/src
+      cp -v $S/src/*.o $INSTALLROOT/$S/src/
+    done
+    export ROOTSYS=$INSTALLROOT
+  fi
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   cd $INSTALLROOT/test
@@ -33,46 +43,77 @@ case $ARCHITECTURE in
   ;;
 esac
 
-cmake $SOURCEDIR                                                \
-      -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                      \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                       \
-      ${ALIEN_RUNTIME_ROOT:+-DALIEN_DIR=$ALIEN_RUNTIME_ROOT}    \
-      ${ALIEN_RUNTIME_ROOT:+-DMONALISA_DIR=$ALIEN_RUNTIME_ROOT} \
-      ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$ALIEN_RUNTIME_ROOT}     \
-      -Dhttp=ON                                                 \
-      ${CXX11:+-Dcxx11=ON}                                      \
-      -Dbuiltin_freetype=ON                                     \
-      -Dbuiltin_pcre=ON                                         \
-      ${ENABLE_COCOA:+-Dcocoa=ON}                               \
-      -DCMAKE_CXX_COMPILER=$COMPILER_CXX                        \
-      -DCMAKE_C_COMPILER=$COMPILER_CC                           \
-      -DCMAKE_LINKER=$COMPILER_LD                               \
-      ${OPENSSL_ROOT:+-DOPENSSL_ROOT=$ALIEN_RUNTIME_ROOT}       \
-      ${SYS_OPENSSL_ROOT:+-DOPENSSL_ROOT=$SYS_OPENSSL_ROOT}     \
-      ${LIBXML2_ROOT:+-DLIBXML2_ROOT=$ALIEN_RUNTIME_ROOT}       \
-      ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                          \
-      -Dminuit2=ON                                              \
-      -Dpythia6_nolink=ON                                       \
-      -Droofit=ON                                               \
-      -Dsoversion=ON                                            \
-      -Dshadowpw=OFF                                            \
-      -Dvdt=ON
+if [[ $ALICE_DAQ ]]; then
+  # DAQ requires static ROOT, only supported by ./configure (not CMake).
+  export ROOTSYS=$BUILDDIR
+  $SOURCEDIR/configure                  \
+    --with-pythia6-uscore=SINGLE        \
+    --enable-minuit2                    \
+    --enable-roofit                     \
+    --enable-soversion                  \
+    --enable-builtin-freetype           \
+    --enable-builtin-pcre               \
+    --enable-mathmore                   \
+    --with-f77=gfortran                 \
+    --with-cc=$COMPILER_CC              \
+    --with-cxx=$COMPILER_CXX            \
+    --with-ld=$COMPILER_LD              \
+    ${CXXFLAGS:+--cxxflags="$CXXFLAGS"} \
+    --disable-shadowpw                  \
+    --disable-astiff                    \
+    --disable-globus                    \
+    --enable-mysql
+  FEATURES="builtin_freetype builtin_pcre mathmore minuit2 pythia6 roofit
+            soversion ${CXX11:+cxx11} mysql xml"
+else
+  # Normal ROOT build.
+  cmake $SOURCEDIR                                                \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                      \
+        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                       \
+        ${ALIEN_RUNTIME_ROOT:+-DALIEN_DIR=$ALIEN_RUNTIME_ROOT}    \
+        ${ALIEN_RUNTIME_ROOT:+-DMONALISA_DIR=$ALIEN_RUNTIME_ROOT} \
+        ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$ALIEN_RUNTIME_ROOT}     \
+        ${CXX11:+-Dcxx11=ON}                                      \
+        -Dbuiltin_freetype=ON                                     \
+        -Dbuiltin_pcre=ON                                         \
+        ${ENABLE_COCOA:+-Dcocoa=ON}                               \
+        -DCMAKE_CXX_COMPILER=$COMPILER_CXX                        \
+        -DCMAKE_C_COMPILER=$COMPILER_CC                           \
+        -DCMAKE_LINKER=$COMPILER_LD                               \
+        ${OPENSSL_ROOT:+-DOPENSSL_ROOT=$ALIEN_RUNTIME_ROOT}       \
+        ${SYS_OPENSSL_ROOT:+-DOPENSSL_ROOT=$SYS_OPENSSL_ROOT}     \
+        ${LIBXML2_ROOT:+-DLIBXML2_ROOT=$ALIEN_RUNTIME_ROOT}       \
+        ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                          \
+        -Dminuit2=ON                                              \
+        -Dpythia6_nolink=ON                                       \
+        -Droofit=ON                                               \
+        -Dsoversion=ON                                            \
+        -Dshadowpw=OFF                                            \
+        -Dvdt=ON
+  FEATURES="builtin_freetype builtin_pcre mathmore xml ssl opengl minuit2
+            pythia6 roofit soversion vdt ${CXX11:+cxx11} ${XROOTD_ROOT:+xrootd}
+            ${ALIEN_RUNTIME_ROOT:+alien monalisa}"
+fi
 
-# Check if essential features are enabled
+# Check if all required features are enabled
 bin/root-config --features
-for FEATURE in http builtin_freetype builtin_pcre mathmore xml \
-               ssl opengl minuit2 pythia6 roofit soversion vdt \
-               ${CXX11:+cxx11} ${XROOTD_ROOT:+xrootd}          \
-               ${ALIEN_RUNTIME_ROOT:+alien monalisa}
-do
+for FEATURE in $FEATURES; do
   bin/root-config --has-$FEATURE | grep -q yes
 done
 
+if [[ $ALICE_DAQ ]]; then
+  make ${JOBS+-j$JOBS}
+  make static
+  # *.o files from these modules need to be copied to the install directory
+  # because AliRoot static build uses them directly
+  for S in montecarlo/vmc tree/treeplayer io/xmlparser math/minuit2 sql/mysql; do
+    mkdir -p $INSTALLROOT/$S/src
+    cp -v $S/src/*.o $INSTALLROOT/$S/src/
+  done
+  export ROOTSYS=$INSTALLROOT
+fi
 make ${JOBS+-j$JOBS} install
-pushd $INSTALLROOT/test
-  # Compile ROOT tests
-  env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH make ${JOBS+-j$JOBS}
-popd
+[[ -d $INSTALLROOT/test ]] && ( cd $INSTALLROOT/test && env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH make ${JOBS+-j$JOBS} )
 
 # Modulefile
 mkdir -p etc/modulefiles


### PR DESCRIPTION
* A new default (daq) sets some environment variables required for DAQ software.
* Using `--defaults daq` ROOT will be built statically (using `configure`
  instead of CMake, since the latter does not support static builds).
* AliRoot also produces RPMs for the detector algorithms if `--defaults daq`.