### PR TITLE
o2.sh: query ARROW_ROOT instead of ARROW_VERSION

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -116,11 +116,11 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                                             \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                               \
-      ${O2HLTCATRACKING_VERSION:+-DO2_TPCCA_TRACKING_LIB_DIR=$O2HLTCATRACKING_ROOT}         \
+      ${O2HLTCATRACKING_ROOT:+-DO2_TPCCA_TRACKING_LIB_DIR=$O2HLTCATRACKING_ROOT}            \
       ${MONITORING_VERSION:+-DMonitoring_ROOT=$MONITORING_ROOT}                             \
       ${CONFIGURATION_VERSION:+-DConfiguration_ROOT=$CONFIGURATION_ROOT}                    \
       -DRAPIDJSON_INCLUDEDIR=${RAPIDJSON_ROOT}/include                                      \
-      ${ARROW_VERSION:+-DARROW_HOME=$ARROW_ROOT}                                            \
+      ${ARROW_ROOT:+-DARROW_HOME=$ARROW_ROOT}                                               \
       -Dbenchmark_DIR=${GOOGLEBENCHMARK_ROOT}/lib/cmake/benchmark
 
 if [[ $GIT_TAG == master ]]; then


### PR DESCRIPTION
ARROW_ROOT is the actual environment variable used for cmake. It is more consistent and better to query this one instead of ARROW_VERSION (which is not defined by the arrow modulefile).

Same for o2hltcatracking.