### PR TITLE
Remove SWIG from Common deps

### DIFF
--- a/common-o2.sh
+++ b/common-o2.sh
@@ -6,7 +6,6 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
-  - SWIG
 source: https://github.com/AliceO2Group/Common
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
@@ -17,7 +16,6 @@ incremental_recipe: |
 case $ARCHITECTURE in
     osx*) 
       [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-      [[ ! $SWIG_ROOT ]] && SWIG_ROOT=$(brew --prefix swig)
     ;;
 esac
 


### PR DESCRIPTION
SWIG was added to `Common` as the TCL wrap file was supposed to be generated via CMake. As it's still not the case I propose to remove it.