### PR TITLE
Improve clang-tidy code checker support

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -61,6 +61,7 @@ if [[ $GIT_TAG == master ]]; then
   CONTINUE_ON_ERROR=true
 fi
 make ${CONTINUE_ON_ERROR+-k} ${JOBS+-j $JOBS} install
+
 # install the compilation database so that we can post-check the code
 cp compile_commands.json ${INSTALLROOT}
 
@@ -95,3 +96,7 @@ prepend-path LD_LIBRARY_PATH \$::env(O2_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(O2_ROOT)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+
+if [[ $ALIBUILD_O2_TESTS ]]; then
+  make test
+fi

--- a/o2.sh
+++ b/o2.sh
@@ -24,6 +24,9 @@ incremental_recipe: |
     perl -p -i -e "s|$SOURCEDIR|$DEVEL_SOURCES|" compile_commands.json
     ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
   fi
+  if [[ $ALIBUILD_O2_TESTS ]]; then
+    make test
+  fi
 valid_defaults:
   - o2
   - o2-daq

--- a/o2.sh
+++ b/o2.sh
@@ -11,6 +11,19 @@ tag: dev
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+  # install the compilation database so that we can post-check the code
+  cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}
+
+  DEVEL_SOURCES="`readlink $SOURCEDIR || echo $SOURCEDIR`"
+  # This really means we are in development mode. We need to make sure we
+  # use the real path for sources in this case. We also copy the
+  # compile_commands.json file so that IDEs can make use of it directly, this
+  # is a departure from our "no changes in sourcecode" policy, but for a good reason
+  # and in any case the file is in gitignore.
+  if [ "$DEVEL_SOURCES" != "$SOURCEDIR" ]; then
+    perl -p -i -e "s|$SOURCEDIR|$DEVEL_SOURCES|" compile_commands.json
+    ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
+  fi
 valid_defaults:
   - o2
   - o2-daq

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -22,7 +22,7 @@ cp ${O2_ROOT}/compile_commands.json .
 
 # These are checks which are currently all green, so we should
 # Now enable them.
-CHECKS="${O2_CHECKER_CHECKS:--*,modernize-*,-modernize-use-auto,-modernize-use-bool-literals,-modernize-use-using,-modernize-loop-convert,-modernize-use-bool-literals,aliceO2-member-name}"
+CHECKS="${O2_CHECKER_CHECKS:--*,modernize-*,-modernize-use-auto,-modernize-use-bool-literals,-modernize-use-using,-modernize-loop-convert,-modernize-use-bool-literals,-modernize-make-unique,aliceO2-member-name}"
 # run actual checks
 run_O2CodeChecker.py -clang-tidy-binary `which O2codecheck` ${O2_CHECKER_FIX:+-fix} -checks=$CHECKS 2>&1 | tee error-log.txt
 

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -5,6 +5,7 @@ requires:
   - o2codechecker
 build_requires:
   - CMake
+force_rebuild: 1
 version: "1.0"
 ---
 #!/bin/bash -e
@@ -19,9 +20,14 @@ cp ${O2_ROOT}/compile_commands.json .
 # - filtering out ROOT dictionary results
 # - filtering files relevant for pull request etc.
 
-
+# These are checks which are currently all green, so we should
+# Now enable them.
+CHECKS="${O2_CHECKER_CHECKS:--*,modernize-*,-modernize-use-auto,-modernize-use-bool-literals,-modernize-use-using,-modernize-loop-convert,-modernize-use-bool-literals,aliceO2-member-name}"
 # run actual checks
-run_O2CodeChecker.py -clang-tidy-binary `which O2codecheck` -checks=-*,alice*
+run_O2CodeChecker.py -clang-tidy-binary `which O2codecheck` ${O2_CHECKER_FIX:+-fix} -checks=$CHECKS 2>&1 | tee error-log.txt
 
-# exit with the return code from the checker
-exit $?
+perl -p -i -e 's/ warning:/ error:/g' error-log.txt
+
+if grep -v "/G__" error-log.txt | grep " error:" ; then
+  exit 1
+fi

--- a/o2codechecker.sh
+++ b/o2codechecker.sh
@@ -6,12 +6,15 @@ build_requires:
   - CMake
 source: https://github.com/AliceO2Group/O2CodeChecker.git
 tag: master
+incremental_recipe: |
+  make ${JOBS+-j$JOBS} install
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/bash -e
-cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT    \
-                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE   \
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \
+                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE    \
                  -DClang_DIR=$CLANG_ROOT/lib/cmake/clang \
-                 -DLLVM_DIR=$CLANG_ROOT/lib/cmake/llvm   
+                 -DLLVM_DIR=$CLANG_ROOT/lib/cmake/llvm
 make ${JOBS+-j$JOBS} install
 ctest
 


### PR DESCRIPTION
- Can specify checks via O2_CHECKER_CHECKS
- Can fix automatically checks by setting O2_CHECKER_FIX
- Default configuration is something which is currently clean
- Exit in case of errors and warnings
- Always recheck sources
- Add incremental recipe for o2codechecker.sh