### PR TITLE
Use defaults to specify O2 peculiarities

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -1,0 +1,21 @@
+package: defaults-o2
+version: v1
+env:
+  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CFLAGS: "-fPIC -g -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+disable:
+  - AliEn-Runtime
+  - AliRoot
+overrides:
+  ROOT:
+    version: "%(tag_basename)s"
+    tag: "v6-06-04"
+  CMake:
+    tag: "v3.5.2"
+    prefer_system_check: |
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-3].*|3.4.[0-2]) exit 1 ;; esac
+---
+# This file is included in any build recipe and it's only used to set
+# environment variables. Which file to actually include can be defined by the
+# "--defaults" option of alibuild.


### PR DESCRIPTION
This disables AliEn-Runtime and moves to ROOT 6.

This requires alisw/alibuild#352 .