### PR TITLE
Provide C++11 Guideline Support Library; Use in O2

### DIFF
--- a/ms_gsl.sh
+++ b/ms_gsl.sh
@@ -1,0 +1,12 @@
+package: ms_gsl
+version: "1"
+source: https://github.com/Microsoft/GSL.git
+tag: b014508
+---
+#!/bin/bash -e
+
+# recipe for the C++ guidelines support library (Microsoft implementation)
+# can be deleted once we are fully C++17 compliant
+
+# just rsync into the installdir since header only
+rsync -a $SOURCEDIR/include $INSTALLROOT

--- a/ms_gsl.sh
+++ b/ms_gsl.sh
@@ -1,7 +1,7 @@
 package: ms_gsl
 version: "1"
-source: https://github.com/Microsoft/GSL.git
 tag: b014508
+source: https://github.com/Microsoft/GSL.git
 ---
 #!/bin/bash -e
 

--- a/o2.sh
+++ b/o2.sh
@@ -6,6 +6,7 @@ requires:
   - DDS
   - Vc
   - hijing
+  - ms_gsl
 source: https://github.com/AliceO2Group/AliceO2
 prepend_path:
   ROOT_INCLUDE_PATH: "$O2_ROOT/include"
@@ -76,6 +77,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                            \
       ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}  \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}   \
+      -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                   \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 if [[ $GIT_TAG == master ]]; then


### PR DESCRIPTION
This provides the C++ guidelines support library with useful
features such as span (array_view) on containers.
We can use this until we are fully C++17 compliant.