### PR TITLE
Fix boost prefer_system_check

### DIFF
--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -24,6 +24,8 @@ overrides:
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python
+    prefer_system_check: |
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 && BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -23,6 +23,8 @@ overrides:
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python
+    prefer_system_check: |
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 && BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -23,6 +23,8 @@ overrides:
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python
+    prefer_system_check: |
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 && BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -11,20 +11,18 @@ overrides:
   autotools:
     tag: v1.5.0
   boost:
+    tag: "v1.64.0-alice1"
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python
+    prefer_system_check: |
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 && BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |
       set -e
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
-  boost:
-    tag: "v1.64.0-alice1"
-    requires:
-      - "GCC-Toolchain:(?!osx)"
-      - Python
   ROOT:
     tag: "v6-10-02"
     source: https://github.com/root-mirror/root


### PR DESCRIPTION
Newer boost versions also require newer CMake versions, they need to be upgraded
at the same time. For O2, we are forcing boost to be exactly version 1.64.