### PR TITLE
Openssl added header check on linux, unified osx and linux script

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -3,8 +3,7 @@ version: "v2-19-le%(defaults_upper)s"
 build_requires:
  - zlib
  - libxml2
- - "OpenSSL:(?!osx)"
- - "osx-system-openssl:(osx.*)"
+ - OpenSSL
  - AliEn-CAs
  - gSOAP
  - MonALISA-gSOAP-client

--- a/gsoap.sh
+++ b/gsoap.sh
@@ -4,8 +4,7 @@ tag: alice/v2.7.13
 source: https://github.com/alisw/gsoap.git
 build_requires:
  - autotools
- - "OpenSSL:(?!osx)"
- - "osx-system-openssl:(osx.*)"
+ - OpenSSL
  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e

--- a/openssl.sh
+++ b/openssl.sh
@@ -2,12 +2,20 @@ package: OpenSSL
 version: v0.9.8zf
 tag: "v0.9.8_1.2.4"
 source: https://github.com/alisw/alice-openssl.git
-prefer_system: (?!slc5|slc6)
+prefer_system: (?!slc5|slc6|osx)
 prefer_system_check: |
-  if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; else exit 0; fi
+ echo "Prefer system - shell is ${0}"
+ if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
+ echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"
+system_requirement_missing: |
+ Please make sure you install openssl using Homebrew (brew install openssl)
+system_requirement: "osx.*"
+system_requirement_check: |
+ echo "System requirement - shell is ${0}"
+ echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
 ---
 #!/bin/bash -e
 

--- a/openssl.sh
+++ b/openssl.sh
@@ -4,7 +4,6 @@ tag: "v0.9.8_1.2.4"
 source: https://github.com/alisw/alice-openssl.git
 prefer_system: (?!slc5|slc6|osx)
 prefer_system_check: |
- echo "Prefer system - shell is ${0}"
  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
 build_requires:
@@ -14,7 +13,6 @@ system_requirement_missing: |
  Please make sure you install openssl using Homebrew (brew install openssl)
 system_requirement: "osx.*"
 system_requirement_check: |
- echo "System requirement - shell is ${0}"
  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
 ---
 #!/bin/bash -e

--- a/openssl.sh
+++ b/openssl.sh
@@ -4,8 +4,7 @@ tag: "v0.9.8_1.2.4"
 source: https://github.com/alisw/alice-openssl.git
 prefer_system: (?!slc5|slc6|osx)
 prefer_system_check: |
- if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
- echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
+ echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"

--- a/osx-system-openssl.sh
+++ b/osx-system-openssl.sh
@@ -1,9 +1,0 @@
-package: osx-system-openssl
-version: 1.0
-system_requirement_missing: |
-  Please make sure you install openssl using Homebrew (brew install openssl)
-system_requirement: "osx.*"
-system_requirement_check: |
-  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
----
-

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -4,8 +4,7 @@ tag: v3.3.6
 source: https://github.com/xrootd/xrootd.git
 build_requires:
  - CMake
- - "OpenSSL:(?!osx)"
- - "osx-system-openssl:(osx.*)"
+ - OpenSSL
  - ApMon-CPP
  - libxml2
  - MonALISA-gSOAP-client


### PR DESCRIPTION
Dear @ktf , dear @dberzano ,

This is a continuation of PR #661 on the openssl check in alidist. Following the suggestion there, this PR is against the dev branch of alisw/alidist.

I followed the suggestion by Dario to simplify the check to 
```
if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
``` 
However, this script gets executed by /bin/sh not /bin/bash, thus the comparison for Darwin must read `=` instead of `==`. I further found out, that this line would never be executed on Darwin, since on Darwin the package is osx-system-openssl where a `system_requirement_check` is performed instead of the `prefer_system_check` on linux in the openssl package. I then unified these two packages, moving the `system_requirement_check` of OS X to the openssl.sh. In the end it boils down to
```
package: OpenSSL
version: v0.9.8zf
tag: "v0.9.8_1.2.4"
source: https://github.com/alisw/alice-openssl.git
prefer_system: (?!slc5|slc6|osx)
prefer_system_check: |
 echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null || exit 1
build_requires:
 - zlib
 - "GCC-Toolchain:(?!osx)"
system_requirement_missing: |
 Please make sure you install openssl using Homebrew (brew install openssl)
system_requirement: "osx.*"
system_requirement_check: |
 echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
---
```

Tests below.

Cheers,
Hans

#
# OLD openssl check in alidist
#

Ubuntu 16 with openssl headers installed
+ Correct behavior
  SUCCESS: Package OpenSSL will be picked up from the system.

Ubuntu 16 with broken openssl headers added in bio.h
       #error "This is a test - broken openssl header"
       invalid code
- Bad behavior
  SUCCESS: Package OpenSSL will be picked up from the system.

Ubuntu 16 without openssl headers
- Bad behavior
  SUCCESS: Package OpenSSL will be picked up from the system.


#
# NEW two-lined check in alidist proposed by Dario
```
 if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
 echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
```
#

Ubuntu 16 without openssl headers
+ Correct behavior, BUT shell script complains about syntax. The script is executed by /bin/sh not by /bin/bash. Running the two lines check in sh and bash reproduces the behavior. 
  WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
  WARNING: This is due to the fact the following script fails: 
  WARNING: 
  WARNING: brew() { true; }; if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  WARNING: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
  WARNING: 
  WARNING: with the following output:
  WARNING: 
  WARNING: OpenSSL: /bin/sh: 1: [: Linux: unexpected operator
  WARNING: OpenSSL: <stdin>:1:25: fatal error: openssl/bio.h: No such file or directory
  WARNING: OpenSSL: compilation terminated.
  WARNING: OpenSSL: 
  WARNING: 



#
# NEW two-lined check with sh / POSIX compliant = comparison
```
  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
```
#

Ubuntu 16 without openssl headers
+ Correct behavior
  WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
  WARNING: This is due to the fact the following script fails:
  WARNING: 
  WARNING: brew() { true; }; if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  WARNING: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
  WARNING: 
  WARNING: with the following output:
  WARNING: 
  WARNING: OpenSSL: <stdin>:1:25: fatal error: openssl/bio.h: No such file or directory
  WARNING: OpenSSL: compilation terminated.
  WARNING: OpenSSL: 
  WARNING: 


Ubuntu 16 with broken openssl headers
       #error "This is a test - broken openssl header"
       invalid code
+ Correct behavior

  WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
  WARNING: This is due to the fact the following script fails:
  WARNING: 
  WARNING: brew() { true; }; if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  WARNING: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
  WARNING: 
  WARNING: with the following output:
  WARNING: 
  WARNING: OpenSSL: In file included from <stdin>:1:0:
  WARNING: OpenSSL: /usr/include/openssl/bio.h:59:2: error: #error "This is a test - broken openssl header"
  WARNING: OpenSSL:  #error "This is a test - broken openssl header"
  WARNING: OpenSSL:   ^
  WARNING: OpenSSL: /usr/include/openssl/bio.h:60:1: error: ?invalid? does not name a type
  WARNING: OpenSSL:  invalid code
  WARNING: OpenSSL:  ^
  WARNING: OpenSSL: 
  WARNING: 


Ubuntu 16 with good openssl headers
+ Correct behavior   
  SUCCESS: Package OpenSSL will be picked up from the system.


OSX
 On OSX, the script alidist/openssl.sh is not invoked. Instead the script alidist/osx-system-openssl.sh is executed. See the grep below
```
   hbeck@mira:~/alice/alibuild$ grep OpenSSL alidist/*
   alidist/alien-runtime.sh: - "OpenSSL:(?!osx)"
   alidist/gsoap.sh: - "OpenSSL:(?!osx)"
   alidist/openssl.sh:package: OpenSSL
   alidist/perl-modules.sh:          Crypt::DES_EDE3 Crypt::OpenSSL::RSA Crypt::OpenSSL::Random Crypt::OpenSSL::X509
   alidist/xrootd.sh: - "OpenSSL:(?!osx)"
   hbeck@mira:~/alice/alibuild$
```


#
# Combined OpenSSL package for all OS
#
```
package: OpenSSL
version: v0.9.8zf
tag: "v0.9.8_1.2.4"
source: https://github.com/alisw/alice-openssl.git
prefer_system: (?!slc5|slc6)
prefer_system_check: |
  echo "shell is $0"
  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
build_requires:
 - zlib
 - "GCC-Toolchain:(?!osx)"
system_requirement_missing: |
  Please make sure you install openssl using Homebrew (brew install openssl)
system_requirement: "osx.*"
system_requirement_check: |
  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
---
```

# broken header on Ubuntu
+ Correct behavior
  WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
  WARNING: This is due to the fact the following script fails:
  WARNING: 
  WARNING: brew() { true; }; if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  WARNING: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
  WARNING: 
  WARNING: with the following output:
  WARNING: 
  WARNING: OpenSSL: In file included from <stdin>:1:0:
  WARNING: OpenSSL: /usr/include/openssl/bio.h:59:2: error: #error "openssl broken header test"
  WARNING: OpenSSL:  #error "openssl broken header test"
  WARNING: OpenSSL:   ^
  WARNING: OpenSSL: /usr/include/openssl/bio.h:60:1: error: ?invalid? does not name a type
  WARNING: OpenSSL:  invalid code
  WARNING: OpenSSL:  ^
  WARNING: OpenSSL: 
  WARNING:

# missing openssl headers
+ Correct behavior
  WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
  WARNING: This is due to the fact the following script fails:
  WARNING: 
  WARNING: brew() { true; }; if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  WARNING: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
  WARNING: 
  WARNING: with the following output:
  WARNING: 
  WARNING: OpenSSL: <stdin>:1:25: fatal error: openssl/bio.h: No such file or directory
  WARNING: OpenSSL: compilation terminated.
  WARNING: OpenSSL: 
  WARNING: 



# good headers on Ubuntu 16.04
+ Correct behavior
  SUCCESS: Package OpenSSL will be picked up from the system.



# OSX broken headers
+ Correct behavior
ERROR: Package OpenSSL is a system requirement and cannot be found.
ERROR: This is due to the fact that the following script fails:
ERROR: 
ERROR: echo "System requirement - shell is ${0}"
ERROR: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
ERROR: with the following output:
ERROR: 
ERROR: OpenSSL: System requirement - shell is /bin/sh
ERROR: OpenSSL: In file included from <stdin>:1:
ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:59:2: error: "Test - broken ssl headers"
ERROR: OpenSSL: #error "Test - broken ssl headers"
ERROR: OpenSSL:  ^
ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:60:1: error: unknown type name 'invalid'
ERROR: OpenSSL: invalid code
ERROR: OpenSSL: ^
ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:60:13: error: expected ';' after top level declarator
ERROR: OpenSSL: invalid code
ERROR: OpenSSL:             ^
ERROR: OpenSSL:             ;
ERROR: OpenSSL: 3 errors generated.
ERROR: OpenSSL: 
ERROR: Please make sure you install openssl using Homebrew (brew install openssl)
ERROR: 
ERROR: 

# OSX good headers
+ Correct behavior
SUCCESS: Required package OpenSSL will be picked up from the system.
DEBUG: echo "System requirement - shell is ${0}"
DEBUG: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
DEBUG: OpenSSL: System requirement - shell is /bin/sh


#
#
# With removed osx-system-openssl.sh 
# and referencing combined openssl throughout
#

# OSX with good headers
+ Correct behavior
SUCCESS: Required package OpenSSL will be picked up from the system.

# OSX with broken headers 
+ Correct behavior
  ERROR: Package OpenSSL is a system requirement and cannot be found.
  ERROR: This is due to the fact that the following script fails:
  ERROR: 
  ERROR: echo "System requirement - shell is ${0}"
  ERROR: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
  ERROR: with the following output:
  ERROR: 
  ERROR: OpenSSL: System requirement - shell is /bin/sh
  ERROR: OpenSSL: In file included from <stdin>:1:
  ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:59:2: error: "Test - broken ssl header"
  ERROR: OpenSSL: #error "Test - broken ssl header"
  ERROR: OpenSSL:  ^
  ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:60:1: error: unknown type name 'invalid'
  ERROR: OpenSSL: invalid code
  ERROR: OpenSSL: ^
  ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:60:13: error: expected ';' after top level declarator
  ERROR: OpenSSL: invalid code
  ERROR: OpenSSL:             ^
  ERROR: OpenSSL:             ;
  ERROR: OpenSSL: 3 errors generated.
  ERROR: OpenSSL: 
  ERROR: Please make sure you install openssl using Homebrew (brew install openssl)
  ERROR: 
  ERROR:
...
  ==> The following packages are system dependencies and could not be found:
    
      - OpenSSL



# OSX without openssl package from brew
+ Correct behavior
  ERROR: Package OpenSSL is a system requirement and cannot be found.
  ERROR: This is due to the fact that the following script fails:
  ERROR: 
  ERROR: echo "System requirement - shell is ${0}"
  ERROR: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
  ERROR: with the following output:
  ERROR: 
  ERROR: OpenSSL: System requirement - shell is /bin/sh
  ERROR: OpenSSL: <stdin>:1:10: fatal error: 'openssl/bio.h' file not found
  ERROR: OpenSSL: #include <openssl/bio.h>
  ERROR: OpenSSL:          ^
  ERROR: OpenSSL: 1 error generated.
  ERROR: OpenSSL: 
  ERROR: Please make sure you install openssl using Homebrew (brew install openssl)
  ERROR: 
  ERROR: 


#
#
# With removed check for brew in prefer_system
#
```
package: OpenSSL
version: v0.9.8zf
tag: "v0.9.8_1.2.4"
source: https://github.com/alisw/alice-openssl.git
prefer_system: (?!slc5|slc6|osx)
prefer_system_check: |
 echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null || exit 1
build_requires:
 - zlib
 - "GCC-Toolchain:(?!osx)"
system_requirement_missing: |
 Please make sure you install openssl using Homebrew (brew install openssl)
system_requirement: "osx.*"
system_requirement_check: |
 echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
---
```


# OS X no openssl

Hanss-MacBook:alibuild hbeck$ aliDoctor openssl
ERROR: Package OpenSSL is a system requirement and cannot be found.
ERROR: This is due to the fact that the following script fails:
ERROR: 
ERROR: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
ERROR: with the following output:
ERROR: 
ERROR: OpenSSL: <stdin>:1:10: fatal error: 'openssl/bio.h' file not found
ERROR: OpenSSL: #include <openssl/bio.h>
ERROR: OpenSSL:          ^
ERROR: OpenSSL: 1 error generated.
ERROR: OpenSSL: 
ERROR: Please make sure you install openssl using Homebrew (brew install openssl)
ERROR: 
ERROR: 
SUCCESS: Package zlib will be picked up from the system.

==> The following packages will be picked up from the system:
    
    - zlib
    
    If this is not you want, you have to uninstall / unload them.

==> The following packages are system dependencies and could not be found:
    
    - OpenSSL


# OS X - With openssl installed via brew
+ Correct behavior

SUCCESS: Required package OpenSSL will be picked up from the system.


# OSX - Broken headers
+ Correct behavior

ERROR: Package OpenSSL is a system requirement and cannot be found.
ERROR: This is due to the fact that the following script fails:
ERROR: 
ERROR: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
ERROR: with the following output:
ERROR: 
ERROR: OpenSSL: In file included from <stdin>:1:
ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:59:2: error: "Test - broken header"
ERROR: OpenSSL: #error "Test - broken header"
ERROR: OpenSSL:  ^
ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:60:1: error: unknown type name 'invalid'
ERROR: OpenSSL: invalid code
ERROR: OpenSSL: ^
ERROR: OpenSSL: /usr/local/opt/openssl/include/openssl/bio.h:60:13: error: expected ';' after top level declarator
ERROR: OpenSSL: invalid code
ERROR: OpenSSL:             ^
ERROR: OpenSSL:             ;
ERROR: OpenSSL: 3 errors generated.
ERROR: OpenSSL: 
ERROR: Please make sure you install openssl using Homebrew (brew install openssl)
ERROR: 
ERROR: 
SUCCESS: Package zlib will be picked up from the system.

==> The following packages will be picked up from the system:
    
    - zlib
    
    If this is not you want, you have to uninstall / unload them.

==> The following packages are system dependencies and could not be found:
    
    - OpenSSL



# Ubuntu 16 with correct openssl headers
+ Correct behavior
SUCCESS: Package OpenSSL will be picked up from the system.


# Ubuntu 16 without libssl-dev
+ Correct behavior

WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
WARNING: This is due to the fact the following script fails:
WARNING:
WARNING: brew() { true; }; echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null || exit 1
WARNING:
WARNING: with the following output:
WARNING:
WARNING: OpenSSL: <stdin>:1:25: fatal error: openssl/bio.h: No such file or directory
WARNING: OpenSSL: compilation terminated.
WARNING: OpenSSL:
WARNING:


# Ubuntu 16 broken header
+ Correct behavior

WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
WARNING: This is due to the fact the following script fails:
WARNING:
WARNING: brew() { true; }; echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null || exit 1
WARNING:
WARNING: with the following output:
WARNING:
WARNING: OpenSSL: In file included from <stdin>:1:0:
WARNING: OpenSSL: /usr/include/openssl/bio.h:59:2: error: #error "Test - broken ssl header"
WARNING: OpenSSL:  #error "Test - broken ssl header"
WARNING: OpenSSL:   ^
WARNING: OpenSSL: /usr/include/openssl/bio.h:60:1: error: ?invalid? does not name a type
WARNING: OpenSSL:  invalid code
WARNING: OpenSSL:  ^
WARNING: OpenSSL:
WARNING:



