### PR TITLE
Bump GEANT4_VMC to tag v3-5-p1 for O2

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -65,7 +65,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p1"
     source: https://github.com/vmc-project/geant4_vmc
   vgm:
     tag: "v4-4"

--- a/defaults-o2-prod.sh
+++ b/defaults-o2-prod.sh
@@ -67,7 +67,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p1"
     source: https://github.com/vmc-project/geant4_vmc
   vgm:
     tag: "v4-4"

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -70,7 +70,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p1"
     source: https://github.com/vmc-project/geant4_vmc
   vgm:
     tag: "v4-4"


### PR DESCRIPTION
Needed for O2 simulation as fixing a problem with empty event handling in Geant4_VMC.