### PR TITLE
Add tags for o2 and ROOT6 to root version in defaults files

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -23,7 +23,7 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "v6-10-06+git_%(short_hash)s"
+    version: "v6-10-06+git_%(short_hash)s_O2"
     tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
     source: https://github.com/root-mirror/root
     requires:

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -13,7 +13,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    version: "v6-10-06+git_%(short_hash)s"
+    version: "v6-10-06+git_%(short_hash)s_ROOT6"
     tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
     source: https://github.com/root-mirror/root
     requires:


### PR DESCRIPTION
Fixes #919 (ROOT6 versions from different defaults currently
overwrite each other in case they use the same sw directory).