### PR TITLE
Add automation for coverage builds

### DIFF
--- a/aliroot-coverage.sh
+++ b/aliroot-coverage.sh
@@ -2,6 +2,7 @@ package: AliRoot-coverage
 version: "%(year)s%(month)s%(day)s%(defaults_upper)s"
 force_rebuild: 1
 requires:
+  - lcov
   - AliRoot-test
 ---
 #!/bin/sh
@@ -10,8 +11,10 @@ if [[ $CMAKE_BUILD_TYPE == COVERAGE ]]; then
   source $ALIROOT_ROOT/etc/gcov-setup.sh
 fi
 
+mkdir -p $WORK_DIR/$ARCHITECTURE/profile-web
 # Run coverage analysis directly from aliBuild
 if [[ $CMAKE_BUILD_TYPE == COVERAGE ]]; then
-  lcov --capture --directory $WORKDIR/sw/$ARCHITECTURE/profile-data --output-file coverage.info
-  genhtml coverage.info --output-directory out
+  lcov --capture --directory $WORK_DIR/$ARCHITECTURE/profile-data --output-file $WORK_DIR/$ARCHITECTURE/profile-web/coverage.info
+  genhtml $WORK_DIR/$ARCHITECTURE/profile-web/coverage.info --output-directory $WORK_DIR/$ARCHITECTURE/profile-web/out
+  pushd $WORK_DIR/$ARCHITECTURE/profile-web/out ; zip -r ${WORKSPACE:-..}/coverage-`date +%Y%m%d`-$BUILD_NUMBER.zip . ; popd
 fi

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -32,7 +32,7 @@ if [[ $CMAKE_BUILD_TYPE == COVERAGE ]]; then
 mkdir -p $INSTALLROOT/etc
 cat << EOF > $INSTALLROOT/etc/gcov-setup.sh
 export GCOV_PREFIX=${GCOV_PREFIX:-"$WORK_DIR/${ARCHITECTURE}/profile-data/AliRoot/$PKGVERSION-$PKGREVISION"}
-export GCOV_PREFIX_STRIP=$(($(echo $INSTALLROOT | sed -e 's|/$||;s|^/||;s|//*|/|g;s|[^/]||g' | wc -c | sed -e 's/[^0-9]*//') - 1))
+export GCOV_PREFIX_STRIP=$(echo $INSTALLROOT | sed -e 's|/$||;s|^/||;s|//*|/|g;s|[^/]||g' | wc -c | sed -e 's/[^0-9]*//')
 EOF
 source $INSTALLROOT/etc/gcov-setup.sh
 fi

--- a/lcov.sh
+++ b/lcov.sh
@@ -7,3 +7,23 @@ tag: v1.11
 rsync -av $SOURCEDIR/ $BUILDDIR/
 make ${JOBS+-j $JOBS}
 make PREFIX=$INSTALLROOT BIN_DIR=$INSTALLROOT/bin install
+
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv LCOV_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(LCOV_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LCOV_ROOT)/lib")
+EoF
+


### PR DESCRIPTION
- Correct GCOV_PREFIX_STRIP. Given we have to use development packages
  for AliRoot and AliPhysics in any case, we revert back the changes to
  those which work in that case.
- Add lcov as a dependency.
- Fix various typos