### PR TITLE
Bump ROOT 5 to a GCC7-compat version

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: v5-34-30-alice8
+tag: v5-34-30-alice9
 source: https://github.com/alisw/root
 requires:
   - AliEn-Runtime:(?!.*ppc64)


### PR DESCRIPTION
Still not to be merged. The aim is to make ROOT 5 builds compatible with GCC v7.