### PR TITLE
Integrate Apache Arrow v0.9.0

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -1,45 +1,56 @@
 package: arrow
-version: v0.8.0
-tag: apache-arrow-0.8.0
-source: https://github.com/apache/arrow
+version: v0.9.0-alice1
+tag: apache-arrow-0.9.0-alice1
+source: https://github.com/alisw/arrow
 requires:
-  - flatbuffers
   - boost
 build_requires:
- - CMake
- - "GCC-Toolchain:(?!osx)"
+  - zlib
+  - flatbuffers
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 mkdir -p $INSTALLROOT
 case $ARCHITECTURE in
   osx*)
     # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $FLATBUFFERS_ROOT ]] && FLATBUFFERS_ROOT=`brew --prefix flatbuffers`
-    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
+    [[ ! $FLATBUFFERS_ROOT ]] && FLATBUFFERS_ROOT=$(brew --prefix flatbuffers)
+    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
   ;;
 esac
 
-FLATBUFFERS_HOME=$FLATBUFFERS_ROOT            \
-cmake $SOURCEDIR/cpp                          \
-      -DARROW_BUILD_BENCHMARKS=OFF            \
-      -DARROW_BUILD_TESTS=OFF                 \
-      -DARROW_JEMALLOC=OFF                    \
-      -DARROW_HDFS=OFF                        \
-      -DARROW_IPC=OFF                         \
-      -DARROW_USE_SSE=ON                      \
-      -DARROW_WITH_LZ4=ON                     \
-      -DARROW_WITH_SNAPPY=OFF                 \
-      -DARROW_WITH_GRPC=OFF                   \
-      -DARROW_WITH_ZSTD=ON                    \
-      -DARROW_WITH_ZLIB=ON                    \
-      -DARROW_NO_DEPRECATED_API=ON            \
-      -DBOOST_ROOT=$BOOST_ROOT                \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \
+# Downloaded by CMake, built, and linked statically (not needed at runtime):
+#   zlib, lz4, brotli
+#
+# Taken from our stack, linked statically (not needed at runtime):
+#   flatbuffers
+#
+# Taken from our stack, linked dynamically (needed at runtime):
+#   boost
+
+cmake $SOURCEDIR/cpp                       \
+      -DARROW_BUILD_BENCHMARKS=OFF         \
+      -DARROW_BUILD_TESTS=OFF              \
+      -DARROW_JEMALLOC=OFF                 \
+      -DARROW_HDFS=OFF                     \
+      -DARROW_IPC=ON                       \
+      -DFLATBUFFERS_HOME=$FLATBUFFERS_ROOT \
+      -DARROW_USE_SSE=ON                   \
+      -DARROW_WITH_LZ4=ON                  \
+      -DARROW_WITH_SNAPPY=OFF              \
+      -DARROW_WITH_GRPC=OFF                \
+      -DARROW_WITH_ZSTD=OFF                \
+      -DARROW_WITH_ZLIB=ON                 \
+      -DARROW_NO_DEPRECATED_API=ON         \
+      -DBOOST_ROOT=$BOOST_ROOT             \
+      -DARROW_WITH_BROTLI=ON               \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT  \
       -DARROW_PYTHON=OFF
 
 make ${JOBS:+-j $JOBS}
 make install
 
-#ModuleFil
+# Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
@@ -52,10 +63,9 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION} ${FLATBUFFERS_VERSION:+flatbuffers/${FLATBUFFERS_VERSION}-${FLATBUFFERS_REVISION}}
+module load BASE/1.0 ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}
 # Our environment
 setenv ARROW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(ARROW_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ARROW_ROOT)/lib")
-prepend-path PATH \$::env(ARROW_ROOT)/bin
 EoF

--- a/flatbuffers.sh
+++ b/flatbuffers.sh
@@ -10,15 +10,19 @@ prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include \"flatbuffers/flatbuffers.h\"\nint main(){}" | c++ -I$(brew --prefix flatbuffers)/include -xc++ -std=c++11 - -o /dev/null
 ---
-mkdir -p $INSTALLROOT
 cmake $SOURCEDIR                          \
       -G "Unix Makefiles"                 \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
-
 make ${JOBS:+-j $JOBS}
 make install
 
-#ModuleFile
+# Work around potentially faulty CMake (missing `install` for binaries)
+mkdir -p $INSTALLROOT/bin
+for BIN in flathash flatc flatsamplebinary flatsampletext flattests; do
+  [[ -e $INSTALLROOT/bin/$BIN ]] || cp -p $BIN $INSTALLROOT/bin/
+done
+
+# Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
@@ -34,6 +38,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${ZLIB_VERSION:+zlib/${ZLIB_VERSION}-${ZLIB_REVISION}}
 # Our environment
 setenv FLATBUFFERS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(FLATBUFFERS_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(FLATBUFFERS_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FLATBUFFERS_ROOT)/lib")
 prepend-path PATH \$::env(FLATBUFFERS_ROOT)/bin

--- a/o2.sh
+++ b/o2.sh
@@ -2,6 +2,7 @@ package: O2
 version: "%(tag_basename)s"
 tag: dev
 requires:
+  - arrow
   - FairRoot
   - DDS
   - Vc
@@ -45,7 +46,7 @@ incremental_recipe: |
     rm -rf coverage.info
     lcov --base-directory $SOURCEDIR --directory . --capture --output-file coverage.info
     lcov --remove coverage.info '*/usr/*' --output-file coverage.info
-    lcov --remove coverage.info '*/boost/*' --output-file coverage.info 
+    lcov --remove coverage.info '*/boost/*' --output-file coverage.info
     lcov --remove coverage.info '*/ROOT/*' --output-file coverage.info
     lcov --remove coverage.info '*/FairRoot/*' --output-file coverage.info
     lcov --remove coverage.info '*/G__*Dict*' --output-file coverage.info
@@ -119,6 +120,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${MONITORING_VERSION:+-DMonitoring_ROOT=$MONITORING_ROOT}                             \
       ${CONFIGURATION_VERSION:+-DConfiguration_ROOT=$CONFIGURATION_ROOT}                    \
       -DRAPIDJSON_INCLUDEDIR=${RAPIDJSON_ROOT}/include                                      \
+      ${ARROW_VERSION:+-DARROW_HOME=$ARROW_ROOT}                                            \
       -Dbenchmark_DIR=${GOOGLEBENCHMARK_ROOT}/lib/cmake/benchmark
 
 if [[ $GIT_TAG == master ]]; then
@@ -151,7 +153,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION ${DDS_VERSION:+DDS/$DDS_VERSION-$DDS_REVISION} ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${VC_VERSION:+Vc/$VC_VERSION-$VC_REVISION} ${HEPMC3_VERSION:+HepMC3/$HEPMC3_VERSION-$HEPMC3_REVISION} ${O2HLTCATRACKING_VERSION:+O2HLTCATracking/$O2HLTCATRACKING_VERSION-$O2HLTCATRACKING_REVISION} ${MONITORING_VERSION:+Monitoring/$MONITORING_VERSION-$MONITORING_REVISION} ${CONFIGURATION_VERSION:+Configuration/$CONFIGURATION_VERSION-$CONFIGURATION_REVISION} ms_gsl/$MS_GSL_VERSION-$MS_GSL_REVISION
+module load BASE/1.0 FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION ${DDS_VERSION:+DDS/$DDS_VERSION-$DDS_REVISION} ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${VC_VERSION:+Vc/$VC_VERSION-$VC_REVISION} ${HEPMC3_VERSION:+HepMC3/$HEPMC3_VERSION-$HEPMC3_REVISION} ${O2HLTCATRACKING_VERSION:+O2HLTCATracking/$O2HLTCATRACKING_VERSION-$O2HLTCATRACKING_REVISION} ${MONITORING_VERSION:+Monitoring/$MONITORING_VERSION-$MONITORING_REVISION} ${CONFIGURATION_VERSION:+Configuration/$CONFIGURATION_VERSION-$CONFIGURATION_REVISION} ms_gsl/$MS_GSL_VERSION-$MS_GSL_REVISION ${ARROW_VERSION:+arrow/$ARROW_VERSION-$ARROW_REVISION}
 # Our environment
 setenv O2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv VMCWORKDIR \$::env(O2_ROOT)/share
@@ -176,7 +178,7 @@ if [[ $CMAKE_BUILD_TYPE == COVERAGE ]]; then
   rm -rf coverage.info
   lcov --base-directory $SOURCEDIR --directory . --capture --output-file coverage.info
   lcov --remove coverage.info '*/usr/*' --output-file coverage.info
-  lcov --remove coverage.info '*/boost/*' --output-file coverage.info 
+  lcov --remove coverage.info '*/boost/*' --output-file coverage.info
   lcov --remove coverage.info '*/ROOT/*' --output-file coverage.info
   lcov --remove coverage.info '*/FairRoot/*' --output-file coverage.info
   lcov --remove coverage.info '*/G__*Dict*' --output-file coverage.info


### PR DESCRIPTION
* Work around flatbuffers installation issues (install missing binaries)
* Bump Apache Arrow to v0.9.0 (with ALICE patches) and fix search and linking of
  third-party projects
* Add statically linked third-party packages as build dependencies (not runtime)
* Add Apache Arrow as O2 dependency