### PR TITLE
Avoid conflict with local LHAPDF installation

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -45,7 +45,10 @@ make ${JOBS+-j $JOBS} all
 make install
 
 PDFSETS="cteq6l1 MMHT2014lo68cl MMHT2014nlo68cl"
-$INSTALLROOT/bin/lhapdf install $PDFSETS
+PATH=$INSTALLROOT/bin lhapdf               \
+      --pdfdir=$INSTALLROOT/share/LHAPDF   \
+      --listdir=$INSTALLROOT/share/LHAPDF  \
+      install $PDFSETS
 # Check if PDF sets were really installed
 for P in $PDFSETS; do
   ls $INSTALLROOT/share/LHAPDF/$P


### PR DESCRIPTION
Turns out LHAPDF is particularly stubborn in trying to pick up system
installation, if available. This results in errors when we are trying to
install our own PDF sets. This commit forces installation of PDF pdf
sets to use our own version of lhapdf, lhapdf-config (which was not the
case before) and forces usage of our own `share` path.