### PR TITLE
Declare Vc as external dependency to AliRoot

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -5,6 +5,7 @@ requires:
   - fastjet:(?!.*ppc64)
   - GEANT3
   - GEANT4_VMC
+  - Vc
 build_requires:
   - CMake
   - DAQ:slc6.*

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,16 +1,16 @@
 package: CMake
 version: "%(tag_basename)s"
-tag: v2.8.12.2
+tag: "v3.5.2"
 source: https://github.com/Kitware/CMake
 build_requires:
  - "GCC-Toolchain:(?!osx)"
 prefer_system: .*
 prefer_system_check: |
-  which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-1]*|2.[0-7].*|2.8.[0-9]|2.8.1[0-1]) exit 1 ;; esac
+  which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-4].*|3.5.[0-1]) exit 1 ;; esac
 ---
 #!/bin/bash -e
 
-echo "Building ALICE CMake. To avoid this install at least CMake 2.8.12."
+echo "Building ALICE CMake. To avoid this install at least CMake 3.5.2."
 
 cat > build-flags.cmake <<- EOF
 # Disable Java capabilities; we don't need it and on OS X might miss the

--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -22,10 +22,6 @@ overrides:
   protobuf:
     version: "%(tag_basename)s"
     tag: "v3.0.2"
-  CMake:
-    tag: "v3.5.2"
-    prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-3].*|3.4.[0-2]) exit 1 ;; esac
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -24,10 +24,6 @@ overrides:
   protobuf:
     version: "%(tag_basename)s"
     tag: "v3.0.2"
-  CMake:
-    tag: "v3.5.2"
-    prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-4].*|3.5.[0-1]) exit 1 ;; esac
   libpng:
   Python-modules:
   Python:

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -19,10 +19,6 @@ overrides:
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
-  CMake:
-    tag: "v3.5.2"
-    prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-4].*|3.5.[0-1]) exit 1 ;; esac
   libpng:
   Python-modules:
   Python:


### PR DESCRIPTION
* AliRoot supports building against external Vc
 * This mode is needed in future in order to build other dependencies against Vc