### PR TITLE
nanomsg: bump to version 1.0

### DIFF
--- a/nanomsg.sh
+++ b/nanomsg.sh
@@ -1,13 +1,33 @@
 package: nanomsg
-version: v0.8
+version: v1.0.0
 source: https://github.com/nanomsg/nanomsg
-tag: 0.8-beta
+tag: 1.0.0
 build_requires:
-  - autotools
+  - CMake
 ---
 #!/bin/sh
-rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
-./autogen.sh 
-./configure --prefix=$INSTALLROOT
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}"
 make ${JOBS+-j $JOBS}
+make test
 make install
+
+# Modulefile support
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv NANOMSG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(NANOMSG_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(NANOMSG_ROOT)/lib")
+prepend-path PATH \$::env(NANOMSG_ROOT)/bin
+EoF


### PR DESCRIPTION
This CL bumps the nanomsg version to the first production-grade
release of nanomsg: 1.0