### PR TITLE
Change version: field in O2 for daily builds

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -1,5 +1,5 @@
 package: O2
-version: dev
+version: "%(tag_basename)s"
 tag: dev
 requires:
   - FairRoot


### PR DESCRIPTION
This change has absolutely no effect on existing installations but it's used for daily O2 builds.