### PR TITLE
Fix AliRoot build when not using coverage

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -15,8 +15,8 @@ tag: master
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   rsync -a $SOURCEDIR/test/ $INSTALLROOT/test
-  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   [[ $CMAKE_BUILD_TYPE == COVERAGE ]] && mkdir -p "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$PKGVERSION-$PKGREVISION/" && rsync -acv --filter='+ */' --filter='+ *.cpp' --filter='+ *.cc' --filter='+ *.h' --filter='+ *.gcno' --filter='- *' "$BUILDDIR/" "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$PKGVERSION-$PKGREVISION/"
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
Shell `[[ ... ]] && ...` conditions do not make the script exit if `set -e`, however if `[[ ... ]]` fails and it is the last command of a given script, the script still returns nonzero. We simply make sure that the test coverage condition is not the last one in the recipe.