### PR TITLE
Fix googlebenchmark support in O2

### DIFF
--- a/googlebenchmark.sh
+++ b/googlebenchmark.sh
@@ -6,9 +6,30 @@ build_requires:
  - "GCC-Toolchain:(?!osx)"
  - CMake
 ---
-#!/bin/sh
+#!/bin/bash -e
 cmake $SOURCEDIR                           \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT  \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}
 make ${JOBS+-j $JOBS}
 make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv GOOGLEBENCHMARK_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(GOOGLEBENCHMARK_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GOOGLEBENCHMARK_ROOT)/lib")
+EoF
+

--- a/o2.sh
+++ b/o2.sh
@@ -11,9 +11,9 @@ requires:
   - Configuration
   - Monitoring
   - ms_gsl
-  - googlebenchmark
 build_requires:
   - RapidJSON
+  - googlebenchmark
 source: https://github.com/AliceO2Group/AliceO2
 prepend_path:
   ROOT_INCLUDE_PATH: "$O2_ROOT/include"


### PR DESCRIPTION
* Make `googlebenchmark` a build requirement: it produces a static library
  therefore it is not needed at runtime
* Add a Modulefile for `googlebenchmark` for completeness