### PR TITLE
Fixes for integrating O2 nightlies on CVMFS

### DIFF
--- a/agile.sh
+++ b/agile.sh
@@ -7,7 +7,7 @@ requires:
   - boost
   - lhapdf5
   - HepMC
-  - Python
+  - Python-modules
 build_requires:
   - autotools
 ---

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -43,6 +43,8 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - libxml2
+      - libpng
+      - lzma
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -33,8 +33,8 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "v6-10-06+git_%(short_hash)s"
-    tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
+    version: "%(tag_basename)s"
+    tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
       - GSL

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -23,7 +23,7 @@ overrides:
     tag: "v1.64.0-alice1"
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - Python-modules
     prefer_system_check: |
       printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:

--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -24,6 +24,8 @@ overrides:
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
+      - libpng
+      - lzma
     prefer_system_check: |
       printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:

--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -35,8 +35,8 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "v6-10-06+git_%(short_hash)s"
-    tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
+    version: "%(tag_basename)s"
+    tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
       - GSL

--- a/defaults-o2-daq.sh
+++ b/defaults-o2-daq.sh
@@ -23,7 +23,7 @@ overrides:
     tag: "v1.64.0-alice1"
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - Python-modules
     prefer_system_check: |
       printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -15,7 +15,7 @@ overrides:
     tag: "v1.64.0-alice1"
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - Python-modules
     prefer_system_check: |
       printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -16,6 +16,8 @@ overrides:
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
+      - libpng
+      - lzma
     prefer_system_check: |
       printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -27,8 +27,8 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "v6-10-06+git_%(short_hash)s"
-    tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
+    version: "%(tag_basename)s"
+    tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
       - GSL

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -14,7 +14,7 @@ overrides:
     tag: "v1.64.0-alice1"
     requires:
       - "GCC-Toolchain:(?!osx)"
-      - Python
+      - Python-modules
     prefer_system_check: |
       printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -24,8 +24,8 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "v6-10-06+git_%(short_hash)s"
-    tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
+    version: "%(tag_basename)s"
+    tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -35,6 +35,8 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - "GCC-Toolchain:(?!osx)"
+      - libpng
+      - lzma
   AliRoot:
     requires:
       - ROOT

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -24,6 +24,8 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - "GCC-Toolchain:(?!osx)"
+      - libpng
+      - lzma
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -13,8 +13,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    version: "v6-10-06+git_%(short_hash)s"
-    tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
+    tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/defaults-user-root6.sh
+++ b/defaults-user-root6.sh
@@ -17,8 +17,8 @@ overrides:
     tag: v5-09-20-01
   ROOT:
     version: "%(tag_basename)s"
-    version: "v6-10-06+git_%(short_hash)s"
-    tag: "c54db1c10b19b05f157dc44078b45edd9f38c741"
+    version: "%(tag_basename)s"
+    tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/lzma.sh
+++ b/lzma.sh
@@ -1,0 +1,45 @@
+package: lzma
+version: "%(tag_basename)s"
+tag: "v5.2.3"
+source: https://github.com/alisw/liblzma
+build_requires:
+  - autotools
+  - "GCC-Toolchain:(?!osx)"
+prefer_system: "(?!slc5)"
+prefer_system_check: |
+  printf "#include <lzma.h>\n" | gcc -xc++ - -c -M 2>&1
+---
+#!/bin/bash -e
+
+rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
+./autogen.sh
+./configure CFLAGS="$CFLAGS -fPIC -Ofast" \
+            --prefix="$INSTALLROOT"       \
+            --disable-static              \
+            --disable-nls                 \
+            --disable-rpath               \
+            --disable-dependency-tracking \
+            --disable-doc
+make ${JOBS+-j $JOBS} install
+rm -f "$INSTALLROOT"/lib/*.la
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv LZMA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
+EoF

--- a/mesos.sh
+++ b/mesos.sh
@@ -1,12 +1,12 @@
 package: mesos
 version: v0.28.2
-source: https://git-wip-us.apache.org/repos/asf/mesos.git
 tag: 0.28.2
+source: https://git-wip-us.apache.org/repos/asf/mesos.git
 build_requires:
 - autotools
 - protobuf
 - glog
-- Python
+- Python-modules
 prepend_path:
   PATH: "$MESOS_ROOT/sbin"
   PYTHONPATH: $MESOS_ROOT/lib/python2.7/site-packages

--- a/root.sh
+++ b/root.sh
@@ -111,11 +111,11 @@ else
         -Dshadowpw=OFF                                                                   \
         -Dvdt=ON                                                                         \
         -Dbuiltin_vdt=ON                                                                 \
-        -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT"
+        -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}
             ${ALIEN_RUNTIME_ROOT:+alien monalisa}"
-  NO_FEATURES="root7"
+  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png}"
 
   if [[ $ENABLE_COCOA ]]; then
     FEATURES="$FEATURES builtin_freetype"
@@ -163,7 +163,9 @@ module load BASE/1.0 ${ALIEN_RUNTIME_ROOT:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-
                      ${GSL_VERSION:+GSL/$GSL_VERSION-$GSL_REVISION}                                             \\
                      ${FREETYPE_VERSION:+FreeType/$FREETYPE_VERSION-$FREETYPE_REVISION}                         \\
                      ${PYTHON_VERSION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
-                     ${PYTHON_MODULES_VERSION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}
+                     ${PYTHON_MODULES_VERSION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION} \\
+                     ${LIBPNG_VERSION:+libpng/$LIBPNG_VERSION-$LIBPNG_REVISION}                                 \\
+                     ${LZMA_VERSION:+lzma/$LZMA_VERSION-$LZMA_REVISION}
 # Our environment
 setenv ROOT_RELEASE \$version
 setenv ROOT_BASEDIR \$::env(BASEDIR)/$PKGNAME

--- a/root.sh
+++ b/root.sh
@@ -111,11 +111,13 @@ else
         -Dshadowpw=OFF                                                                   \
         -Dvdt=ON                                                                         \
         -Dbuiltin_vdt=ON                                                                 \
+        -Dkrb5=OFF                                                                       \
+        -Dldap=OFF                                                                       \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}
             ${ALIEN_RUNTIME_ROOT:+alien monalisa}"
-  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png}"
+  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 ldap"
 
   if [[ $ENABLE_COCOA ]]; then
     FEATURES="$FEATURES builtin_freetype"

--- a/sacrifice.sh
+++ b/sacrifice.sh
@@ -7,7 +7,7 @@ requires:
   - boost
   - lhapdf
   - HepMC
-  - Python
+  - Python-modules
   - pythia
 build_requires:
   - autotools


### PR DESCRIPTION
Those fixes are necessary for such integration. For CVMFS builds, we pick all packages from our recipes and we don't use "system" packages at all, and this causes some problems: this is one of the points being addressed.

**Note:** this is a WIP at the moment, do not merge!

The only recipe depending on Python should be Python-modules itself.