### PR TITLE
Version bump to v1.2, fix header that makes o2 compilation on MacOS f…

### DIFF
--- a/o2hltcatracking.sh
+++ b/o2hltcatracking.sh
@@ -1,6 +1,6 @@
 package: O2HLTCATracking
 version: "%(tag_basename)s"
-tag: hlt_o2_ca_tracking-v1.1
+tag: hlt_o2_ca_tracking-v1.2
 source: https://github.com/davidrohr/AliRoot
 requires:
   - GCC-Toolchain:(?!osx)


### PR DESCRIPTION
…ail, use new version of track fit, some bug fixes and improvements

@sawenzel : Can you test this on Mac. We need a version bump because the AliRoot header breaks the compilation of O2 on Mac.