### PR TITLE
Add ROOT 6 default for aliBuild >= 1.4.0

### DIFF
--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -5,12 +5,25 @@ env:
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 overrides:
-  ROOT:
-    version: "%(tag_basename)s"
-    tag: "v6-06-04"
+  ROOT@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
+    version: "v6-09-01-alice1"
+    tag: "2196305bbc693a9085551df6a8d4a0fada96b696"
+    source: https://github.com/root-mirror/root
+    requires:
+      - AliEn-Runtime:(?!.*ppc64)
+      - GSL
+      - opengl:(?!osx)
+      - Xdevel:(?!osx)
+      - FreeType:(?!osx)
+      - Python-modules
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
+  CMake:
+    tag: v3.6.2
+  libpng@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
+  Python-modules@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
+  Python@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
This default overrides recipes by picking them from upstream.