### PR TITLE
Add MySQL/MariaDB as a ROOT system dep on CC7

### DIFF
--- a/mysql.sh
+++ b/mysql.sh
@@ -1,0 +1,7 @@
+package: MySQL
+version: "1.0"
+system_requirement_missing: "Please install the MySQL/MariaDB development package."
+system_requirement: ".*"
+system_requirement_check: |
+  printf "#include <mysql.h>\n" | cc -xc - `mysql_config --include` -c -o /dev/null
+---

--- a/root.sh
+++ b/root.sh
@@ -8,6 +8,7 @@ requires:
   - opengl:(?!osx)
   - Xdevel:(?!osx)
   - FreeType:(?!osx)
+  - "MySQL:slc7.*"
 build_requires:
   - CMake
 env:


### PR DESCRIPTION
Enables building of MySQL ROOT classes.