### PR TITLE
AliTPCCommon bump: macOS+SLC6 fixes

### DIFF
--- a/alitpccommon.sh
+++ b/alitpccommon.sh
@@ -1,6 +1,6 @@
 package: AliTPCCommon
 version: "%(tag_basename)s"
-tag: alitpccommon-v1.0
+tag: alitpccommon-v1.1
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake


### PR DESCRIPTION
Version bump to a new version that contains several fixes for the AliRoot and O2 builds, related to Pull Requests alisw/AliRoot#671 and AliceO2Group/AliceO2#1068.