### PR TITLE
Update defaults for native/DAQ SLC6 builds

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -9,7 +9,6 @@ requires:
   - Vc
 build_requires:
   - CMake
-  - DAQ:slc6.*
   - "Xcode:(osx.*)"
 env:
   ALICE_ROOT: "$ALIROOT_ROOT"

--- a/daq.sh
+++ b/daq.sh
@@ -1,12 +1,6 @@
 package: DAQ
 version: v1
-prefer_system: slc6.*
-prefer_system_check: |
-  ! rpm -q date amore daqDA-lib ACT
 ---
 #!/bin/bash -e
-# This is a dummy recipe used to track DAQ dependencies installed via RPMs.
-# AliRoot depends on it and will be rebuilt if this package's version changes.
-# For DAQ use: prefer_system_check returns 1 in order to force the creation of
-# this dummy package. For all the other use cases: prefer_system_check returns 0
-# and this dependency will be silently ignored.
+# We do nothing but checking that those packages are installed.
+rpm -q date amore daqDA-lib ACT

--- a/defaults-el6native.sh
+++ b/defaults-el6native.sh
@@ -1,15 +1,9 @@
-package: defaults-daq
+package: defaults-el6native
 version: v1
 env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++98"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
-  ALICE_DAQ: "1"
-  AMORE_CONFIG: /opt/amore/bin/amore-config
-  DATE_CONFIG: /opt/date/.commonScripts/date-config
-  DATE_ENV: /date/setup.sh
-  DAQ_DIM: /opt/dim
-  DAQ_DALIB: /opt/daqDA-lib
 
 disable:
   - AliEn-Runtime
@@ -20,7 +14,6 @@ overrides:
     requires:
       - ROOT
     build_requires:
-      - DAQ
       - CMake
 ---
 # This file is included in any build recipe and it's only used to set


### PR DESCRIPTION
AliRoot must also compile using the native SLC6 compiler. Those defaults are
to be used for the native AliRoot build tests, and for generating the DA RPMs