### PR TITLE
Fix ROOT package name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,9 +74,8 @@ def buildAny(architecture) {
       done
 
       rm -f $WORKAREA/$WORKAREA_INDEX/current_slave
-      if [ ! "X$BUILDERR" = X ]; then
-        exit $BUILDERR
-      fi
+      [[ "$BUILDERR" != '' ]] && exit $BUILDERR
+      exit 0
     '''
   return { -> node("${architecture}-large") {
                 dir ("alidist") { checkout scm }

--- a/root.sh
+++ b/root.sh
@@ -1,5 +1,5 @@
 package: ROOT
-version: "%(tag_basename)s-alice%(defaults_upper)s"
+version: "%(tag_basename)s%(defaults_upper)s"
 tag: v5-34-30-alice5
 source: https://github.com/alisw/root
 requires:


### PR DESCRIPTION
This prevents packages from being called with `alice` appearing twice such as in `v5-34-30-alice5-alice-1`. With this patch, the next built package will be called `v5-34-30-alice5-1`.