### PR TITLE
Explicit disable of unused options, add ALIBUILD_ROOT_CMAKE_ADDOPTS env var for user customisation of ROOT build

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -130,6 +130,7 @@ else
         -Dfftw3=OFF                                                                      \
         -Ddcache=OFF                                                                     \
         -Doracle=OFF                                                                     \
+        -Dfitsio=OFF                                                                     \
         ${ALIBUILD_ROOT_CMAKE_ADDOPTS:+${ALIBUILD_ROOT_CMAKE_ADDOPTS}}                   \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http

--- a/root.sh
+++ b/root.sh
@@ -124,7 +124,6 @@ else
         -Dgfal=OFF                                                                       \
         -Dcastor=OFF                                                                     \
         -Drfio=OFF                                                                       \
-        -Dodbc=OFF                                                                       \
         -Ddcache=OFF                                                                     \
         -Doracle=OFF                                                                     \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"

--- a/root.sh
+++ b/root.sh
@@ -89,6 +89,7 @@ else
         -Dbuiltin_freetype=OFF                                                           \
         -Dpcre=OFF                                                                       \
         -Dbuiltin_pcre=ON                                                                \
+        -Dasimage=ON                                                                     \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -122,6 +122,8 @@ else
         -Dbonjour=OFF                                                                    \
         -Dglobus=OFF                                                                     \
         -Dgfal=OFF                                                                       \
+        -Dcastor=OFF                                                                     \
+        -Drfio=OFF                                                                       \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -119,6 +119,7 @@ else
         -Dldap=OFF                                                                       \
         -Dgviz=OFF                                                                       \
         -Ddavix=OFF                                                                      \
+        -Dbonjour=OFF                                                                    \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -124,6 +124,7 @@ else
         -Dgfal=OFF                                                                       \
         -Dcastor=OFF                                                                     \
         -Drfio=OFF                                                                       \
+        -Dodbc=OFF                                                                       \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -91,7 +91,6 @@ else
         -Dbuiltin_pcre=ON                                                                \
         -Dasimage=ON                                                                     \
         -Dbuiltin_afterimage=ON                                                          \
-        -Dbuiltin_ftgl=ON                                                                \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -128,6 +128,7 @@ else
         -Dodbc=OFF                                                                       \
         -Dsqlite=OFF                                                                     \
         -Dfftw3=OFF                                                                      \
+        -Ddcache=OFF                                                                     \
         ${ALIBUILD_ROOT_CMAKE_ADDOPTS:+${ALIBUILD_ROOT_CMAKE_ADDOPTS}}                   \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http

--- a/root.sh
+++ b/root.sh
@@ -125,6 +125,7 @@ else
         -Dcastor=OFF                                                                     \
         -Drfio=OFF                                                                       \
         -Dodbc=OFF                                                                       \
+        -Dsqlite=OFF                                                                     \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -120,6 +120,7 @@ else
         -Dgviz=OFF                                                                       \
         -Ddavix=OFF                                                                      \
         -Dbonjour=OFF                                                                    \
+        -Dglobus=OFF                                                                     \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -126,7 +126,6 @@ else
         -Drfio=OFF                                                                       \
         -Dodbc=OFF                                                                       \
         -Dsqlite=OFF                                                                     \
-        -Dfftw3=OFF                                                                      \
         -Ddcache=OFF                                                                     \
         -Doracle=OFF                                                                     \
         -Dfitsio=OFF                                                                     \

--- a/root.sh
+++ b/root.sh
@@ -129,6 +129,7 @@ else
         -Dsqlite=OFF                                                                     \
         -Dfftw3=OFF                                                                      \
         -Ddcache=OFF                                                                     \
+        -Doracle=OFF                                                                     \
         ${ALIBUILD_ROOT_CMAKE_ADDOPTS:+${ALIBUILD_ROOT_CMAKE_ADDOPTS}}                   \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http

--- a/root.sh
+++ b/root.sh
@@ -112,6 +112,7 @@ else
         ${ALIEN_RUNTIME_VERSION:+-Dmonalisa=ON}                                          \
         -Dkrb5=OFF                                                                       \
         -Dldap=OFF                                                                       \
+        -Dgviz=OFF                                                                       \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -125,7 +125,7 @@ else
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}
             ${ALIEN_RUNTIME_ROOT:+alien monalisa}"
-  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 ldap"
+  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 ldap gviz"
 
   if [[ $ENABLE_COCOA ]]; then
     FEATURES="$FEATURES builtin_freetype"

--- a/root.sh
+++ b/root.sh
@@ -91,6 +91,7 @@ else
         -Dbuiltin_pcre=ON                                                                \
         -Dasimage=ON                                                                     \
         -Dbuiltin_afterimage=ON                                                          \
+        -Dbuiltin_ftgl=ON                                                                \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -76,7 +76,6 @@ if [[ $ALICE_DAQ ]]; then
   NO_FEATURES="ssl alien"
 else
   # Normal ROOT build.
-  [[ -n "${ALIBUILD_ROOT_CMAKE_ADDOPTS}" ]] && echo -ne "\n\nALIBUILD_ROOT_CMAKE_ADDOPTS is set!!\n>>>>>>>   User customization of aliBuild root cmake is enabled!   <<<<<<<\n\n"
   cmake $SOURCEDIR                                                                       \
         -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                                             \
         -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                              \
@@ -131,7 +130,6 @@ else
         -Ddcache=OFF                                                                     \
         -Doracle=OFF                                                                     \
         -Dfitsio=OFF                                                                     \
-        ${ALIBUILD_ROOT_CMAKE_ADDOPTS:+${ALIBUILD_ROOT_CMAKE_ADDOPTS}}                   \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -113,14 +113,6 @@ else
         -Dkrb5=OFF                                                                       \
         -Dldap=OFF                                                                       \
         -Dgviz=OFF                                                                       \
-        -Ddavix=OFF                                                                      \
-        -Dbonjour=OFF                                                                    \
-        -Dglobus=OFF                                                                     \
-        -Dgfal=OFF                                                                       \
-        -Dcastor=OFF                                                                     \
-        -Drfio=OFF                                                                       \
-        -Ddcache=OFF                                                                     \
-        -Doracle=OFF                                                                     \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -118,6 +118,7 @@ else
         -Dkrb5=OFF                                                                       \
         -Dldap=OFF                                                                       \
         -Dgviz=OFF                                                                       \
+        -Ddavix=OFF                                                                      \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -76,6 +76,7 @@ if [[ $ALICE_DAQ ]]; then
   NO_FEATURES="ssl alien"
 else
   # Normal ROOT build.
+  [[ -n "${ALIBUILD_ROOT_CMAKE_ADDOPTS}" ]] && echo -ne "\n\nALIBUILD_ROOT_CMAKE_ADDOPTS is set!!\n>>>>>>>   User customization of aliBuild root cmake is enabled!   <<<<<<<\n\n"
   cmake $SOURCEDIR                                                                       \
         -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                                             \
         -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                              \
@@ -127,6 +128,7 @@ else
         -Dodbc=OFF                                                                       \
         -Dsqlite=OFF                                                                     \
         -Dfftw3=OFF                                                                      \
+        ${ALIBUILD_ROOT_CMAKE_ADDOPTS:+${ALIBUILD_ROOT_CMAKE_ADDOPTS}}                   \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -127,7 +127,6 @@ else
         -Dodbc=OFF                                                                       \
         -Ddcache=OFF                                                                     \
         -Doracle=OFF                                                                     \
-        -Dfitsio=OFF                                                                     \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -90,6 +90,7 @@ else
         -Dpcre=OFF                                                                       \
         -Dbuiltin_pcre=ON                                                                \
         -Dasimage=ON                                                                     \
+        -Dbuiltin_afterimage=ON                                                          \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -93,7 +93,6 @@ else
         -Dbuiltin_afterimage=ON                                                          \
         -Dbuiltin_ftgl=ON                                                                \
         -Dbuiltin_glew=ON                                                                \
-        -Dbuiltin_lzma=ON                                                                \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -125,7 +125,6 @@ else
         -Dcastor=OFF                                                                     \
         -Drfio=OFF                                                                       \
         -Dodbc=OFF                                                                       \
-        -Dsqlite=OFF                                                                     \
         -Ddcache=OFF                                                                     \
         -Doracle=OFF                                                                     \
         -Dfitsio=OFF                                                                     \

--- a/root.sh
+++ b/root.sh
@@ -93,6 +93,7 @@ else
         -Dbuiltin_afterimage=ON                                                          \
         -Dbuiltin_ftgl=ON                                                                \
         -Dbuiltin_glew=ON                                                                \
+        -Dbuiltin_lzma=ON                                                                \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -126,6 +126,7 @@ else
         -Drfio=OFF                                                                       \
         -Dodbc=OFF                                                                       \
         -Dsqlite=OFF                                                                     \
+        -Dfftw3=OFF                                                                      \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -121,6 +121,7 @@ else
         -Ddavix=OFF                                                                      \
         -Dbonjour=OFF                                                                    \
         -Dglobus=OFF                                                                     \
+        -Dgfal=OFF                                                                       \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/root.sh
+++ b/root.sh
@@ -89,7 +89,6 @@ else
         -Dbuiltin_freetype=OFF                                                           \
         -Dpcre=OFF                                                                       \
         -Dbuiltin_pcre=ON                                                                \
-        -Dasimage=ON                                                                     \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -90,7 +90,6 @@ else
         -Dpcre=OFF                                                                       \
         -Dbuiltin_pcre=ON                                                                \
         -Dasimage=ON                                                                     \
-        -Dbuiltin_afterimage=ON                                                          \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -92,6 +92,7 @@ else
         -Dasimage=ON                                                                     \
         -Dbuiltin_afterimage=ON                                                          \
         -Dbuiltin_ftgl=ON                                                                \
+        -Dbuiltin_glew=ON                                                                \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \

--- a/root.sh
+++ b/root.sh
@@ -92,7 +92,6 @@ else
         -Dasimage=ON                                                                     \
         -Dbuiltin_afterimage=ON                                                          \
         -Dbuiltin_ftgl=ON                                                                \
-        -Dbuiltin_glew=ON                                                                \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \


### PR DESCRIPTION
To have identical builds it would be best to disable all options that are not used and have overall a tight control on build options. A safeguard is added as an environment variable named ALIBUILD_ROOT_CMAKE_ADDOPTS that, if defined, will add its content to cmake options.
Tested on an "Christmas tree" EL7 installation, no other options beside the intended were picked up. 