### PR TITLE
Disable problematic SSL in CMake

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -23,6 +23,9 @@ SET(Java_JAVAC_EXECUTABLE FALSE CACHE BOOL "" FORCE)
 # but cmake is not smart enough to find it. We do not really need ccmake anyway,
 # so just disable it.
 SET(BUILD_CursesDialog FALSE CACHE BOOL "" FORCE)
+
+# OpenSSL is problematic
+set(CMAKE_USE_OPENSSL FALSE CACHE BOOL "" FORCE)
 EOF
 
 $SOURCEDIR/bootstrap --prefix=$INSTALLROOT \


### PR DESCRIPTION
It seems that CMake decides to link to SSL libraries which might not be
available at a later time under certain conditions.

This should solve the problems with O2 pull request tests.