### PR TITLE
Set CMAKE_BUILD_TYPE=COVERAGE for lcov dependencies

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -49,8 +49,6 @@ overrides:
     build_requires:
       - ms_gsl
       - lcov
-    env:
-      CMAKE_BUILD_TYPE: COVERAGE
   CMake:
     version: "%(tag_basename)s"
     tag: "v3.9.4"

--- a/lcov.sh
+++ b/lcov.sh
@@ -2,6 +2,8 @@ package: lcov
 version: v1.13
 tag: v1.13
 source: https://github.com/linux-test-project/lcov.git
+env:
+  CMAKE_BUILD_TYPE=COVERAGE
 ---
 #!/bin/sh
 rsync -av $SOURCEDIR/ $BUILDDIR/


### PR DESCRIPTION
The env stanza is for variables which need to be set in the
build dependencies, not in the recipe itself. Therefore we
make sure that CMAKE_BUILD_TYPE=COVERAGE is done in the lcov
recipe, which will set it to all its dependencies.