### PR TITLE
openssl: Added header check on linux

### DIFF
--- a/openssl.sh
+++ b/openssl.sh
@@ -4,7 +4,7 @@ tag: "v0.9.8_1.2.4"
 source: https://github.com/alisw/alice-openssl.git
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; else exit 0; fi
+  if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; else echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null || exit 1; fi
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Hi Dario, hi Giulio,

Aaron and Antonin reported on the task force list that the openssl system availability check is not enough on Ubuntu. In fact, there was no check at all. I added the openssl/bio.h check which is done for mac OS with the brew prefix for other OS as well. Just checked on my Ubuntu 16.04 and the aliDoctor correctly reports that openssl is present. 

Cheers,
Hans