### PR TITLE
Harden support for spaces in paths

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -29,7 +29,7 @@ incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   cd $INSTALLROOT/test
-  env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH make ${JOBS+-j$JOBS}
+  env PATH="$INSTALLROOT/bin:$PATH" LD_LIBRARY_PATH="$INSTALLROOT/lib:$LD_LIBRARY_PATH" DYLD_LIBRARY_PATH="$INSTALLROOT/lib:$DYLD_LIBRARY_PATH" make ${JOBS+-j$JOBS}
 ---
 #!/bin/bash -e
 unset ROOTSYS


### PR DESCRIPTION
While it's reasonable to ask users not to have spaces in the `--work-dir`, they might be not in control of PATH / LD_LIBRARY_PATH / DYLD_LIBRARY_PATH, so we should probably protect ourself at least for those.