### PR TITLE
Fix curl check on all platforms

### DIFF
--- a/curl.sh
+++ b/curl.sh
@@ -2,6 +2,6 @@ package: curl
 version: "1.0"
 system_requirement_missing: "Please install Curl."
 system_requirement: ".*"
-system_requirement_check: "curl --help > /dev/null"
+system_requirement_check: "curl --version > /dev/null || [ $? -ne 127 ]"
 ---
 


### PR DESCRIPTION
Notably, `curl --help|--version` returns 2 on SLC5. Here we check whether the
shell returns 127 (command not found) explicitly.