### PR TITLE
Update AMPT version

### DIFF
--- a/ampt.sh
+++ b/ampt.sh
@@ -1,6 +1,6 @@
 package: AMPT
 version: "%(tag_basename)s"
-tag: "alice/v1.26t7-v2.26t7"
+tag: "v1.26t7-v2.26t7-alice1"
 source: https://github.com/alisw/ampt
 requires:
  - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
@rbertens: with fix for HIJING

We would then need a new version of AMPT deployed to cvmfs.