### PR TITLE
Deactivate ppconsul on Mac

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -9,7 +9,7 @@ requires:
   - grpc
   - Common-O2
   - RapidJSON
-  - Ppconsul
+  - "Ppconsul:(?!osx)"
   - "MySQL:slc.*"
 build_requires:
   - CMake


### PR DESCRIPTION
It does not compile on Mac at the moment and is used by Configuration for the tests with Consul. If we use consul in the future we need to use a different interface.