### PR TITLE
Bump FastJet to v3.2.1_1.024-alice3

### DIFF
--- a/fastjet.sh
+++ b/fastjet.sh
@@ -1,6 +1,6 @@
 package: fastjet
 version: "%(tag_basename)s"
-tag: "v3.2.1_1.024-alice2"
+tag: "v3.2.1_1.024-alice3"
 source: https://github.com/alisw/fastjet
 requires:
   - cgal


### PR DESCRIPTION
Fixes an occasional problem with relocation on macOS: alisw/fastjet#2