### PR TITLE
[WIP] Disable unreliable multicore Python builds

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -63,7 +63,7 @@ fi
             --with-system-expat   \
             --with-system-ffi     \
             --enable-unicode=ucs4
-make ${JOBS:+-j$JOBS}
+make  # no multicore
 make install
 
 # Install pip


### PR DESCRIPTION
We've found out that Python builds fail at random for Python versions < 3.4.
It seems that making them in single-core solves the problem.

We're currently testing it, *do not merge yet*.