### PR TITLE
ZeroMQ added version check

### DIFF
--- a/zeromq.sh
+++ b/zeromq.sh
@@ -6,7 +6,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 prefer_system: (?!slc5.*)
 prefer_system_check: |
-  printf "#include \"zmq.h\"\n" | gcc -I$(brew --prefix zeromq)/include -xc++ - -c -M 2>&1
+  printf "#include <zmq.h>\n#if(ZMQ_VERSION < 40103)\n#error \"zmq version >= 4.1.3 needed\"\n#endif\n int main(){}" | gcc -I$(brew --prefix zeromq)/include -xc++ - -c -M 2>&1
 ---
 #!/bin/sh
 cd $SOURCEDIR


### PR DESCRIPTION
Fairroot needs ZeroMQ to be at least of version 4.1.3 as witnessed from its configuration log. This patch checks the ZeroMQ version from the zmq header, following the GSL version check. This patch is necessary, because otherwise aliDoctor suggests to install a system provided ZeroMQ, does not complain about the version, FairRoot fails silently without building the FairMQ libraries (compilation goes through), and O2 fails compiling with linking errors.   

```
=== FairRoot configuration with system provided ZeroMQ 2.2 by export'ing ZEROMQ_ROOT=/usr ===
-- Looking for ZeroMQ...
-- Installed version 2.2.0 of ZeroMQ does not meet the minimum required version 4.1.3
```

```
== new aliDoctor output ==
WARNING: Package ZeroMQ cannot be picked up from the system and will be built by aliBuild.
WARNING: This is due to the fact the following script fails:
WARNING: 
WARNING: brew() { true; }; printf "#include <zmq.h>\n#if(ZMQ_VERSION < 40103)\n#error \"zmq version >= 4.1.3 needed\"\n#endif\n int main(){}" | gcc -I$(brew --prefix zeromq)/include -xc++ - -c -M 2>&1
WARNING: 
WARNING: with the following output:
WARNING: 
WARNING: ZeroMQ: <stdin>:3:2: error: #error "zmq version >= 4.1.3 needed"
WARNING: ZeroMQ: 
WARNING: 
```
