### PR TITLE
Adjustment of enabled checks in o2checkcode.sh

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -22,9 +22,10 @@ cp ${O2_ROOT}/compile_commands.json .
 
 # These are checks which are currently all green, so we should
 # Now enable them.
-CHECKS="${O2_CHECKER_CHECKS:--*,modernize-*,-modernize-use-auto,-modernize-use-bool-literals,-modernize-use-using,-modernize-loop-convert,-modernize-use-bool-literals,-modernize-make-unique,aliceO2-member-name}"
+CHECKS="${O2_CHECKER_CHECKS:--*,modernize-*,-modernize-use-default,-modernize-pass-by-value,-modernize-use-auto,-modernize-use-bool-literals,-modernize-use-using,-modernize-loop-convert,-modernize-use-bool-literals,-modernize-make-unique,aliceO2-member-name}"
+
 # run actual checks
-run_O2CodeChecker.py -clang-tidy-binary `which O2codecheck` ${O2_CHECKER_FIX:+-fix} -checks=$CHECKS 2>&1 | tee error-log.txt
+run_O2CodeChecker.py -clang-tidy-binary `which O2codecheck` -header-filter=.*SOURCES.* ${O2_CHECKER_FIX:+-fix} -checks=${CHECKS} 2>&1 | tee error-log.txt
 
 perl -p -i -e 's/ warning:/ error:/g' error-log.txt
 


### PR DESCRIPTION
 * introduce header filter (which will activate "modernize-use-override" to take effect)
 * for now disable:
   -modernize-pass-by-value
   -modernize-use-default (can not be applied without causing a compile error)