### PR TITLE
Move to CMake 3.5.2

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -1,12 +1,12 @@
 package: CMake
 version: "%(tag_basename)s"
-tag: v2.8.12.2
+tag: v3.5.2
 source: https://github.com/Kitware/CMake
 build_requires:
  - "GCC-Toolchain:(?!osx)"
 prefer_system: .*
 prefer_system_check: |
-  which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-1]*|2.[0-7].*|2.8.[0-9]|2.8.1[0-1]) exit 1 ;; esac
+  which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-3].*|3.4.[0-2]) exit 1 ;; esac
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
ROOT v6.6.X now requires at least CMake 3.4.3.