### PR TITLE
Boost: Added check for libboost-system and libboost-thread needed for…

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -8,7 +8,7 @@ build_requires:
  - "bz2"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread
 ---
 #!/bin/bash -e
 

--- a/boost.sh
+++ b/boost.sh
@@ -8,7 +8,8 @@ build_requires:
  - "bz2"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread || printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread-mt
+    printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && (printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread || printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread-mt;)
+    if [ $? -ne 0 ]; then printf "One or more boost libraries are missing on your system.\n * On a RHEL-compatible system you probably need: boost-devel\n * On an Ubuntu-like system you probably need: libboost-all-dev"; exit 1; fi
 ---
 #!/bin/bash -e
 

--- a/boost.sh
+++ b/boost.sh
@@ -8,8 +8,8 @@ build_requires:
  - "bz2"
 prefer_system: (?!slc5)
 prefer_system_check: |
-    printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && (printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread || printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread-mt;)
-    if [ $? -ne 0 ]; then printf "One or more boost libraries are missing on your system.\n * On a RHEL-compatible system you probably need: boost-devel\n * On an Ubuntu-like system you probably need: libboost-all-dev"; exit 1; fi
+  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && (printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread || printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread-mt;)
+  if [ $? -ne 0 ]; then printf "One or more boost libraries are missing on your system.\n * On a RHEL-compatible system you probably need: boost-devel\n * On an Ubuntu-like system you probably need: libboost-all-dev"; exit 1; fi
 ---
 #!/bin/bash -e
 

--- a/boost.sh
+++ b/boost.sh
@@ -8,7 +8,7 @@ build_requires:
  - "bz2"
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread
+  printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread || printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread-mt
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
… cgal

Trying to get AliPhysics to compile out of the box on Ubuntu 17.04. Using root 6 and matching all suggested packages by aliDoctor (below) fails in cgal
```bash
==> Building cgal@v4.6.3_ROOT6
==> cgal is being built (use --debug for full output): failed
ERROR: Error while executing /home/pi/alice/sw/SPECS/ubuntu1704_x86-64/cgal/v4.6.3_ROOT6-1/build.sh on `pi'.
ERROR: Log can be found in /home/pi/alice/sw/BUILD/cgal-latest/log.
ERROR: Please attach this file if you intend to request support.
ERROR: Build directory is /home/pi/alice/sw/BUILD/cgal-latest/cgal.
pi@pi:~/alice$ 
```

Reason are missing boost libraries
```bash
CMake Error at /usr/share/cmake-3.7/Modules/FindBoost.cmake:1831 (message):
  Unable to find the requested Boost libraries.

  Boost version: 1.62.0

  Boost include path: /usr/include

  Could not find the following Boost libraries:

          boost_thread
          boost_system

  Some (but not all) of the required Boost libraries were found.  You may
  need to install these additional Boost libraries.  Alternatively, set
  BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT
  to the location of Boost.
```
The system has `libboost-dev` installed but not `libboost-all-dev`. 
# AliDoctor should check for libboost-system and libboost-thread and suggest libboost-all-dev
`alidist/cgal.sh` requires boost. 
This PR adds a check for libboost-system and libboost-thread.

Cheers,
Hans

## Old aliDoctor output 
```bash
pi@pi:~/alice$ aliDoctor --defaults root6 AliPhysics
SUCCESS: Package CMake will be picked up from the system.
SUCCESS: Package GSL will be picked up from the system.
SUCCESS: Required package opengl will be picked up from the system.
SUCCESS: Required package Xdevel will be picked up from the system.
SUCCESS: Package FreeType will be picked up from the system.
SUCCESS: Package Python-modules will be picked up from the system.
SUCCESS: Package GCC-Toolchain will be picked up from the system.
SUCCESS: Package zlib will be picked up from the system.
SUCCESS: Package libxml2 will be picked up from the system.
SUCCESS: Package OpenSSL will be picked up from the system.
SUCCESS: Package boost will be picked up from the system.
SUCCESS: Required package curl will be picked up from the system.
SUCCESS: Package autotools will be picked up from the system.
SUCCESS: Package SWIG will be picked up from the system.
SUCCESS: Required package libperl will be picked up from the system.

==> The following packages will be picked up from the system:
    
    - Python-modules
    - FreeType
    - CMake
    - libxml2
    - SWIG
    - zlib
    - OpenSSL
    - GCC-Toolchain
    - autotools
    - boost
    - GSL
    
    If this is not you want, you have to uninstall / unload them.
pi@pi:~/alice$ 
```
# With added check
On Ubuntu
```bash
 printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread
```
and libboost-all-dev installed
```bash
 SUCCESS: Package boost will be picked up from the system.
```
with libboost-dev but not libboost-all-dev 
```bash
WARNING: Package boost cannot be picked up from the system and will be built by aliBuild.
WARNING: This is due to the fact the following script fails:
WARNING: 
WARNING: brew() { true; }; printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | cc -I$(brew --prefix boost)/include -xc++ - -o /dev/null && printf "int main(){}" | cc -L$(brew --prefix boost)/lib -xc++ - -o /dev/null -lboost_system -lboost_thread
WARNING: 
WARNING: with the following output:
WARNING: 
WARNING: boost: /usr/bin/ld: cannot find -lboost_system
WARNING: boost: /usr/bin/ld: cannot find -lboost_thread
WARNING: boost: collect2: error: ld returned 1 exit status
WARNING: boost: 
WARNING:
```

### Problem 
This does not work on macOS, where the library is called boost_thread-mt

