### PR TITLE
ZeroMQ: check for system static lib

### DIFF
--- a/zeromq.sh
+++ b/zeromq.sh
@@ -5,7 +5,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 prefer_system: (?!slc5.*)
 prefer_system_check: |
-  printf "#include <zmq.h>\n#if(ZMQ_VERSION < 40103)\n#error \"zmq version >= 4.1.3 needed\"\n#endif\n int main(){}" | gcc -I$(brew --prefix zeromq)/include -xc++ - -c -M 2>&1
+  printf "#include <zmq.h>\n#if(ZMQ_VERSION < 40103)\n#error \"zmq version >= 4.1.3 needed\"\n#endif\n int main(){}" | gcc -I$(brew --prefix zeromq)/include $([[ -d $(brew --prefix zeromq) ]] || echo "-l:libzmq.a") -xc++ - 2>&1
 ---
 #!/bin/sh
 


### PR DESCRIPTION
This is required by FairRoot. If not found we will compile our own.