### PR TITLE
Rename o2-daq to o2-dataflow in the spirit of O2

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -1,4 +1,4 @@
-package: defaults-o2-daq
+package: defaults-o2-dataflow
 version: v1
 env:
   CXXFLAGS: "-fPIC -O2 -std=c++14"

--- a/o2.sh
+++ b/o2.sh
@@ -54,7 +54,7 @@ incremental_recipe: |
   fi
 valid_defaults:
   - o2
-  - o2-daq
+  - o2-dataflow
   - o2-dev-fairroot
   - alo
   - o2-prod


### PR DESCRIPTION
@vascobarroso as requested, this PR makes the naming convention more compliant with the spirit of O2.

Here's a checklist of things to do:

- [ ] Update the continuous integration
- [ ] Update documentation, alisw/alibuild#521
- [x] Change the recipes
- [x] Update [Grafana interface](https://alisw.cern.ch/dashboard/) to exclude `o2-daq`