### PR TITLE
Update defaults-o2.sh to use required cmake 3.9.4

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -50,9 +50,9 @@ overrides:
     tag: "v3.0.2"
   CMake:
     version: "%(tag_basename)s"
-    tag: "v3.8.2"
+    tag: "v3.9.4"
     prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-7].*) exit 1 ;; esac
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-8].*|3.9.[0-3]) exit 1 ;; esac
   AliRoot:
     version: "%(commit_hash)s_O2"
   AliPhysics:


### PR DESCRIPTION
This change is (urgently) needed to build against new FairRoot. It is a straight copy of the fix already applied to defaults-o2-dev-fairroot.sh (by @matthiasrichter).