### PR TITLE
Root: Check for AvailabilityMacros.h, i.e. command line tools, on osx

### DIFF
--- a/availabilitymacros.sh
+++ b/availabilitymacros.sh
@@ -1,0 +1,8 @@
+package: availabilitymacros
+version: 1.0
+system_requirement_missing: |
+  Please make sure you install xcode command line tools using xcode-select --install
+system_requirement: "osx.*"
+system_requirement_check: |
+  echo '#include <AvailabilityMacros.h>' | c++ -x c++ - -c -o /dev/null
+---

--- a/root.sh
+++ b/root.sh
@@ -10,6 +10,7 @@ requires:
   - FreeType:(?!osx)
 build_requires:
   - CMake
+  - "availabilitymacros:(osx.*)"
 env:
   ROOTSYS: "$ROOT_ROOT"
 prepend_path:


### PR DESCRIPTION
Hello @ktf , @dberzano ,

Here's a pull request for the issue of missing AvailabilityMacros.h experienced by Sedhana today. I hope this PR can be a base for discussion. No strong feelings on this PR from my side. Let me know if I should focus on other ways of contributing.

Cheers,
Hans

```sh
Hanss-MacBook:alibuild hbeck$ aliDoctor root
[...]
SUCCESS: Required package availabilitymacros will be picked up from the system.
```

Cheers,
Hans 