### PR TITLE
Use tagged ROOT and GCC-Toolchain

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -1,7 +1,7 @@
 package: GCC-Toolchain
 version: "%(tag_basename)s"
 source: https://github.com/alisw/gcc-toolchain
-tag: alice/v4.9.3
+tag: v4.9.3-alice2
 prepend_path:
   "LD_LIBRARY_PATH": "$GCC_TOOLCHAIN_ROOT/lib64"
   "DYLD_LIBRARY_PATH": "$GCC_TOOLCHAIN_ROOT/lib64"

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s-alice%(defaults_upper)s"
-tag: alice/v5-34-30
+tag: v5-34-30-alice5
 source: https://github.com/alisw/root
 requires:
   - AliEn-Runtime:(?!.*ppc64)


### PR DESCRIPTION
This is to avoid unexpected rebuilds on user machines when alidist is not updated.