### PR TITLE
Bump boost to 1.66 for O2

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -62,7 +62,7 @@ b2 -q                        \
 # inside the same directory as the main ones, on macOS (@loader_path).
 if [[ $ARCHITECTURE == osx* ]]; then
   for LIB in $INSTALLROOT/lib/libboost*.dylib; do
-    otool -L $LIB | grep -v $(basename $LIB) | grep -oE 'libboost_[^ ]+' | \
+    otool -L $LIB | grep -v $(basename $LIB) | { grep -oE 'libboost_[^ ]+' || true; } | \
       xargs -I{} install_name_tool -change {} @loader_path/{} "$LIB"
   done
 fi

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -24,12 +24,12 @@ overrides:
   autotools:
     tag: v1.5.0
   boost:
-    tag: "v1.64.0-alice1"
+    tag: "v1.66.0"
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
     prefer_system_check: |
-      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106600 || BOOST_VERSION > 106699)\n#error \"Cannot use system's boost: boost 1.66 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -22,14 +22,14 @@ overrides:
   autotools:
     tag: v1.5.0
   boost:
-    tag: "v1.64.0-alice1"
+    tag: "v1.66.0"
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
       - libpng
       - lzma
     prefer_system_check: |
-      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106600 || BOOST_VERSION > 106699)\n#error \"Cannot use system's boost: boost 1.66 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -12,14 +12,14 @@ overrides:
   autotools:
     tag: v1.5.0
   boost:
-    tag: "v1.64.0-alice1"
+    tag: "v1.66.0"
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
       - libpng
       - lzma
     prefer_system_check: |
-      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106600 || BOOST_VERSION > 106699)\n#error \"Cannot use system's boost: boost 1.66 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2-prod.sh
+++ b/defaults-o2-prod.sh
@@ -11,12 +11,12 @@ overrides:
   autotools:
     tag: v1.5.0
   boost:
-    tag: "v1.64.0-alice1"
+    tag: "v1.66.0"
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
     prefer_system_check: |
-      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106600 || BOOST_VERSION > 106699)\n#error \"Cannot use system's boost: boost 1.66 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -14,12 +14,12 @@ overrides:
   autotools:
     tag: v1.5.0
   boost:
-    tag: "v1.64.0-alice1"
+    tag: "v1.66.0"
     requires:
       - "GCC-Toolchain:(?!osx)"
       - Python-modules
     prefer_system_check: |
-      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106400 || BOOST_VERSION > 106499)\n#error \"Cannot use system's boost: boost 1.64 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+      printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 106600 || BOOST_VERSION > 106699)\n#error \"Cannot use system's boost: boost 1.66 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
   GCC-Toolchain:
     tag: v6.2.0-alice1
     prefer_system_check: |


### PR DESCRIPTION
Fix a problem in `@loader_path` relocation on macOS too