### PR TITLE
Ib/v5 08/dev

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -8,7 +8,7 @@ build_requires:
  - "bz2"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -I$BOOST_ROOT/include -xc++ - -o /dev/null
 ---
 #!/bin/bash -e
 

--- a/crmc.sh
+++ b/crmc.sh
@@ -16,9 +16,22 @@ case $ARCHITECTURE in
   ;;
 esac
 
+# In case root is available determine std
+std=
+if [ "x$(which root-config)" != "x" ]; then
+  if [ $(root-config --has-cxx11) == "yes" ] ; then
+    std="c++11"
+  fi
+  if [ $(root-config --has-cxx14) == "yes" ] ; then
+    std="c++14"
+  fi
+fi
+
 cmake $SOURCEDIR                               \
       ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}  \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+      ${std:+-DCMAKE_CXX_FLAGS="$(printf "\-std=%s" "$std")"} \
+      ${FASTJET_ROOT:+-DFastjet_DIR=$FASTJET_ROOT}
 make ${JOBS+-j $JOBS} all
 make install
 

--- a/jewel.sh
+++ b/jewel.sh
@@ -1,5 +1,5 @@
 package: JEWEL
-version: "%(tag_basename)s%(defaults_upper)s"
+version: "%(tag_basename)s"
 tag: alice/v2.0.2
 source: https://github.com/alisw/jewel.git
 requires:


### PR DESCRIPTION
While installing aligenerators I came across several issues:
- I provided BOOST as external installation in my defaults file, still aliBuild wanted to build it and ignored my existing BOOST_ROOT -> test adapted to allow for external BOOST_ROOT
- CRMC: Compiler error in ROOT interface as root was compiled under c++14, CRMC however under c++98. Module adapted in the way that it handles both c++14 and c++11, depending on which standard was used in the root installation. This part is only handled if root-config is found. Also the interface to fastjet is fixed.
- JEWEL: tag from defaults was included in the filenames of the jewel files in install, making the install fail because the files it was looking for do not exist. It can probably be fixed in a more elegant way by the experts, but for the moment it is necessary to remove the defaults tag from the version tag.
