### PR TITLE
Adaptions needed for ROOT6

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -11,6 +11,10 @@ overrides:
   ROOT:
     version: "%(tag_basename)s"
     tag: "v6-06-04"
+    source: https://github.com/root-mirror/root
+  GSL:
+    prefer_system_check: |
+      printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
   protobuf:
     version: "%(tag_basename)s"
     tag: "v3.0.2"


### PR DESCRIPTION
- ROOT source set to official root mirror
- GSL prefer_system_check accepts GSL versions >= 2