### PR TITLE
Fix YODA installation w/o python from system

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -12,8 +12,8 @@ prepend_path:
   PYTHONPATH: $PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH
 prefer_system: (?!slc5)
 prefer_system_check:
-  python -c 'import matplotlib,numpy,certifi,IPython,ipywidgets,ipykernel,notebook.notebookapp,metakernel,yaml';
-  if [ $? -ne 0 ]; then printf "Required Python modules are missing. You can install them with pip (better as root):\n  pip install matplotlib numpy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml\n"; exit 1; fi
+  python -c 'import matplotlib,numpy,certifi,IPython,ipywidgets,ipykernel,notebook.notebookapp,metakernel,yaml,cython';
+  if [ $? -ne 0 ]; then printf "Required Python modules are missing. You can install them with pip (better as root):\n  pip install matplotlib numpy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml cython\n"; exit 1; fi
 ---
 #!/bin/bash -ex
 
@@ -31,6 +31,7 @@ If you want to avoid this please install the following modules (pip recommended)
   - notebook
   - metakernel
   - pyyaml
+  - cython
 
 EoF
 fi
@@ -52,7 +53,8 @@ for X in "mock==1.0.0"         \
          "ipykernel==4.5.0"    \
          "notebook==4.2.3"     \
          "metakernel==0.14.0"  \
-         "pyyaml"
+         "pyyaml"              \
+         "cython==0.25.2"
 do
   pip install --user $X
 done

--- a/rivet.sh
+++ b/rivet.sh
@@ -44,6 +44,8 @@ fi
 
 [[ "$CXXFLAGS" != *'-std=c++11'* ]] || CXX11=1
 
+(
+unset PYTHON_VERSION
 autoreconf -ivf
 ./configure                                 \
   --prefix="$INSTALLROOT"                   \
@@ -56,6 +58,7 @@ autoreconf -ivf
   ${CXX11:+--enable-stdcxx11}
 make -j$JOBS
 make install
+)
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/yoda.sh
+++ b/yoda.sh
@@ -13,10 +13,13 @@ prepend_path:
 #!/bin/bash -e
 rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
 
+(
+unset PYTHON_VERSION
 autoreconf -ivf
 ./configure --prefix="$INSTALLROOT" --with-boost="$Boost"
 make -j$JOBS
 make install
+)
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
- adding Cython which is needed for YODA
  (unclear how installation could work without so far if not provided by the system)
- PYTHON_VERSION creates confusion for YODA and Rivet,
  when set searching for pythonv2.7.10
  (still to be understood)

This PR is up for discussion and not yet to be merged before the issues are understood.

Przemek and Jochen