### PR TITLE
O2 PR checks : Fix a problem due to unused but installed files

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -16,6 +16,11 @@ source: https://github.com/AliceO2Group/AliceO2
 prepend_path:
   ROOT_INCLUDE_PATH: "$O2_ROOT/include"
 incremental_recipe: |
+  # In incremental mode we need to clean the installation area, because we might otherwise
+  # accumulate unused libs/dictionaries which cause 'duplicate symbol' errors in ROOT
+  # leading to failing PR checks
+  find $INSTALLROOT -mindepth 1 -exec rm -r -f {} ';'
+
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   # install the compilation database so that we can post-check the code


### PR DESCRIPTION
Currently, all PR checks of https://github.com/AliceO2Group/AliceO2 fail because the O2 installation directory is not cleaned and it keeps old files from previous installations.

This PR solves the issue by manually making sure the installation directory is emptied before attempting a new incremental build.

Note that this will not affect users who just remake in the build directory without using the incremental build mechanism of AliBuild.