### PR TITLE
Make python-modules python3 ready

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -7,7 +7,7 @@ requires:
 build_requires:
   - curl
 env:
-  SSL_CERT_FILE: "$(env PYTHONPATH=$PYTHON_MODULES_ROOT/lib/python$(python -c \"import distutils.sysconfig; print(distutils.sysconfig.get_python_version())\")/site-packages:$PYTHONPATH python -c \"import certifi; print certifi.where()\")"
+  SSL_CERT_FILE: "$(env PYTHONPATH=$PYTHON_MODULES_ROOT/lib/python$(python -c \"import distutils.sysconfig; print(distutils.sysconfig.get_python_version())\")/site-packages:$PYTHONPATH python -c \"import certifi; print (certifi.where())\")"
 prepend_path:
   PYTHONPATH: $PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH
 prefer_system: (?!slc5)

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -7,7 +7,7 @@ requires:
 build_requires:
   - curl
 env:
-  SSL_CERT_FILE: "$(env PYTHONPATH=$PYTHON_MODULES_ROOT/lib/python$(python -c \"import distutils.sysconfig; print(distutils.sysconfig.get_python_version())\")/site-packages:$PYTHONPATH python -c \"import certifi; print (certifi.where())\")"
+  SSL_CERT_FILE: "$(env PYTHONPATH=$PYTHON_MODULES_ROOT/lib/python$(python -c \"import distutils.sysconfig; print(distutils.sysconfig.get_python_version())\")/site-packages:$PYTHONPATH python -c \"import certifi; print(certifi.where())\")"
 prepend_path:
   PYTHONPATH: $PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH
 prefer_system: (?!slc5)


### PR DESCRIPTION
Hello @ktf,

Your fix to make python-modules.sh python3 ready mentioned in https://github.com/alisw/alidist/issues/568 to use `print("hello")` instead of `print "hello"` looks good to me :) In fact, I don't even need the `from __future__ import print_statement` which is mentioned in #568 . `print("hello")` works in both python2 and python3 (as compared to the old `print "hello"` which fails in python3).
In the dev branch of alidist the new `print ("hello")` syntax is already used in the very same affected line.

Ubuntu 16.04
```bash
alice-serv10:~ hbeck$ python --version
Python 2.7.12
alice-serv10:~ hbeck$ python -c "import certifi; print (certifi.where())"
/usr/local/lib/python2.7/dist-packages/certifi/cacert.pem
alice-serv10:~ hbeck$ python3 --version
Python 3.5.2
alice-serv10:~ hbeck$ python3 -c "import certifi; print (certifi.where())"
/usr/local/lib/python3.5/dist-packages/certifi/cacert.pem
```

Scientific Linux CERN SLC release 6.9 (Carbon)
```bash
[habeck@lxplus049] ~> python --version
Python 2.6.6
[habeck@lxplus049] ~> python -c "import certifi; print (certifi.where())"
/afs/cern.ch/user/h/habeck/.local/lib/python2.6/site-packages/certifi/cacert.pem
[habeck@lxplus049] ~> 
```

macOS
```bash
Hanss-MacBook:~ hbeck$ python --version
Python 2.7.10
Hanss-MacBook:~ hbeck$ python -c "import certifi; print (certifi.where())"
/Library/Python/2.7/site-packages/certifi/cacert.pem
Hanss-MacBook:~ hbeck$ 
```

Cheers,
Hans