### PR TITLE
Follow recent FairRoot requirement: cmake 3.9.4

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -53,9 +53,9 @@ overrides:
     version: "%(short_hash)s%(defaults_upper)s"
   CMake:
     version: "%(tag_basename)s"
-    tag: "v3.8.2"
+    tag: "v3.9.4"
     prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-7].*) exit 1 ;; esac
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-8].*|3.9.[0-3]) exit 1 ;; esac
   FairRoot:
     version: dev
     tag: dev


### PR DESCRIPTION
Latest update in FairRoot breaks the O2 CI, newer cmake is now
required (was at 3.8.2), see
https://github.com/FairRootGroup/FairRoot/pull/659
Boost is already at 1.64 in our recipies