### PR TITLE
Add protections and dependencies to configuration.sh, system option for grpc.sh, protobuf to grpc.sh modulefile

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -9,6 +9,7 @@ requires:
   - grpc
   - Common-O2
   - MySQL
+  - RapidJSON
 build_requires:
   - CMake
 source: https://github.com/AliceO2Group/Configuration
@@ -28,6 +29,10 @@ cmake $SOURCEDIR                                              \
       ${BOOST_ROOT:+-DBoost_DIR=$BOOST_ROOT}                  \
       ${BOOST_ROOT:+-DBoost_INCLUDE_DIR=$BOOST_ROOT/include}  \
       ${COMMON_O2_VERSION:+-DCommon_ROOT=$COMMON_O2_ROOT}     \
+      -DPROTOBUF_INCLUDE_DIR=${PROTOBUF_ROOT}/include         \
+      -DPROTOBUF_LIBRARY=${PROTOBUF_ROOT}/lib/libprotobuf.so  \
+      ${GRPC_ROOT:+-DGRPC_ROOT=${GRPC_ROOT}}                  \
+      -DRAPIDJSON_INCLUDEDIR=${RAPIDJSON_ROOT}/include        \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS} install
@@ -48,7 +53,7 @@ module load BASE/1.0                                                          \\
             ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
             ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION} \\
             ${GRPC_VERSION:+grpc/$GRPC_VERSION-$GRPC_REVISION}                \\
-            ${COMMON_O2_VERSION:+Common-O2/$COMMON_O2_VERSION-$COMMON_O2_REVISION}
+            Common-O2/$COMMON_O2_VERSION-$COMMON_O2_REVISION
 
 # Our environment
 setenv Configuration_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/configuration.sh
+++ b/configuration.sh
@@ -47,8 +47,8 @@ module load BASE/1.0                                                          \\
             ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}            \\
             ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
             ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION} \\
-            grpc/$GRPC_VERSION-$GRPC_REVISION                                 \\
-            Common-O2/$COMMON_O2_VERSION-$COMMON_O2_REVISION
+            ${GRPC_VERSION:+grpc/$GRPC_VERSION-$GRPC_REVISION}                \\
+            ${COMMON_O2_VERSION:+Common-O2/$COMMON_O2_VERSION-$COMMON_O2_REVISION}
 
 # Our environment
 setenv Configuration_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/grpc.sh
+++ b/grpc.sh
@@ -1,11 +1,11 @@
 package: grpc
 version: "%(tag_basename)s"
+tag:  v1.2.5
 requires:
   - protobuf
 build_requires:
   - "GCC-Toolchain:(?!osx)"
 source: https://github.com/grpc/grpc
-tag:  v1.2.5
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/grpc.sh
+++ b/grpc.sh
@@ -31,7 +31,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0 ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
 # Our environment
 prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
 prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib

--- a/grpc.sh
+++ b/grpc.sh
@@ -6,6 +6,8 @@ requires:
 build_requires:
   - "GCC-Toolchain:(?!osx)"
 source: https://github.com/grpc/grpc
+prefer_system: "(?!slc5)"
+prefer_system_check: which grpc_cpp_plugin
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
@@ -31,7 +33,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
+module load BASE/1.0
 # Our environment
 prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
 prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib


### PR DESCRIPTION
PR for addressing the comments in #897 

1. in grpc.sh you say you depend on protobuf, but then protobuf is not mentioned in the modulefile below. If someone picks up only grpc he will be in trouble.
2. grpc.sh is not pickable from the system, which would be nice.
3. If the above is done, then you need to protect configuration.sh against it.

I think I've done points 1 and 3, but I'm not sure how to do 2.