### PR TITLE
Add Support for G4PY, XercesC and add automated version detection for GEANT4 data files

### DIFF
--- a/g4py.sh
+++ b/g4py.sh
@@ -1,0 +1,55 @@
+package: G4PY
+version: "%(tag_basename)s%(defaults_upper)s"
+tag: v4.10.01.p03
+source: https://github.com/alisw/geant4
+requires:
+  - GEANT4
+  - Python-modules
+  - ROOT
+  - boost
+  - XercesC
+  - opengl
+build_requires:
+  - CMake
+  - "Xcode:(osx.*)"
+env:
+  G4PYINSTALL: "$G4PY_ROOT"
+---
+#!/bin/bash -e
+rsync -a $SOURCEDIR/environments/g4py/* $INSTALLROOT
+
+cmake $INSTALLROOT                               \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}     \
+      -DBoost_NO_SYSTEM_PATHS=TRUE               \
+      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"      \
+      -DBOOST_ROOT=${BOOST_ROOT}                 \
+      -DXERCESC_ROOT_DIR=${XERCESC_ROOT}         \
+      -DCMAKE_VERBOSE_MAKEFILE=TRUE              \
+      -DBoost_NO_BOOST_CMAKE=TRUE
+
+make ${JOBS:+-j $JOBS}
+make install
+ctest
+
+ln -s lib64 $INSTALLROOT/lib
+
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION ${GEANT4_VERSION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION} XercesC/$XERCESC_VERSION-$XERCESC_REVISION boost/$BOOST_VERSION-$BOOST_REVISION
+# Our environment
+setenv G4PY_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv PYTHONPATH \$::env(G4PY_ROOT)/lib:\$::env(G4PY_ROOT)/lib/g4py:\$::env(G4PY_ROOT)/lib/Geant4:\$::env(G4PY_ROOT)/lib/examples:\$::env(G4PY_ROOT)/lib/tests
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(G4PY_ROOT)/lib")
+EoF

--- a/geant4.sh
+++ b/geant4.sh
@@ -1,16 +1,16 @@
 package: GEANT4
 version: "%(tag_basename)s%(defaults_upper)s"
-source: https://github.com/alisw/geant4
 tag: v4.10.01.p03
+source: https://github.com/alisw/geant4
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
 env:
-  G4INSTALL: "$GEANT4_ROOT"
-  G4INSTALL_DATA: "$GEANT4_ROOT/share/Geant4-10.1.3"
-  G4SYSTEM: "$(uname)-g++"
+  G4INSTALL:                "$GEANT4_ROOT"
+  G4INSTALL_DATA:           "$GEANT4_ROOT/share/Geant4-10.1.3"
+  G4SYSTEM:                 "$(uname)-g++"
   G4LEVELGAMMADATA:         "$GEANT4_ROOT/share/Geant4-10.1.3/data/PhotonEvaporation3.1"
   G4RADIOACTIVEDATA:        "$GEANT4_ROOT/share/Geant4-10.1.3/data/RadioactiveDecay4.2"
   G4LEDATA:                 "$GEANT4_ROOT/share/Geant4-10.1.3/data/G4EMLOW6.41"
@@ -40,10 +40,31 @@ cmake $SOURCEDIR                                    \
   -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"            \
   -DGEANT4_USE_G3TOG4=ON                            \
   -DGEANT4_INSTALL_DATA=ON                          \
-  -DGEANT4_USE_SYSTEM_EXPAT=OFF
+  -DGEANT4_USE_SYSTEM_EXPAT=OFF                     \
+  ${XERCESC_ROOT:+-DGEANT4_USE_OPENGL_X11=ON -DGEANT4_USE_GDML=ON -DXERCESC_ROOT_DIR=$XERCESC_ROOT}
 
 make ${JOBS+-j $JOBS}
 make install
+
+ln -s lib $INSTALLROOT/lib64
+
+#Get data file versions:
+source $INSTALLROOT/bin/geant4.sh
+
+G4LEVELGAMMADATA_NAME=$(basename "$G4LEVELGAMMADATA")
+G4RADIOACTIVEDATA_NAME=$(basename "$G4RADIOACTIVEDATA")
+G4LEDATA_NAME=$(basename "$G4LEDATA")
+G4NEUTRONHPDATA_NAME=$(basename "$G4NEUTRONHPDATA")
+G4NEUTRONXSDATA_NAME=$(basename "$G4NEUTRONXSDATA")
+G4SAIDXSDATA_NAME=$(basename "$G4SAIDXSDATA")
+G4NEUTRONXSDATA_NAME=$(basename "$G4NEUTRONXSDATA")
+G4PIIDATA_NAME=$(basename "$G4PIIDATA")
+G4REALSURFACEDATA_NAME=$(basename "$G4REALSURFACEDATA")
+G4ENSDFSTATEDATA_NAME=$(basename "$G4ENSDFSTATEDATA")
+G4ABLADATA_NAME=$(basename "$G4ABLADATA")
+GEANT4_DATA_VERSION=$(dirname "$G4LEDATA")
+GEANT4_DATA_VERSION=$(dirname "$GEANT4_DATA_VERSION")
+GEANT4_DATA_VERSION=$(basename "$GEANT4_DATA_VERSION")
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
@@ -63,14 +84,18 @@ module load BASE/1.0
 set osname [uname sysname]
 setenv GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv G4INSTALL \$::env(GEANT4_ROOT)
-setenv G4INSTALL_DATA \$::env(GEANT4_ROOT)/share/Geant4-10.1.3
+setenv G4INSTALL_DATA \$::env(GEANT4_ROOT)/share/$GEANT4_DATA_VERSION/data
 setenv G4SYSTEM \$osname-g++
-setenv G4LEVELGAMMADATA \$::env(G4INSTALL_DATA)/data/PhotonEvaporation3.1
-setenv G4RADIOACTIVEDATA  \$::env(G4INSTALL_DATA)/data/RadioactiveDecay4.2
-setenv G4LEDATA \$::env(G4INSTALL_DATA)/data/G4EMLOW6.41
-setenv G4NEUTRONHPDATA \$::env(G4INSTALL_DATA)/data/G4NDL4.5
-setenv G4NEUTRONXSDATA \$::env(G4INSTALL_DATA)/data/G4NEUTRONXS1.4
-setenv G4SAIDXSDATA \$::env(G4INSTALL_DATA)/data/G4SAIDDATA1.1
+setenv G4LEVELGAMMADATA \$::env(G4INSTALL_DATA)/$G4LEVELGAMMADATA_NAME
+setenv G4RADIOACTIVEDATA  \$::env(G4INSTALL_DATA)/$G4RADIOACTIVEDATA_NAME
+setenv G4LEDATA \$::env(G4INSTALL_DATA)/$G4LEDATA_NAME
+setenv G4NEUTRONHPDATA \$::env(G4INSTALL_DATA)/$G4NEUTRONHPDATA_NAME
+setenv G4NEUTRONXSDATA \$::env(G4INSTALL_DATA)/$G4NEUTRONXSDATA_NAME
+setenv G4SAIDXSDATA \$::env(G4INSTALL_DATA)/$G4SAIDXSDATA_NAME
+setenv G4ABLADATA \$::env(G4INSTALL_DATA)/$G4ABLADATA_NAME
+setenv G4PIIDATA \$::env(G4INSTALL_DATA)/G4PIIDATA_NAME
+setenv G4REALSURFACEDATA \$::env(G4INSTALL_DATA)/$G4REALSURFACEDATA_NAME
+setenv G4ENSDFSTATEDATA  \$::env(G4INSTALL_DATA)/$G4ENSDFSTATEDATA_NAME
 prepend-path PATH \$::env(GEANT4_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib")

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -1,0 +1,40 @@
+package: XercesC
+version: v3.1.4
+tag: v3.1.4
+source: https://github.com/ShipSoft/XercesC
+build_requires:
+  - GCC-Toolchain:(?!osx)
+env:
+  XERCESC_INST_DIR: "$XERCESC_ROOT"
+  XERCESCINST: "$XERCESC_ROOT"
+  XERCESCROOT: "$XERCESC_ROOT"
+---
+#!/bin/sh
+
+$SOURCEDIR/configure --prefix=$INSTALLROOT CFLAGS="$CFLAGS" CXXFLAGS="$CFLAGS"
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv XERCESC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv XERCESCROOT \$::env(XERCESC_ROOT)
+setenv XERCESC_INST_DIR \$::env(XERCESC_ROOT)
+setenv XERCESCINST \$::env(XERCESC_ROOT)
+prepend-path PATH \$::env(XERCESC_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(XERCESC_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(XERCESC_ROOT)/lib")
+EoF


### PR DESCRIPTION
This patch adds support for the Python bindings for GEANT4 and it also allows the versions of the GEANT4 data files to be automatically detected. 
Previously the version numbers had to be manually set in the GEANT4 recipe, which effectively restricted the recipe to a single version of GEANT4.