### PR TITLE
Version Bump of O2 TPC CA Tracking Library to v1.6

### DIFF
--- a/o2hltcatracking.sh
+++ b/o2hltcatracking.sh
@@ -1,6 +1,6 @@
 package: O2HLTCATracking
 version: "%(tag_basename)s"
-tag: hlt_o2_ca_tracking-v1.5
+tag: hlt_o2_ca_tracking-v1.6
 source: https://github.com/davidrohr/AliRoot
 requires:
   - GCC-Toolchain:(?!osx)


### PR DESCRIPTION
Version bump, with fixes for O2 TPC tracking. @brinick : could you please merge before tomorrow evening.