### PR TITLE
New recipes for FairMQ

### DIFF
--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -1,0 +1,43 @@
+package: FairLogger
+version: "%(tag_basename)s"
+tag: v1.1.0
+source: https://github.com/FairRootGroup/FairLogger
+build_requires:
+ - CMake
+ - "GCC-Toolchain:(?!osx)"
+incremental_recipe: |
+  cmake --build . --target install ${JOBS:+-- -j$JOBS}
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+mkdir -p $INSTALLROOT
+
+cmake $SOURCEDIR                                                 \
+      ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER=$CXX_COMPILER}        \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}  \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                        \
+      -DDISABLE_COLOR=ON                                         \
+      -DCMAKE_INSTALL_LIBDIR=lib
+
+cmake --build . ${JOBS:+-- -j$JOBS}
+ctest ${JOBS:+-j$JOBS}
+cmake --build . --target install ${JOBS:+-- -j$JOBS}
+
+# ModuleFile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv FAIRLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(FAIRLOGGER_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRLOGGER_ROOT)/lib")
+EoF
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+mkdir -p $MODULEDIR && rsync -a --delete etc/modulefiles/ $MODULEDIR

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,0 +1,79 @@
+package: FairMQ
+version: "%(tag_basename)s"
+tag: v1.2.1
+source: https://github.com/FairRootGroup/FairMQ
+requires:
+ - boost
+ - FairLogger
+ - ZeroMQ
+ - nanomsg
+ - msgpack
+ - DDS
+build_requires:
+ - CMake
+ - "GCC-Toolchain:(?!osx)"
+ - googletest
+incremental_recipe: |
+  cmake --build . --target install ${JOBS:+-- -j$JOBS}
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+mkdir -p $INSTALLROOT
+
+case $ARCHITECTURE in
+  osx*)
+    # If we preferred system tools, we need to make sure we can pick them up.
+    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
+    [[ ! $ZEROMQ_ROOT ]] && ZEROMQ_ROOT=`brew --prefix zeromq`
+    [[ ! $NANOMSG_ROOT ]] && NANOMSG_ROOT=`brew --prefix nanomsg`
+    [[ ! $MSGPACK_ROOT ]] && MSGPACK_ROOT=`brew --prefix msgpack`
+  ;;
+esac
+
+cmake $SOURCEDIR                                                 \
+      ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER=$CXX_COMPILER}        \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}  \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                        \
+      ${GOOGLETEST_ROOT:+-DGTEST_ROOT=$GOOGLETEST_ROOT}          \
+      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                    \
+      ${FAIRLOGGER_ROOT:+-DFAIRLOGGER_ROOT=$FAIRLOGGER_ROOT}     \
+      ${ZEROMQ_ROOT:+-DZEROMQ_ROOT=$ZEROMQ_ROOT}                 \
+      ${NANOMSG_ROOT:+-DNANOMSG_ROOT=$NANOMSG_ROOT}              \
+      ${MSGPACK_ROOT:+-DMSGPACK_ROOT=$MSGPACK_ROOT}              \
+      ${DDS_ROOT:+-DDDS_ROOT=$DDS_ROOT}                          \
+      -DDISABLE_COLOR=ON                                         \
+      -DBUILD_DDS_PLUGIN=ON                                      \
+      -DBUILD_NANOMSG_TRANSPORT=ON                               \
+      -DBUILD_EXAMPLES=OFF                                       \
+      -DCMAKE_INSTALL_LIBDIR=lib                                 \
+      -DCMAKE_INSTALL_BINDIR=bin
+
+cmake --build . ${JOBS:+-- -j$JOBS}
+ctest ${JOBS:+-j$JOBS}
+cmake --build . --target install ${JOBS:+-- -j$JOBS}
+
+# ModuleFile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0                                                                    \\
+            ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}                      \\
+            ${FAIRLOGGER_VERSION:+FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION}  \\
+            ${ZEROMQ_VERSION:+ZeroMQ/$ZEROMQ_VERSION-$ZEROMQ_REVISION}                  \\
+            ${NANOMSG_VERSION:+nanomsg/$NANOMSG_VERSION-$NANOMSG_REVISION}              \\
+            ${MSGPACK_VERSION:+msgpack/$MSGPACK_VERSION-$MSGPACK_REVISION}              \\
+            ${DDS_VERSION:+DDS/$DDS_VERSION-$DDS_REVISION}
+# Our environment
+setenv FAIRMQ_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(FAIRMQ_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(FAIRMQ_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRMQ_ROOT)/lib")
+EoF
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+mkdir -p $MODULEDIR && rsync -a --delete etc/modulefiles/ $MODULEDIR

--- a/msgpack.sh
+++ b/msgpack.sh
@@ -1,0 +1,41 @@
+package: msgpack
+version: v2.1.5
+tag: cpp-2.1.5
+source: https://github.com/msgpack/msgpack-c
+build_requires:
+ - CMake
+ - "GCC-Toolchain:(?!osx)"
+prefer_system: "(?!slc5)"
+prefer_system_check: |
+  printf "#include <msgpack/version.hpp>\n#define VERSION (MSGPACK_VERSION_MAJOR * 10000) + (MSGPACK_VERSION_MINOR * 100) + MSGPACK_VERSION_REVISION\n#if(VERSION < 20105)\n#error \"msgpack version >= 2.1.5 needed\"\n#endif\nint main(){}" | c++ -I$(brew --prefix msgpack)/include -xc++ -std=c++11 - -o /dev/null
+---
+mkdir -p $INSTALLROOT
+
+cmake $SOURCEDIR                                                 \
+      ${C_COMPILER:+-DCMAKE_C_COMPILER=$C_COMPILER}              \
+      ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER=$CXX_COMPILER}        \
+      -DMSGPACK_CXX11=ON                                         \
+      -DMSGPACK_BUILD_TESTS=OFF                                  \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+
+cmake --build . --target install ${JOBS:+-- -j$JOBS}
+
+# ModuleFile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+setenv MSGPACK_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(MSGPACK_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(MSGPACK_ROOT)/lib")
+EoF
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+mkdir -p $MODULEDIR && rsync -a --delete etc/modulefiles/ $MODULEDIR


### PR DESCRIPTION
FairMQ (and FairLogger) have been separated from the FairRoot repository. The proposed new recipes will be needed once you decide to bump your FairRoot version beyond FairRootGroup/FairRoot@3b01d28.

I have only tested on Linux (Fedora 27) so far:

```
$ aliDoctor --defaults o2 FairMQ
(...)
==> The following packages will be picked up from the system:
    
    - Python-modules
    - GCC-Toolchain
    - autotools
    - CMake
    
    If this is not you want, you have to uninstall / unload them.

==> The following packages will be built by aliBuild because they couldn't be picked up from the system:
    
    - ZeroMQ
    - msgpack
    - boost
    - nanomsg
```
