### PR TITLE
 Make GCC_TOOLCHAING a dependency for pythia6

### DIFF
--- a/pythia6.sh
+++ b/pythia6.sh
@@ -3,6 +3,8 @@ package: pythia6
 version: "%(tag_basename)s"
 tag: "428-alice1"
 source: https://github.com/alisw/pythia6.git
+requires:
+  - GCC-Toolchain:(?!osx)
 build_requires:
   - CMake
 ---


### PR DESCRIPTION
Fixing a problem where building pythia6 could pick up a different compiler than the rest of the software stack
due to a missing explicit dependency on GCC-Toolchain.