### PR TITLE
Fix long shebangs in Python executables

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -76,7 +76,13 @@ for U in https://bootstrap.pypa.io/get-pip.py \
   curl -kSsL -o get-pip.py $U || continue && break
 done
 python get-pip.py
-pip install -U pip
+python "$INSTALLROOT/bin/pip" install -U pip
+
+# Remove long shebangs (by default max is 128 chars on Linux)
+pushd "$INSTALLROOT/bin"
+  sed -i.deleteme -e "1 s|^#!${INSTALLROOT}/bin/\(.*\)$|#!/usr/bin/env \1|" * || true
+  rm -f *.deleteme
+popd
 
 # Remove useless stuff
 rm -rvf $INSTALLROOT/share \


### PR DESCRIPTION
Python installation and setuptools produce by default Python scripts with the
full `python` executable path in the shebang. In some cases, on our installation
directories, that shebang exceeds 128 chars in length (max lenght on most
Linuxes), resulting in a "bad interpreter" error.

Since in our case we always have `python` in our environment, we now replace
every generated shebang with the shorter `/usr/bin/env python`.

We have noticed that this hack is not needed for the Python-modules package.

This complements #907.