### PR TITLE
Use $IGNORE_ERRORS to compile with -k

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -35,14 +35,9 @@ cmake "$SOURCEDIR"                                                 \
       ${GMP_ROOT:+-DGMP="$GMP_ROOT"}                               \
       -DALIROOT="$ALIROOT_ROOT"
 
-if [[ $GIT_TAG == master ]]; then
-  make -k ${JOBS+-j $JOBS} install || true
-  ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS} || true
-else
-  make ${JOBS+-j $JOBS} install
-  # ctest will succeed if no load_library tests were found
-  ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
-fi
+make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
+# ctest will succeed if no load_library tests were found
+ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
 
 [[ $CMAKE_BUILD_TYPE == COVERAGE ]]                                                       \
   && mkdir -p "$WORK_DIR/${ARCHITECTURE}/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"  \

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -52,15 +52,10 @@ cmake $SOURCEDIR                                                  \
       ${ALICE_DAQ:+-DDIMDIR=$DAQ_DIM -DODIR=linux}                \
       -DOCDB_INSTALL=PLACEHOLDER
 
-if [[ $GIT_TAG == master && ! $ALICE_DAQ ]]; then
-  make -k ${JOBS+-j $JOBS} install || true
-  ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS} || true
-else
-  make ${JOBS+-j $JOBS} install
-  # ctest will succeed if no load_library tests were found
-  ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
-  [[ $ALICE_DAQ ]] && { make daqDA-all-rpm && make ${JOBS+-j $JOBS} install; }
-fi
+make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
+# ctest will succeed if no load_library tests were found
+ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+[[ $ALICE_DAQ ]] && { make daqDA-all-rpm && make ${JOBS+-j $JOBS} install; }
 
 rsync -av $SOURCEDIR/test/ $INSTALLROOT/test
 


### PR DESCRIPTION
Now that defaults allow us to do so, let's use an environment variable to
control wether or not the build should fail on error.