### PR TITLE
Temporary disable root history when performing ctest

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -10,7 +10,9 @@ prepend_path:
   ROOT_INCLUDE_PATH: "$ALIPHYSICS_ROOT/include"
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
+  [[ ! -z $ROOT_HIST ]] && tmpROOT_HIST="$ROOT_HIST"; export ROOT_HIST=0
   ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+  ROOT_HIST=$tmpROOT_HIST && [[ -z $tmpROOT_HIST ]] && unset ROOT_HIST
   [[ $CMAKE_BUILD_TYPE == COVERAGE ]] && mkdir -p "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/" && rsync -acv --filter='+ */' --filter='+ *.cpp' --filter='+ *.cc' --filter='+ *.h' --filter='+ *.gcno' --filter='- *' "$BUILDDIR/" "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
@@ -38,7 +40,9 @@ cmake "$SOURCEDIR"                                                 \
 
 make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 # ctest will succeed if no load_library tests were found
+[[ ! -z $ROOT_HIST ]] && tmpROOT_HIST="$ROOT_HIST"; export ROOT_HIST=0
 ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+ROOT_HIST=$tmpROOT_HIST && [[ -z $tmpROOT_HIST ]] && unset ROOT_HIST
 
 [[ $CMAKE_BUILD_TYPE == COVERAGE ]]                                                       \
   && mkdir -p "$WORK_DIR/${ARCHITECTURE}/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"  \

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -18,7 +18,9 @@ source: https://github.com/alisw/AliRoot
 tag: master
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
+  [[ ! -z $ROOT_HIST ]] && tmpROOT_HIST="$ROOT_HIST"; export ROOT_HIST=0
   ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+  ROOT_HIST=$tmpROOT_HIST && [[ -z $tmpROOT_HIST ]] && unset ROOT_HIST
   rsync -a $SOURCEDIR/test/ $INSTALLROOT/test
   [[ $CMAKE_BUILD_TYPE == COVERAGE ]] && mkdir -p "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$PKGVERSION-$PKGREVISION/" && rsync -acv --filter='+ */' --filter='+ *.cpp' --filter='+ *.cc' --filter='+ *.h' --filter='+ *.gcno' --filter='- *' "$BUILDDIR/" "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$PKGVERSION-$PKGREVISION/"
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
@@ -58,7 +60,9 @@ cmake $SOURCEDIR                                                     \
 
 make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 # ctest will succeed if no load_library tests were found
+[[ ! -z $ROOT_HIST ]] && tmpROOT_HIST="$ROOT_HIST"; export ROOT_HIST=0
 ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+ROOT_HIST=$tmpROOT_HIST && [[ -z $tmpROOT_HIST ]] && unset ROOT_HIST
 [[ $ALICE_DAQ ]] && { make daqDA-all-rpm && make ${JOBS+-j $JOBS} install; }
 
 rsync -av $SOURCEDIR/test/ $INSTALLROOT/test


### PR DESCRIPTION
The ctest runs a series of load-libraries commands that are stored in the root history.
Since there are lots of library, the user history basically goes outside the buffer.
The patch disable the root history before running the ctest, and turn it on again when the ctest is over