### PR TITLE
Bump Rivet to v2.5.1

### DIFF
--- a/gsl.sh
+++ b/gsl.sh
@@ -36,8 +36,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
-setenv GSL_BASEDIR \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$::env(GSL_BASEDIR)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GSL_BASEDIR)/lib")
-prepend-path PATH \$::env(GSL_BASEDIR)/bin
+setenv GSL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(GSL_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GSL_ROOT)/lib")
+prepend-path PATH \$::env(GSL_ROOT)/bin
 EoF

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: 2.4.3-alice1
+tag: 2.5.1-alice1
 source: https://github.com/alisw/rivet
 requires:
   - GSL

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,5 +1,5 @@
 package: YODA
-version: "v1.6.1"
+version: "v1.6.3"
 source: https://github.com/alisw/yoda
 requires:
   - boost


### PR DESCRIPTION
- bump YODA to 1.6.3
- fix gsl to use GSL_ROOT instead of GSL_BASEDIR

@ktf, @dberzano: the remaining use of GSL_BASEDIR caused troubles for compilation of Rivet plugins, do you see any reason not to switch to GSL_ROOT?

Cheers,
   Jochen