### PR TITLE
Add tentative CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,7 @@ configuration* @alisw/daq-experts
 datasampling* @alisw/daq-experts
 daq* @alisw/daq-experts
 monitoring* @alisw/daq-experts
+infologger* @alisw/daq-experts
 
 # PWGMM
 agile* @alisw/pwgmm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,30 @@
+# Everything has to be approved by ALICE Offline admins
+* @alisw/alice-offline-admins
+
+# DAQ stuff
+readout* @alisw/daq-experts
+configuration* @alisw/daq-experts
+datasampling* @alisw/daq-experts
+daq* @alisw/daq-experts
+monitoring* @alisw/daq-experts
+
+# PWGMM
+agile* @alisw/pwgmm
+aligenerators* @alisw/pwgmm
+crmc* @alisw/pwgmm
+epos* @alisw/pwgmm
+hepmc* @alisw/pwgmm
+jewel* @alisw/pwgmm
+lhapdf* @alisw/pwgmm
+powheg* @alisw/pwgmm
+pythia* @alisw/pwgmm
+rivet* @alisw/pwgmm
+sherpa* @alisw/pwgmm
+thepeg* @alisw/pwgmm
+yoda* @alisw/pwgmm
+
+# Simulation
+geant* @alisw/simulation-experts
+vmc* @alisw/simulation-experts
+vgm* @alisw/simulation-experts
+vecgeom* @alisw/simulation-experts


### PR DESCRIPTION
This introduces a tentative CODEOWNERS file so that sub-groups (e.g. DAQ) can review and eventually approve PRs only affecting their code. Coupled with successful tests, this could result in a PR to `alidist` to be automatically merged.