### PR TITLE
Synchronize ROOT 6 and O2 defaults

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -8,16 +8,29 @@ disable:
   - AliEn-Runtime
   - AliRoot
 overrides:
-  ROOT:
-    version: "%(tag_basename)s"
-    tag: "v6-06-04"
+  ROOT@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
+    tag: "v6-08-02"
+    source: https://github.com/root-mirror/root
+    requires:
+      - AliEn-Runtime:(?!.*ppc64)
+      - GSL
+      - opengl:(?!osx)
+      - Xdevel:(?!osx)
+      - FreeType:(?!osx)
+      - Python-modules
+  GSL:
+    prefer_system_check: |
+      printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
   protobuf:
     version: "%(tag_basename)s"
     tag: "v3.0.2"
   CMake:
     tag: "v3.5.2"
     prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-3].*|3.4.[0-2]) exit 1 ;; esac
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-4].*|3.5.[0-1]) exit 1 ;; esac
+  libpng@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
+  Python-modules@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
+  Python@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -6,8 +6,8 @@ env:
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 overrides:
   ROOT@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
-    version: "v6-09-01-alice1"
-    tag: "2196305bbc693a9085551df6a8d4a0fada96b696"
+    version: "%(tag_basename)s"
+    tag: "v6-08-02"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)
@@ -20,7 +20,9 @@ overrides:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
   CMake:
-    tag: v3.6.2
+    tag: "v3.5.2"
+    prefer_system_check: |
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-4].*|3.5.[0-1]) exit 1 ;; esac
   libpng@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
   Python-modules@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:
   Python@969984f5f25c5c5326d6b4d4f20e72b0ffad164b:

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -12,6 +12,10 @@ requires:
   - protobuf
   - DDS
   - "GCC-Toolchain:(?!osx)"
+env:
+  VMCWORKDIR: "$FAIRROOT_ROOT/share/fairbase/examples"
+  GEOMPATH:   "$FAIRROOT_ROOT/share/fairbase/examples/common/geometry"
+  CONFIG_DIR: "$FAIRROOT_ROOT/share/fairbase/examples/common/gconfig"
 ---
 #!/bin/sh
 
@@ -71,12 +75,24 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${GEANT3_VERSION:+GEANT3/$GEANT3_VERSION-$GEANT3_REVISION} ${GEANT4_VERSION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION} ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION} ${PYTHIA6_VERSION:+Pythia6/$PYTHIA6_VERSION-$PYTHIA6_REVISION} ${PYTHIA_VERSION:+Pythia/$PYTHIA_VERSION-$PYTHIA_REVISION} ${GEANT4_VMC_VERSION:+GEANT4_VMC/$GEANT4_VMC_VERSION-$GEANT4_VMC_REVISION} ${VGM_VERSION:+vgm/$VGM_VERSION-$VGM_REVISION} ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION} ROOT/$ROOT_VERSION-$ROOT_REVISION ${ZEROMQ_VERSION:+ZeroMQ/$ZEROMQ_VERSION-$ZEROMQ_REVISION} ${DDS_ROOT:+DDS/$DDS_VERSION-$DDS_REVISION} ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+module load BASE/1.0                                                                            \\
+            ${GEANT3_VERSION:+GEANT3/$GEANT3_VERSION-$GEANT3_REVISION}                          \\
+            ${GEANT4_VMC_VERSION:+GEANT4_VMC/$GEANT4_VMC_VERSION-$GEANT4_VMC_REVISION}          \\
+            ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}                  \\
+            ${PYTHIA6_VERSION:+Pythia6/$PYTHIA6_VERSION-$PYTHIA6_REVISION}                      \\
+            ${PYTHIA_VERSION:+Pythia/$PYTHIA_VERSION-$PYTHIA_REVISION}                          \\
+            ${VGM_VERSION:+vgm/$VGM_VERSION-$VGM_REVISION}                                      \\
+            ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}                              \\
+            ROOT/$ROOT_VERSION-$ROOT_REVISION                                                   \\
+            ${ZEROMQ_VERSION:+ZeroMQ/$ZEROMQ_VERSION-$ZEROMQ_REVISION}                          \\
+            ${DDS_ROOT:+DDS/$DDS_VERSION-$DDS_REVISION}                                         \\
+            ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
 setenv FAIRROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv VMCWORKDIR \$::env(FAIRROOT_ROOT)/share/fairbase/examples
 setenv GEOMPATH \$::env(VMCWORKDIR)/common/geometry
 setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig
+prepend-path PATH \$::env(FAIRROOT_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib")
 EoF


### PR DESCRIPTION
* ROOT 6 updated to the latest stable version (v6.08.00) for `root6`, `o2` and `o2-daq`