### PR TITLE
Make libxml2 dependency explicit

### DIFF
--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -16,6 +16,7 @@ overrides:
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
       - Python-modules
+      - libxml2
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -1,21 +1,43 @@
 package: libxml2
-version: v2.9.2
-source: git://git.gnome.org/libxml2
-tag: v2.9.2
-build_requires:
-  - autotools
+version: "%(tag_basename)s"
+source: https://github.com/GNOME/libxml2
+tag: v2.9.4
+requires:
   - zlib
+build_requires:
+  - "autotools"
   - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"
-prefer_system_check: which xml2-config
+prefer_system_check: |
+  printf "#include <libxml/parser.xaha>\n" | gcc -I`brew --prefix libxml2`/include/libxml2 -xc - -c -M 2>&1
 ---
 #!/bin/sh
-echo "Building ALICE libxml. To avoid this install libxml development package."
-rsync -a $SOURCEDIR/ ./
-autoreconf -i
-./configure --disable-static \
-            --prefix=$INSTALLROOT \
-            --with-zlib="${ZLIB_ROOT}" --without-python
+
+rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
+autoreconf -ivf
+
+./configure --disable-static --prefix=$INSTALLROOT --without-python --without-lzma
 
 make ${JOBS+-j $JOBS}
 make install
+rm -rf $INSTALLROOT/lib/pkgconfig
+rm -rf $INSTALLROOT/lib/*.{l,}a
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${ZLIB_ROOT:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
+# Our environment
+prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
+EoF

--- a/root.sh
+++ b/root.sh
@@ -44,6 +44,7 @@ case $ARCHITECTURE in
     COMPILER_LD=clang
     [[ ! $GSL_ROOT ]] && GSL_ROOT=`brew --prefix gsl`
     [[ ! $OPENSSL_ROOT ]] && SYS_OPENSSL_ROOT=`brew --prefix openssl`
+    [[ ! $LIBXML2_ROOT ]] && LIBXML2_ROOT=`brew --prefix libxml2`
   ;;
 esac
 
@@ -148,6 +149,7 @@ module load BASE/1.0 ${ALIEN_RUNTIME_ROOT:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-
                      ${GSL_VERSION:+GSL/$GSL_VERSION-$GSL_REVISION}                                             \\
                      ${FREETYPE_VERSION:+FreeType/$FREETYPE_VERSION-$FREETYPE_REVISION}                         \\
                      ${PYTHON_VERSION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
+                     ${LIBXML2_VERSION:+libxml2/$LIBXML2_VERSION-$LIBXML2_REVISION}                             \\
                      ${PYTHON_MODULES_VERSION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}
 # Our environment
 setenv ROOT_RELEASE \$version


### PR DESCRIPTION
We now have a ROOT6 dependency on libxml2, without actually making it explicit.
This should fix the issue.