### PR TITLE
Allow protobuf 2.6 as system package

### DIFF
--- a/protobuf.sh
+++ b/protobuf.sh
@@ -6,7 +6,7 @@ build_requires:
  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"
 prefer_system_check: |
-  printf "#include \"google/protobuf/any.h\"\nint main(){}" | c++ -I$(brew --prefix protobuf)/include -Wno-deprecated-declarations -xc++ - -o /dev/null
+  printf "#include \"google/protobuf/message.h\"\nint main(){}" | c++ -I$(brew --prefix protobuf)/include -Wno-deprecated-declarations -xc++ - -o /dev/null
 ---
 
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .


### PR DESCRIPTION
Current version only works for protobuf 3+, while we compile 2.6 in our own recipe.