### PR TITLE
Add Python-system for non-SLC platforms

### DIFF
--- a/agile.sh
+++ b/agile.sh
@@ -7,9 +7,10 @@ requires:
   - boost
   - lhapdf5
   - HepMC
-  - Python
+  - "Python:slc[567].*"
 build_requires:
   - autotools
+  - "Python-system:(?!slc[567])"
 ---
 #!/bin/bash -e
 

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -22,7 +22,8 @@ overrides:
   boost:
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - "Python-system:(?!slc[567])"
+      - "Python:slc[567].*"
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |
@@ -37,7 +38,8 @@ overrides:
       - opengl:(?!osx)
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
-      - Python-modules
+      - "Python-system:(?!slc[567])"
+      - "Python-modules:slc[567].*"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -21,7 +21,8 @@ overrides:
   boost:
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - "Python:slc[567]"
+      - "Python-system:(?!slc[567])"
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |
@@ -36,7 +37,8 @@ overrides:
       - opengl:(?!osx)
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
-      - Python-modules
+      - "Python-modules:slc[567]"
+      - "Python-system:(?!slc[567])"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -21,7 +21,8 @@ overrides:
   boost:
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - "Python:slc[567]"
+      - "Python-system:(?!slc[567])"
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |
@@ -36,7 +37,8 @@ overrides:
       - opengl:(?!osx)
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
-      - Python-modules
+      - "Python-modules:slc[567]"
+      - "Python-system:(?!slc[567])"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -13,7 +13,8 @@ overrides:
   boost:
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - "Python:slc[567]"
+      - "Python-system:(?!slc[567])"
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |
@@ -29,7 +30,8 @@ overrides:
       - opengl:(?!osx)
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
-      - Python-modules
+      - "Python-modules:slc[567]"
+      - "Python-system:(?!slc[567])"
   AliRoot:
     requires:
       - ROOT

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -15,7 +15,8 @@ overrides:
       - opengl:(?!osx)
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
-      - Python-modules
+      - "Python-modules:slc[567]"
+      - "Python-system:(?!slc[567])"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -5,9 +5,10 @@ source: https://github.com/alisw/LHAPDF
 requires:
  - yaml-cpp
  - boost
- - Python-modules
+ - "Python-modules:slc[567]"
 build_requires:
  - autotools
+ - "Python-system:(?!slc[567])"
 env:
   LHAPATH: "$LHAPDF_ROOT/share/LHAPDF"
 ---

--- a/mesos.sh
+++ b/mesos.sh
@@ -6,7 +6,8 @@ build_requires:
 - autotools
 - protobuf
 - glog
-- Python
+- "Python:slc[567]"
+- "Python-system:(?!slc[567])"
 prepend_path:
   PATH: "$MESOS_ROOT/sbin"
   PYTHONPATH: $MESOS_ROOT/lib/python2.7/site-packages

--- a/python-system.sh
+++ b/python-system.sh
@@ -1,0 +1,21 @@
+package: Python-system
+version: "1.0"
+system_requirement_missing: |
+  Python 2.7+ and pip are required for this installation. Please make sure they are installed.
+  You will also need the development packages (usually called python-dev or python-devel).
+
+  Please also make sure you have the following Python modules, which can be installed via pip:
+
+    - matplotlib
+    - numpy
+    - certifi
+    - ipython
+    - ipywidgets
+    - ipykernel
+    - notebook
+    - metakernel
+    - pyyaml
+system_requirement: ".*"
+system_requirement_check: |
+  python -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (2, 7) else 0)' && pip --help > /dev/null && printf '#include "pyconfig.h"' | cc -c -I$(python-config --includes) -xc -o /dev/null - && python -c 'import matplotlib,numpy,certifi,IPython,ipywidgets,ipykernel,notebook.notebookapp,metakernel,yaml'
+---

--- a/sacrifice.sh
+++ b/sacrifice.sh
@@ -7,10 +7,11 @@ requires:
   - boost
   - lhapdf
   - HepMC
-  - Python
+  - "Python:slc[567]"
   - pythia
 build_requires:
   - autotools
+  - "Python-system:(?!slc[567])"
 ---
 #!/bin/bash -e
 

--- a/yoda.sh
+++ b/yoda.sh
@@ -3,9 +3,10 @@ version: "v1.6.3"
 source: https://github.com/alisw/yoda
 requires:
   - boost
-  - Python-modules
+  - "Python-modules:slc[567]"
 build_requires:
   - autotools
+  - "Python-system:(?!slc[567])"
 prepend_path:
   PYTHONPATH: $YODA_ROOT/lib64/python2.7/site-packages:$YODA_ROOT/lib/python2.7/site-packages
 ---


### PR DESCRIPTION
When required Python components are missing from the system clarify with a
message asking user to install them instead of compiling our own