### PR TITLE
Make GCC_TOOLCHAING a dependency for hijing

### DIFF
--- a/hijing.sh
+++ b/hijing.sh
@@ -3,6 +3,8 @@ package: hijing
 version: "%(tag_basename)s"
 tag: "v1.36"
 source: https://github.com/alisw/hijing.git
+requires:
+  - GCC-Toolchain:(?!osx)
 build_requires:
   - CMake
 


### PR DESCRIPTION
Fixing a problem where building hijing could pick up a different compiler than the rest of the software stack
due to a missing explicit dependency on GCC-Toolchain.