### PR TITLE
Fix DDS lookup for system boost

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -10,7 +10,8 @@ tag: "1.4"
 #!/bin/sh
 
 case $ARCHITECTURE in
-  osx*) BOOST_ROOT=$(brew --prefix boost) ;;
+  osx*) 
+    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost` ;;
 esac
 
 cmake $SOURCEDIR                                              \

--- a/dds.sh
+++ b/dds.sh
@@ -1,11 +1,11 @@
 package: DDS
 version: "master-%(short_hash)s"
+tag: "1.4"
 source: https://github.com/FairRootGroup/DDS
 requires:
   - boost
 build_requires:
   - CMake
-tag: "1.4"
 ---
 #!/bin/sh
 


### PR DESCRIPTION
DDS should look for system boost only if the boost `prefer_system_check` was successful (hence BOOST_ROOT is set).