### PR TITLE
Fix defaults

### DIFF
--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -41,6 +41,7 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - libxml2
+      - "GCC-Toolchain:(?!osx)"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -41,6 +41,7 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - libxml2
+      - "GCC-Toolchain:(?!osx)"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -33,6 +33,7 @@ overrides:
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
       - Python-modules
+      - "GCC-Toolchain:(?!osx)"
   AliRoot:
     requires:
       - ROOT

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -6,7 +6,6 @@ env:
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 disable:
   - AliEn-Runtime
-  - AliRoot
 overrides:
   autotools:
     tag: v1.5.0

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -22,6 +22,7 @@ overrides:
       - Xdevel:(?!osx)
       - FreeType:(?!osx)
       - Python-modules
+      - "GCC-Toolchain:(?!osx)"
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null


### PR DESCRIPTION
This PR supersedes old PR #759.

It achieves:
* correct compilation of ROOT6 when we use defaults (which needs to depend on GCC_TOOLCHAIN)
* does not forbid the compilation of O2 and AliRoot using the same default
   - this is very important to do cross comparisons/tuning of simulation for instance