### PR TITLE
Version bump to v1.7

### DIFF
--- a/o2hltcatracking.sh
+++ b/o2hltcatracking.sh
@@ -1,7 +1,7 @@
 package: O2HLTCATracking
 version: "%(tag_basename)s"
-tag: hlt_o2_ca_tracking-v1.6
-source: https://github.com/davidrohr/AliRoot
+tag: hlt_o2_ca_tracking-v1.7
+source: https://github.com/alisw/AliRoot
 requires:
   - GCC-Toolchain:(?!osx)
 build_requires:


### PR DESCRIPTION
@brinick : Hi, this is now the alidist version bump to the new tracking library version that is now taken from the official alisw/AliRoot repository instead of the private one.