### PR TITLE
Bump O2 ROOT to v6-12-06 (latest prod)

### DIFF
--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -38,7 +38,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    tag: "v6-12-04"
+    tag: "v6-12-06"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -38,7 +38,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    tag: "v6-12-04"
+    tag: "v6-12-06"
     source: https://github.com/root-mirror/root
     requires:
       - GSL

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -28,7 +28,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    tag: "v6-12-04"
+    tag: "v6-12-06"
     source: https://github.com/root-mirror/root
     requires:
       - GSL

--- a/defaults-o2-prod.sh
+++ b/defaults-o2-prod.sh
@@ -25,7 +25,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    tag: "v6-12-04"
+    tag: "v6-12-06"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -28,7 +28,7 @@ overrides:
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060200)\n#error \"System's GCC cannot be used: we need at least GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
     version: "%(tag_basename)s"
-    tag: "v6-12-04"
+    tag: "v6-12-06"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,7 +1,7 @@
 package: FairRoot
 version: "%(tag_basename)s"
-tag: "3b01d28"
-source: https://github.com/FairRootGroup/FairRoot
+tag: "alice-dev-20180507"
+source: https://github.com/alisw/FairRoot
 requires:
   - generators
   - simulation


### PR DESCRIPTION
As pointed out by @frmanso this fixes a bug hitting us when plotting
`geometry.root` in O2.

This also bumps FairRoot properly, following our conventions (same as #1114).