### PR TITLE
xalienfs - Add brew --prefix openssl flags

### DIFF
--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -20,8 +20,11 @@ CXXFLAGS="$CXXFLAGS -I$XROOTD_ROOT/include -I$XROOTD_ROOT/include/xrootd/private
           ${UUID_ROOT:+-I$UUID_ROOT/include -L$UUID_ROOT/lib} "
 case $ARCHITECTURE in
   osx*)
-    CXXFLAGS="$CXXFLAGS -I$(perl -MConfig -e 'print $Config{archlib}')/CORE"
-  ;;
+      CXXFLAGS="$CXXFLAGS -I$(perl -MConfig -e 'print $Config{archlib}')/CORE"
+      # add openssl keg
+      OPENSSLDIR=`brew --prefix openssl`
+      CXXFLAGS="-I${OPENSSLDIR}/include -L${OPENSSLDIR}/lib $CXXFLAGS"
+      ;;
 esac
 export CXXFLAGS
 ./configure --prefix=$INSTALLROOT                \


### PR DESCRIPTION
Homebrew refuses to link openssl, even with the --force flag. Thus, the full preprocessor and linker flags have to be provided as suggested by homebrew itself. This PR adds the openssl flags for xalienfs which otherwise fails to compile for me.
(sierra, clang 8.0, brew 1.0.6)