### PR TITLE
fix usage of system libprotobuf

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -44,6 +44,14 @@ esac
 
 [[ $BOOST_ROOT ]] && BOOST_NO_SYSTEM_PATHS=ON || BOOST_NO_SYSTEM_PATHS=OFF
 
+if [ -n "$PROTOBUF_ROOT" ]; then
+    PROTOBUF_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc
+    PROTOBUF_LIB=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME
+else
+    PROTOBUF_EXECUTABLE=`which protoc`
+    PROTOBUF_LIB=libprotobuf.$SONAME
+fi
+
 cmake $SOURCEDIR                                                 \
       -DMACOSX_RPATH=OFF                                         \
       -DCMAKE_CXX_FLAGS="$CXXFLAGS"                              \
@@ -66,8 +74,8 @@ cmake $SOURCEDIR                                                 \
       ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                           \
       -DGTEST_ROOT=$GOOGLETEST_ROOT                              \
       -DPROTOBUF_INCLUDE_DIR=$PROTOBUF_ROOT/include              \
-      -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc     \
-      -DPROTOBUF_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME  \
+      -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_EXECUTABLE          \
+      -DPROTOBUF_LIBRARY=$PROTOBUF_LIBRARY                       \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 # Limit the number of build processes to avoid exahusting memory when building

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -44,38 +44,30 @@ esac
 
 [[ $BOOST_ROOT ]] && BOOST_NO_SYSTEM_PATHS=ON || BOOST_NO_SYSTEM_PATHS=OFF
 
-if [ -n "$PROTOBUF_ROOT" ]; then
-    PROTOBUF_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc
-    PROTOBUF_LIB=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME
-else
-    PROTOBUF_EXECUTABLE=`which protoc`
-    PROTOBUF_LIB=libprotobuf.$SONAME
-fi
-
-cmake $SOURCEDIR                                                 \
-      -DMACOSX_RPATH=OFF                                         \
-      -DCMAKE_CXX_FLAGS="$CXXFLAGS"                              \
-      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}  \
-      -DROOTSYS=$ROOTSYS                                         \
-      -DROOT_CONFIG_SEARCHPATH=$ROOT_ROOT/bin                    \
-      ${NANOMSG_ROOT:+-DNANOMSG_DIR=$NANOMSG_ROOT}               \
-      -DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib                    \
-      -DGeant3_DIR=$GEANT3_ROOT                                  \
-      -DDISABLE_GO=ON                                            \
-      -DBUILD_EXAMPLES=OFF                                       \
-      ${GEANT4_ROOT:+-DGeant4_DIR=$GEANT4_ROOT}                  \
-      -DFAIRROOT_MODULAR_BUILD=ON                                \
-      ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                          \
-      ${ZEROMQ_ROOT:+-DZEROMQ_ROOT=$ZEROMQ_ROOT}                 \
-      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                    \
-      ${BOOST_ROOT:+-DBOOST_INCLUDEDIR=$BOOST_ROOT/include}      \
-      ${BOOST_ROOT:+-DBOOST_LIBRARYDIR=$BOOST_ROOT/lib}          \
-      -DBoost_NO_SYSTEM_PATHS=${BOOST_NO_SYSTEM_PATHS}           \
-      ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                           \
-      -DGTEST_ROOT=$GOOGLETEST_ROOT                              \
-      -DPROTOBUF_INCLUDE_DIR=$PROTOBUF_ROOT/include              \
-      -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_EXECUTABLE          \
-      -DPROTOBUF_LIBRARY=$PROTOBUF_LIBRARY                       \
+cmake $SOURCEDIR                                                                  \
+      -DMACOSX_RPATH=OFF                                                          \
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS"                                               \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}                   \
+      -DROOTSYS=$ROOTSYS                                                          \
+      -DROOT_CONFIG_SEARCHPATH=$ROOT_ROOT/bin                                     \
+      ${NANOMSG_ROOT:+-DNANOMSG_DIR=$NANOMSG_ROOT}                                \
+      -DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib                                     \
+      -DGeant3_DIR=$GEANT3_ROOT                                                   \
+      -DDISABLE_GO=ON                                                             \
+      -DBUILD_EXAMPLES=OFF                                                        \
+      ${GEANT4_ROOT:+-DGeant4_DIR=$GEANT4_ROOT}                                   \
+      -DFAIRROOT_MODULAR_BUILD=ON                                                 \
+      ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                                           \
+      ${ZEROMQ_ROOT:+-DZEROMQ_ROOT=$ZEROMQ_ROOT}                                  \
+      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                                     \
+      ${BOOST_ROOT:+-DBOOST_INCLUDEDIR=$BOOST_ROOT/include}                       \
+      ${BOOST_ROOT:+-DBOOST_LIBRARYDIR=$BOOST_ROOT/lib}                           \
+      -DBoost_NO_SYSTEM_PATHS=${BOOST_NO_SYSTEM_PATHS}                            \
+      ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                                            \
+      -DGTEST_ROOT=$GOOGLETEST_ROOT                                               \
+      -DPROTOBUF_INCLUDE_DIR=$(dirname $(which protoc))/../include                \
+      -DPROTOBUF_PROTOC_EXECUTABLE=$(which protoc)                                \
+      -DPROTOBUF_LIBRARY=$(dirname $(which protoc))/../lib/libprotobuf.$SONAME    \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 # Limit the number of build processes to avoid exahusting memory when building

--- a/o2.sh
+++ b/o2.sh
@@ -59,41 +59,33 @@ case $ARCHITECTURE in
   *) SONAME=so ;;
 esac
 
-if [ -n "$PROTOBUF_ROOT" ]; then
-    PROTOBUF_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc
-    PROTOBUF_LIB=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME
-else
-    PROTOBUF_EXECUTABLE=`which protoc`
-    PROTOBUF_LIB=`which protoc | sed "s,bin/protoc,lib/libprotobuf.$SONAME,"`
-fi
-
 # For the PR checkers (which sets ALIBUILD_O2_TESTS)
 # we impose -Werror as a compiler flag
 if [[ $ALIBUILD_O2_TESTS ]]; then
   CXXFLAGS="${CXXFLAGS} -Werror"
 fi
-cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                              \
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                           \
       -DCMAKE_MODULE_PATH="$SOURCEDIR/cmake/modules;$FAIRROOT_ROOT/share/fairbase/cmake/modules;$FAIRROOT_ROOT/share/fairbase/cmake/modules_old"  \
-      -DFairRoot_DIR=$FAIRROOT_ROOT                               \
-      -DALICEO2_MODULAR_BUILD=ON                                  \
-      -DROOTSYS=$ROOTSYS                                          \
-      ${PYTHIA6_ROOT:+-DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib}    \
-      ${GEANT3_ROOT:+-DGeant3_DIR=$GEANT3_ROOT}                   \
-      ${GEANT4_ROOT:+-DGeant4_DIR=$GEANT4_ROOT}                   \
-      -DFAIRROOTPATH=$FAIRROOT_ROOT                               \
-      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                     \
-      ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                           \
-      -DZMQ_DIR=$ZEROMQ_ROOT                                      \
-      -DZMQ_INCLUDE_DIR=$ZEROMQ_ROOT/include                      \
-      ${ALIROOT_VERSION:+-DALIROOT=$ALIROOT_ROOT}                 \
-      -DPROTOBUF_INCLUDE_DIR=$PROTOBUF_ROOT/include               \
-      -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_EXECUTABLE           \
-      -DPROTOBUF_LIBRARY=$PROTOBUF_LIB                            \
-      ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                            \
-      ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}  \
-      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}   \
-      -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                   \
-      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                          \
+      -DFairRoot_DIR=$FAIRROOT_ROOT                                            \
+      -DALICEO2_MODULAR_BUILD=ON                                               \
+      -DROOTSYS=$ROOTSYS                                                       \
+      ${PYTHIA6_ROOT:+-DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib}                 \
+      ${GEANT3_ROOT:+-DGeant3_DIR=$GEANT3_ROOT}                                \
+      ${GEANT4_ROOT:+-DGeant4_DIR=$GEANT4_ROOT}                                \
+      -DFAIRROOTPATH=$FAIRROOT_ROOT                                            \
+      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                                  \
+      ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                                        \
+      -DZMQ_DIR=$ZEROMQ_ROOT                                                   \
+      -DZMQ_INCLUDE_DIR=$ZEROMQ_ROOT/include                                   \
+      ${ALIROOT_VERSION:+-DALIROOT=$ALIROOT_ROOT}                              \
+      -DPROTOBUF_INCLUDE_DIR=$(dirname $(which protoc))/../include             \
+      -DPROTOBUF_PROTOC_EXECUTABLE=$(which protoc)                             \
+      -DPROTOBUF_LIBRARY=$(dirname $(which protoc))/../lib/libprotobuf.$SONAME \
+      ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                                         \
+      ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}               \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}                \
+      -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                                \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                       \
       ${O2HLTCATRACKING_VERSION:+-DO2_TPCCA_TRACKING_LIB_DIR=$O2HLTCATRACKING_ROOT}
 
 if [[ $GIT_TAG == master ]]; then

--- a/o2.sh
+++ b/o2.sh
@@ -59,6 +59,14 @@ case $ARCHITECTURE in
   *) SONAME=so ;;
 esac
 
+if [ -n "$PROTOBUF_ROOT" ]; then
+    PROTOBUF_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc
+    PROTOBUF_LIB=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME
+else
+    PROTOBUF_EXECUTABLE=`which protoc`
+    PROTOBUF_LIB=`which protoc | sed "s,bin/protoc,lib/libprotobuf.$SONAME,"`
+fi
+
 # For the PR checkers (which sets ALIBUILD_O2_TESTS)
 # we impose -Werror as a compiler flag
 if [[ $ALIBUILD_O2_TESTS ]]; then
@@ -77,10 +85,10 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                           \
       -DZMQ_DIR=$ZEROMQ_ROOT                                      \
       -DZMQ_INCLUDE_DIR=$ZEROMQ_ROOT/include                      \
-      ${ALIROOT_VERSION:+-DALIROOT=$ALIROOT_ROOT}                \
+      ${ALIROOT_VERSION:+-DALIROOT=$ALIROOT_ROOT}                 \
       -DPROTOBUF_INCLUDE_DIR=$PROTOBUF_ROOT/include               \
-      -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc      \
-      -DPROTOBUF_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME   \
+      -DPROTOBUF_PROTOC_EXECUTABLE=$PROTOBUF_EXECUTABLE           \
+      -DPROTOBUF_LIBRARY=$PROTOBUF_LIB                            \
       ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                            \
       ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}  \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}   \


### PR DESCRIPTION
Recreate pull request after rebase on master (somehow the forced push closed it...):

Compilation with system protobuf does not work because PROTOBUF_ROOT is empty, but the strings PROTOBUF_LIBRARY and PROTOBUF_PROTOC_EXECUTABLE contain absolute paths, which in that case lead e.g. to /bin/protoc, but that executable does not exist.

This patch checks for the empty string, and removes the absolute patch.
For the binary, it uses which to find the correct patch.

For O2, there is the additional problem that O2 needs an absolut patch to the library in the build process.
The patch treats this by modifying the which protoc patch, which is probably not ideal, but I do not see what the script should do better. Ideally, one could improve the O2 build process to use a proper FindProtobuf cmake module or so.