### PR TITLE
Root: Added -Dbuiltin_vdt=ON for root v6-10-00.

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -107,6 +107,7 @@ else
         -Dsoversion=ON                                            \
         -Dshadowpw=OFF                                            \
         -Dvdt=ON                                                  \
+        -Dbuiltin_vdt=ON                                          \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}


### PR DESCRIPTION
Dear @ktf @dberzano ,

As discussed via email, root v6-10-00 fails at configuration stage with alibuild since aliBuild checks for the vdt feature. In the new root production release, vdt is tried to be picked up from the system and not built by root itself. 
I tested the additional cmake flag `-Dbuiltin_vdt=ON` with v6-10-00 and also the standard v5-34-30, both compile without problems.

Regards,
Hans