### PR TITLE
Export O2_ROOT

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -27,6 +27,7 @@ incremental_recipe: |
     ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
   fi
   if [[ $ALIBUILD_O2_TESTS ]]; then
+    export O2_ROOT=$INSTALLROOT
     make test
   fi
 valid_defaults:
@@ -119,5 +120,6 @@ EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 
 if [[ $ALIBUILD_O2_TESTS ]]; then
+  export O2_ROOT=$INSTALLROOT
   make test
 fi


### PR DESCRIPTION
We need to export O2_ROOT before running the tests, because some of them do expect it to be setup in order to look up for shared data. Not sure if this is the best solution, to be rediscussed.