### PR TITLE
Add support for mesos-dds

### DIFF
--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -1,0 +1,39 @@
+package: cpprestsdk
+version: master
+source: https://github.com/Microsoft/cpprestsdk
+requires:
+- boost
+build_requires:
+- CMake
+tag: master
+---
+#!/bin/sh
+
+case $ARCHITECTURE in
+  osx*) BOOST_ROOT=$(brew --prefix boost) ;;
+esac
+
+cmake "$SOURCEDIR/Release"                      \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
+      -DCMAKE_BUILD_TYPE=Debug
+
+make ${JOBS:+-j $JOBS}
+make install
+
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv CPPRESTSDK_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(CPPRESTSDK_ROOT)/lib
+EoF

--- a/mesos-dds.sh
+++ b/mesos-dds.sh
@@ -1,0 +1,32 @@
+package: mesos-dds
+version: master
+source: https://github.com/alisw/mesos-dds
+requires:
+- mesos
+- protobuf
+- boost
+- glog
+- cpprestsdk
+- DDS
+build_requires:
+- CMake
+tag: master
+---
+#!/bin/sh
+
+case $ARCHITECTURE in
+  osx*) BOOST_ROOT=$(brew --prefix boost) ;;
+esac
+
+cmake "$SOURCEDIR"                               \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT        \
+      -DPROTOBUF_ROOT=${PROTOBUF_ROOT}           \
+      -DMESOS_ROOT=${MESOS_ROOT}                 \
+      ${BOOST_ROOT:+-DBOOST_ROOT=${BOOST_ROOT}}  \
+      -DGLOG_ROOT=${GLOG_ROOT}                   \
+      -DCPPRESTSDK_ROOT=${CPPRESTSDK_ROOT}       \
+      -DDDS_ROOT=${DDS_ROOT}
+
+make ${JOBS:+-j $JOBS}
+make install
+


### PR DESCRIPTION
This adds the mesos-dds recipe which also depends on the Microsoft C++ REST SDK (Casablanca).