### PR TITLE
Add missing DDS_ROOT variable for CMake

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -49,7 +49,8 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc      \
       -DPROTOBUF_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME   \
       ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                            \
-      ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}
+      ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}  \
+      ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                           
 
 if [[ $GIT_TAG == master ]]; then
   CONTINUE_ON_ERROR=true


### PR DESCRIPTION
On CC7 (at least) not passing DDS_ROOT to CMake prevent DDS from being found and thus a number of modules to be built (e.g. QC).