### PR TITLE
Update defaults-o2-daq.sh to use cmake 3.9.4.

### DIFF
--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -51,9 +51,9 @@ overrides:
     tag: "v3.0.2"
   CMake:
     version: "%(tag_basename)s"
-    tag: "v3.8.2"
+    tag: "v3.9.4"
     prefer_system_check: |
-      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-7].*) exit 1 ;; esac
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-8].*|3.9.[0-3]) exit 1 ;; esac
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
 ---


### PR DESCRIPTION
This change is required by new FairRoot and is a straight copy of the already applied fix in defaults-o2-dev-fairroot.sh.