### PR TITLE
UUID preserve links when copying to installroot

### DIFF
--- a/uuid.sh
+++ b/uuid.sh
@@ -25,9 +25,9 @@ autoreconf -ivf
             --enable-libuuid
 make ${JOBS:+-j$JOBS} libuuid.la
 mkdir -p $INSTALLROOT/lib
-cp -p .libs/libuuid.a* $INSTALLROOT/lib
+cp -a .libs/libuuid.a* $INSTALLROOT/lib
 if [[ ${ARCHITECTURE:0:3} != osx ]]; then
-  cp -p .libs/libuuid.so* $INSTALLROOT/lib
+  cp -a .libs/libuuid.so* $INSTALLROOT/lib
 fi
 mkdir -p $INSTALLROOT/include
 make install-uuidincHEADERS

--- a/uuid.sh
+++ b/uuid.sh
@@ -1,7 +1,7 @@
 package: UUID
 version: v2.27.1
-source: https://github.com/alisw/uuid
 tag: alice/v2.27.1
+source: https://github.com/alisw/uuid
 build_requires:
  - "GCC-Toolchain:(?!osx)"
  - autotools


### PR DESCRIPTION
Addresses #608. Use -a flag of cp instead of -p to preserve links

With wisdom from https://superuser.com/questions/138587/how-to-copy-symbolic-links
I also tried to add links to the --preserve option but as the comments say, --preserve=... doesn't work whereas -a does. Also macOS is happy with the -a flag. 
### Ubuntu 16.04
```bash
cd $ALIEN_RUNTIME_ROOT/lib/ && ls -l libuuid*
-rw-r--r-- 1 hbeck ceres 109164 Aug  9 17:03 libuuid.a
lrwxrwxrwx 1 hbeck ceres     16 Aug  9 17:03 libuuid.so -> libuuid.so.1.3.0
lrwxrwxrwx 1 hbeck ceres     16 Aug  9 17:03 libuuid.so.1 -> libuuid.so.1.3.0
-rwxr-xr-x 1 hbeck ceres  55824 Aug  9 17:03 libuuid.so.1.3.0
```