### PR TITLE
Use upgraded aliroot version for alo

### DIFF
--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -43,7 +43,7 @@ overrides:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
   AliRoot:
-    tag: "v5-09-03"
+    tag: "v5-09-10"
   protobuf:
     version: "%(tag_basename)s"
     tag: "v3.0.2"


### PR DESCRIPTION
This is done mainly to account for b61ab70ad6d9ece6e77276e32988551829b93274