### PR TITLE
Check for defaults_upper usage

### DIFF
--- a/scripts/lint-recipes
+++ b/scripts/lint-recipes
@@ -93,6 +93,8 @@ if __name__ == "__main__":
             if numberOfProperties != 2:
                 error("version (or tag, if version is missing) should be the second property in the recipe", event)
             hasVersion = True
+            if "%(defaults_upper)s" in event.value:
+                error("%(defaults_upper)s variable expansion should only be specified as part of defaults.", event)
             state = IN_GENERIC_KEY_VALUE
         elif state == IN_TAG_KEY:
             if type(event) != ScalarEvent:


### PR DESCRIPTION
We should not use %(defaults_upper)s as part of the normal version
string because that makes a package and all it's dependencies defaults
dependent, even if there is no real need for it. If one needs a default
dependent behavior should add it to the overrides inside a default.