### PR TITLE
Add module file generation to cmake recipe

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -30,3 +30,22 @@ $SOURCEDIR/bootstrap --prefix=$INSTALLROOT \
                      ${JOBS:+--parallel=$JOBS}
 make ${JOBS+-j $JOBS}
 make install/strip
+
+# Modulefile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
+prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
I added to module file generation to the cmake recipe, so that the version installed with alibuild can be used more easily.

Assuming that the new `dev` branch is now the branch for development.
