### PR TITLE
Add new defaults for prod and user installation

### DIFF
--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -1,0 +1,23 @@
+package: defaults-prod-latest
+version: v1
+env:
+  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CFLAGS: "-fPIC -g -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+overrides:
+  AliRoot:
+    version: v5-09-19
+    tag: v5-09-19
+  AliPhysics:
+    version: v5-09-19-01
+    tag: v5-09-19-01
+---
+# To be used with aliBuild option `--defaults prod-latest`.
+#
+# This is the default set used to produce centralized builds of AliRoot and
+# AliPhysics, with pinpointed versions.
+#
+#   * It is recommended on user laptops to use `--defaults user` instead, which
+#     pinpoints AliRoot and AliPhysics versions.
+#   * Continuous integration tests use this defaults to test AliPhysics changes
+#     against the latest tagged version of AliRoot.

--- a/defaults-prod.sh
+++ b/defaults-prod.sh
@@ -1,0 +1,15 @@
+package: defaults-prod
+version: v1
+env:
+  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CFLAGS: "-fPIC -g -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+---
+# To be used with aliBuild option `--defaults prod`.
+#
+# This is the default set used to produce centralized builds of AliRoot and
+# AliPhysics.
+#
+#   * It is recommended on user laptops to use `--defaults user` instead
+#   * If someone needs to use AliRoot/AliPhysics with GEANT3, 4 or DPMJET then
+#     they can use this defaults set.

--- a/defaults-user.sh
+++ b/defaults-user.sh
@@ -1,0 +1,29 @@
+package: defaults-user
+version: v1
+env:
+  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CFLAGS: "-fPIC -g -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+overrides:
+  AliRoot:
+    version: v5-09-19
+    tag: v5-09-19
+    requires:
+      - ROOT
+      - fastjet:(?!.*ppc64)
+      - Vc
+  AliPhysics:
+    version: v5-09-19-01
+    tag: v5-09-19-01
+---
+# To be used with aliBuild option `--defaults user`.
+#
+# This defaults set is meant to be used on user computers.
+#
+#   * Builds AliRoot and AliPhysics without GEANT3, 4 and DPMJET, which fits
+#     most of the use cases and speeds up compilation time dramatically
+#   * Pinpoints AliRoot and AliPhysics to their latest tags, but they will be
+#     overridden by using packages in development mode
+#
+# This defaults set will become the default and will replace "release" at some
+# point.


### PR DESCRIPTION
This is a first implementation of #921. It has to be discussed before merging.

Three new defaults are introduced (thus, for the moment, not affecting the `release` one):

* `prod`: to be used in place of `release` for centralized Run 2 builds
* `user`: to be used on user laptops (has GEANT* and DPMJET disabled)
* `prod-latest`: to be used for continuous integration (for testing AliPhysics PRs against the latest tagged version of AliRoot instead of, or along with, master)

In a future iteration, and after proper discussion, `user` will be renamed to `release`, becoming the default for every installation. Central installations in the meanwhile should be using `prod`.

One more TODO enhancement the usage of ROOT 6 on platforms not supporting ROOT 5 any longer (such as macOS High Sierra).