### PR TITLE
Base aurora patches on top of 0.15.0

### DIFF
--- a/aurora.sh
+++ b/aurora.sh
@@ -1,7 +1,7 @@
 package: aurora
 version: alice1
 source: https://github.com/alisw/aurora
-tag: alice/cookie-auth
+tag: alice/0.15.0
 ---
 #!/bin/bash -ex
 rsync -a $SOURCEDIR/ ./


### PR DESCRIPTION
Using a later version might create problems since they moved to binary
Thrift for the API.