### PR TITLE
Disable AliEn explicitly for DAQ DA builds

### DIFF
--- a/defaults-daq.sh
+++ b/defaults-daq.sh
@@ -22,6 +22,10 @@ overrides:
     build_requires:
       - DAQ
       - CMake
+  ROOT:
+    requires: []
+    build_requires:
+      - CMake
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/root.sh
+++ b/root.sh
@@ -61,7 +61,6 @@ if [[ $ALICE_DAQ ]]; then
     --enable-soversion                  \
     --enable-builtin-freetype           \
     --enable-builtin-pcre               \
-    --enable-mathmore                   \
     --with-f77=gfortran                 \
     --with-cc=$COMPILER_CC              \
     --with-cxx=$COMPILER_CXX            \
@@ -72,44 +71,46 @@ if [[ $ALICE_DAQ ]]; then
     --disable-globus                    \
     --disable-krb5                      \
     --disable-ssl                       \
+    --disable-alien                     \
     --enable-mysql
-  FEATURES="builtin_freetype builtin_pcre mathmore minuit2 pythia6 roofit
+  FEATURES="builtin_freetype builtin_pcre minuit2 pythia6 roofit
             soversion ${CXX11:+cxx11} ${CXX14:+cxx14} mysql xml"
+  NO_FEATURES="ssl alien"
 else
   # Normal ROOT build.
-  cmake $SOURCEDIR                                                \
-        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                      \
-        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                       \
-        ${ALIEN_RUNTIME_ROOT:+-Dalien=ON}                         \
-        ${ALIEN_RUNTIME_ROOT:+-DALIEN_DIR=$ALIEN_RUNTIME_ROOT}    \
-        ${ALIEN_RUNTIME_ROOT:+-DMONALISA_DIR=$ALIEN_RUNTIME_ROOT} \
-        ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$ALIEN_RUNTIME_ROOT}     \
-        ${CXX11:+-Dcxx11=ON}                                      \
-        ${CXX14:+-Dcxx14=ON}                                      \
-        -Dfreetype=ON                                             \
-        -Dbuiltin_freetype=OFF                                    \
-        -Dpcre=OFF                                                \
-        -Dbuiltin_pcre=ON                                         \
-        ${ENABLE_COCOA:+-Dcocoa=ON}                               \
-        -DCMAKE_CXX_COMPILER=$COMPILER_CXX                        \
-        -DCMAKE_C_COMPILER=$COMPILER_CC                           \
-        -DCMAKE_LINKER=$COMPILER_LD                               \
+  cmake $SOURCEDIR                                                                       \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                                             \
+        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                              \
+        ${ALIEN_RUNTIME_ROOT:+-Dalien=ON}                                                \
+        ${ALIEN_RUNTIME_ROOT:+-DALIEN_DIR=$ALIEN_RUNTIME_ROOT}                           \
+        ${ALIEN_RUNTIME_ROOT:+-DMONALISA_DIR=$ALIEN_RUNTIME_ROOT}                        \
+        ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$ALIEN_RUNTIME_ROOT}                            \
+        ${CXX11:+-Dcxx11=ON}                                                             \
+        ${CXX14:+-Dcxx14=ON}                                                             \
+        -Dfreetype=ON                                                                    \
+        -Dbuiltin_freetype=OFF                                                           \
+        -Dpcre=OFF                                                                       \
+        -Dbuiltin_pcre=ON                                                                \
+        ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
+        -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
+        -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \
+        -DCMAKE_LINKER=$COMPILER_LD                                                      \
         ${GCC_TOOLCHAIN_VERSION:+-DCMAKE_EXE_LINKER_FLAGS="-L$GCC_TOOLCHAIN_ROOT/lib64"} \
-        ${OPENSSL_ROOT:+-DOPENSSL_ROOT=$ALIEN_RUNTIME_ROOT}       \
-        ${SYS_OPENSSL_ROOT:+-DOPENSSL_ROOT=$SYS_OPENSSL_ROOT}     \
-        ${SYS_OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIR=$SYS_OPENSSL_ROOT/include}  \
-        ${LIBXML2_ROOT:+-DLIBXML2_ROOT=$ALIEN_RUNTIME_ROOT}       \
-        ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                          \
-        -Dpgsql=OFF                                               \
-        -Dminuit2=ON                                              \
-        -Dpythia6_nolink=ON                                       \
-        -Droofit=ON                                               \
-        -Dhttp=ON                                                 \
-        -Droot7=OFF                                               \
-        -Dsoversion=ON                                            \
-        -Dshadowpw=OFF                                            \
-        -Dvdt=ON                                                  \
-        -Dbuiltin_vdt=ON                                          \
+        ${OPENSSL_ROOT:+-DOPENSSL_ROOT=$ALIEN_RUNTIME_ROOT}                              \
+        ${SYS_OPENSSL_ROOT:+-DOPENSSL_ROOT=$SYS_OPENSSL_ROOT}                            \
+        ${SYS_OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIR=$SYS_OPENSSL_ROOT/include}             \
+        ${LIBXML2_ROOT:+-DLIBXML2_ROOT=$ALIEN_RUNTIME_ROOT}                              \
+        ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                                                 \
+        -Dpgsql=OFF                                                                      \
+        -Dminuit2=ON                                                                     \
+        -Dpythia6_nolink=ON                                                              \
+        -Droofit=ON                                                                      \
+        -Dhttp=ON                                                                        \
+        -Droot7=OFF                                                                      \
+        -Dsoversion=ON                                                                   \
+        -Dshadowpw=OFF                                                                   \
+        -Dvdt=ON                                                                         \
+        -Dbuiltin_vdt=ON                                                                 \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}


### PR DESCRIPTION
AliEn is not needed. We make sure we don't accidentally pick it up if available from the system.