### PR TITLE
Common-O2 goes to v0.3.0

### DIFF
--- a/common-o2.sh
+++ b/common-o2.sh
@@ -1,6 +1,6 @@
 package: Common-O2
 version: "%(tag_basename)s"
-tag: v0.2.0
+tag: v0.3.0
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
This is to be compatible with the latest repositories extraction from FlpPrototype.