### PR TITLE
Fix #818: remove -g from global compiler flags in o2 defaults

### DIFF
--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -1,8 +1,8 @@
 package: defaults-o2-daq
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O2 -std=c++14"
-  CFLAGS: "-fPIC -g -O2"
+  CXXFLAGS: "-fPIC -O2 -std=c++14"
+  CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 disable:
   - AliEn-Runtime

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -1,8 +1,8 @@
 package: defaults-o2-dev-fairroot
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O2 -std=c++14"
-  CFLAGS: "-fPIC -g -O2"
+  CXXFLAGS: "-fPIC -O2 -std=c++14"
+  CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 disable:
   - AliEn-Runtime

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -1,8 +1,8 @@
 package: defaults-o2
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O2 -std=c++14"
-  CFLAGS: "-fPIC -g -O2"
+  CXXFLAGS: "-fPIC -O2 -std=c++14"
+  CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 disable:
   - AliEn-Runtime


### PR DESCRIPTION
The `-g` can be removed from the global compiler flags because cmake will add it automatically for the build type RELWITHDEBINFO. Having it globally set leads to some problems as described in #818 and https://github.com/alisw/alibuild/issues/434

Fixes #818
Partially addresses also https://github.com/alisw/alibuild/issues/400