### PR TITLE
Adding ZeroMQ dependency for AliRoot build in defaults-o2

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -30,6 +30,14 @@ overrides:
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
       - Python-modules
+  AliRoot:
+    requires:
+      - ROOT
+      - fastjet:(?!.*ppc64)
+      - GEANT3
+      - GEANT4_VMC
+      - Vc
+      - ZeroMQ
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null


### PR DESCRIPTION
Fixes #742
This handles https://github.com/AliceO2Group/AliceO2/issues/369

Note: AliRoot is by default disabled in the defaults, but might be
included in the build by removing this. Then the correct dependencies
must be applied.

In the override section, all dependencies have to be specified, simply
adding to the already defined dependencies is not yet supported.