### PR TITLE
Lower CMake requirement on SHUTTLE

### DIFF
--- a/defaults-shuttle.sh
+++ b/defaults-shuttle.sh
@@ -17,6 +17,10 @@ overrides:
       - ROOT
     build_requires:
       - CMake
+  CMake:
+    prefer_system_check: |
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-1]*|2.[0-7].*|2.8.[0-9]|2.8.1[0-1]) exit 1 ;; esac
+
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
SHUTTLE nodes only require v2.8.12, let's not build our own.