### PR TITLE
Adapt to new FairRoot version

### DIFF
--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -32,6 +32,11 @@ overrides:
     tag: "v3.0.2"
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
+  CMake:
+    version: "%(tag_basename)s"
+    tag: "v3.7.2"
+    prefer_system_check: |
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-5].*) exit 1 ;; esac
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -27,6 +27,11 @@ overrides:
   libpng:
   Python-modules:
   Python:
+  CMake:
+    version: "%(tag_basename)s"
+    tag: "v3.7.2"
+    prefer_system_check: |
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-5].*) exit 1 ;; esac
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -12,6 +12,8 @@ requires:
   - protobuf
   - DDS
   - "GCC-Toolchain:(?!osx)"
+build_requires:
+  - googletest
 env:
   VMCWORKDIR: "$FAIRROOT_ROOT/share/fairbase/examples"
   GEOMPATH:   "$FAIRROOT_ROOT/share/fairbase/examples/common/geometry"
@@ -55,6 +57,7 @@ cmake $SOURCEDIR                                                 \
       ${BOOST_ROOT:+-DBOOST_INCLUDEDIR=$BOOST_ROOT/include}      \
       ${BOOST_ROOT:+-DBOOST_LIBRARYDIR=$BOOST_ROOT/lib}          \
       ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                           \
+      -DGTEST_ROOT=$GOOGLETEST_ROOT                              \
       -DPROTOBUF_INCLUDE_DIR=$PROTOBUF_ROOT/include              \
       -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc     \
       -DPROTOBUF_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME  \

--- a/googletest.sh
+++ b/googletest.sh
@@ -1,7 +1,7 @@
 package: googletest
-version: "1.7.0"
+version: "1.8.0"
 source: https://github.com/google/googletest
-tag: release-1.7.0
+tag: release-1.8.0
 build_requires:
  - "GCC-Toolchain:(?!osx)"
 ---
@@ -10,6 +10,4 @@ cmake $SOURCEDIR                           \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 make ${JOBS+-j $JOBS}
-mkdir -p $INSTALLROOT/lib
-cp *.a $INSTALLROOT/lib
-rsync -av $SOURCEDIR/include/ $INSTALLROOT/include/
+make install


### PR DESCRIPTION
- Bump CMake version for O2 related packages
- Bump googletest and add it as requirement
- Cleanup googletest recipe to use make install