### PR TITLE
Disable ApMon-CPP in o2-dataflow defaults

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -8,6 +8,7 @@ env:
 disable:
   - AliEn-Runtime
   - AliRoot
+  - ApMon-CPP
   - simulation
   - generators
   - GEANT4


### PR DESCRIPTION
`ApMon-CPP` is planed to be used only in the Grid.