### PR TITLE
Openssl: Added header check on linux

### DIFF
--- a/openssl.sh
+++ b/openssl.sh
@@ -4,7 +4,8 @@ tag: "v0.9.8_1.2.4"
 source: https://github.com/alisw/alice-openssl.git
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` == Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; else exit 0; fi
+  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
+  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Hello @dberzano 

This commit adds the openssl header check on linux, as proposed by you, Dario, in #661 but with the POSIX compliant `=` comparison instead of `==`, since the check is performed by `sh` not `bash`.
```sh
  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
```

Sorry for the delay and the overambitious attempt in #706 (see there for tests). I should have followed your, Dario, advice more closely. Below a couple of tests. 

Cheers,
Hans


## Ubuntu 16 with headers
> SUCCESS: Package OpenSSL will be picked up from the system.
> 
> ==> The following packages will be picked up from the system:
>     
>     - OpenSSL
>     
>     If this is not you want, you have to uninstall / unload them.
> 

## mac OS with openssl via brew
> Hanss-MacBook:alibuild hbeck$ aliDoctor openssl
> SUCCESS: Package OpenSSL will be picked up from the system.
> 
> ==> The following packages will be picked up from the system:
>     
>     - OpenSSL
>     
>     If this is not you want, you have to uninstall / unload them.
> Hanss-MacBook:alibuild hbeck$ aliBuild -d build openssl
> DEBUG: User has analytics id. Pushing analytics to Google Analytics.
> DEBUG: Building for architecture osx_x86-64
> DEBUG: Number of parallel builds: 4
> DEBUG: Using aliBuild from alibuild@1.4.0 recipes in alidist@f1161b15b9123448f82de32469dba6a80408c478
> 
> ==> aliBuild can take the following packages from the system and will not build them:
>       OpenSSL
> 
> ==> Nothing to be done.
> Hanss-MacBook:alibuild hbeck$ 
> 

## macOS without openssl
> Hanss-MacBook:alibuild hbeck$ brew uninstall openssl
> Uninstalling /usr/local/Cellar/openssl/1.0.2k... (1,697 files, 12.1MB)
> Hanss-MacBook:alibuild hbeck$ aliDoctor openssl
> WARNING: Package OpenSSL cannot be picked up from the system and will be built by aliBuild.
> WARNING: This is due to the fact the following script fails:
> WARNING: 
> WARNING: if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi
> WARNING: echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
> WARNING: 
> WARNING: with the following output:
> WARNING: 
> WARNING: OpenSSL: 
> WARNING: 
> SUCCESS: Package zlib will be picked up from the system.
> 
> ==> The following packages will be picked up from the system:
>     
>     - zlib
>     
>     If this is not you want, you have to uninstall / unload them.
> 
> ==> The following packages will be build by aliBuild because they couldn't be picked up from the system:
>     
>     - OpenSSL
>     
>     This is not a real issue, but it might take longer the first time you invoke aliBuild.
> Hanss-MacBook:alibuild hbeck$ 
> 

## Building openssl on macOS
> 
> Hanss-MacBook:alibuild hbeck$ aliBuild -d build openssl
> DEBUG: User has analytics id. Pushing analytics to Google Analytics.
> DEBUG: Building for architecture osx_x86-64
> DEBUG: Number of parallel builds: 4
> DEBUG: Using aliBuild from alibuild@1.4.0 recipes in alidist@f1161b15b9123448f82de32469dba6a80408c478
> 
> ==> aliBuild can take the following packages from the system and will not build them:
>       zlib
> 
> ==> The following packages cannot be taken from the system and will be built:
>       OpenSSL
> 
> ==> Packages will be built in the following order:
>      - defaults-release@v1
>      - OpenSSL@v0.9.8_1.2.4
> DEBUG: Main package is OpenSSL@v0.9.8_1.2.4
> DEBUG:OpenSSL:v0.9.8_1: Commit hash for https://github.com/alisw/alice-openssl.git@v0.9.8_1.2.4 is v0.9.8_1.2.4
> [...]
> DEBUG:OpenSSL:v0.9.8_1: Package OpenSSL was correctly compiled. Moving to next one.
> DEBUG:OpenSSL:v0.9.8_1: 
> DEBUG:OpenSSL:v0.9.8_1: 
> DEBUG:OpenSSL:v0.9.8_1: 
> DEBUG:OpenSSL:v0.9.8_1: 
> DEBUG:OpenSSL:v0.9.8_1: 
> DEBUG:OpenSSL:v0.9.8_1: Cleaning up:
> DEBUG:OpenSSL:v0.9.8_1: /Users/hbeck/alice/alibuild/sw/BUILD/49ca9287dfbd103f0b330430b768c7900f03d5ce
> DEBUG:OpenSSL:v0.9.8_1: /Users/hbeck/alice/alibuild/sw/INSTALLROOT/49ca9287dfbd103f0b330430b768c7900f03d5ce
> 
> ==> Build of OpenSSL successfully completed on `Hanss-MacBook.fritz.box'.
>     Your software installation is at:
>     
>       /Users/hbeck/alice/alibuild/sw/osx_x86-64
>     
>     You can use this package by loading the environment:
>     
>       alienv enter OpenSSL/latest
> Hanss-MacBook:alibuild hbeck$ 