### PR TITLE
Make defaults-o2-dev-fairroot build simulation and take true dev branch

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -7,14 +7,6 @@ env:
 disable:
   - AliEn-Runtime
   - AliRoot
-  - simulation
-  - generators
-  - GEANT4
-  - GEANT3
-  - GEANT4_VMC
-  - pythia
-  - pythia6
-  - hijing
 overrides:
   autotools:
     tag: v1.5.0
@@ -59,6 +51,7 @@ overrides:
   FairRoot:
     version: dev
     tag: dev
+    source: https://github.com/FairRootGroup/FairRoot
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
We have the o2-dev-fairroot default in order to compile against the head of the FairRoot dev branch, -- in particular to detect problems with the dev branch early before we adopt it.

This commit extends the scope of such builds to include simulation/reco which otherwise would not be checked.

This commit also makes sure that we actually compile the true dev branch and not a potentially outdated branch of our fork.