### PR TITLE
Fix YODA and Rivet issues with Python

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -44,6 +44,8 @@ fi
 
 [[ "$CXXFLAGS" != *'-std=c++11'* ]] || CXX11=1
 
+(
+unset PYTHON_VERSION
 autoreconf -ivf
 ./configure                                 \
   --prefix="$INSTALLROOT"                   \
@@ -56,6 +58,7 @@ autoreconf -ivf
   ${CXX11:+--enable-stdcxx11}
 make -j$JOBS
 make install
+)
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,6 +1,6 @@
 package: YODA
 version: "%(tag_basename)s%(defaults_upper)s"
-tag: "v1.6.3"
+tag: "v1.6.3-alice1"
 source: https://github.com/alisw/yoda
 requires:
   - boost
@@ -13,8 +13,8 @@ prepend_path:
 #!/bin/bash -e
 rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
 
-autoreconf -ivf
-./configure --prefix="$INSTALLROOT" --with-boost="$Boost"
+[[ -e .missing_timestamps ]] && ./missing-timestamps.sh --apply || autoreconf -ivf
+./configure --prefix="$INSTALLROOT"
 make -j$JOBS
 make install
 


### PR DESCRIPTION
* Unset `PYTHON_VERSION` as the same variable is used internally by autotools
  and causes weird behaviours
* Restore autogenerated files timestamps for YODA to allow building using
  generated C templates instead of requiring Cython to regenerate them