### PR TITLE
Fix xrootd to work on SUSE

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -28,3 +28,4 @@ cmake "$SOURCEDIR" -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                \
                    -DZLIB_ROOT=$ZLIB_ROOT
 make ${JOBS:+-j$JOBS}
 make install
+ln -sf lib $INSTALLROOT/lib64


### PR DESCRIPTION
Apparently on some distributions, some of the dependencies of XRootD use
lib64, rather than lib. This should make there is no issues with that.