### PR TITLE
Use a working commit for FairRoot

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,6 +1,6 @@
 package: FairRoot
-version: "%(tag_basename)s"
-tag: "3b01d28"
+version: "%(short_hash)s"
+tag: "3b01d287cdd3a52cac981fab4a122e8a81ad4f4c"
 source: https://github.com/FairRootGroup/FairRoot
 requires:
   - generators

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,7 +1,7 @@
 package: FairRoot
 version: "%(tag_basename)s"
-tag: "alice-dev-20180507"
-source: https://github.com/alisw/FairRoot
+tag: "3b01d28"
+source: https://github.com/FairRootGroup/FairRoot
 requires:
   - generators
   - simulation


### PR DESCRIPTION
This was already done but reverted citing our convention. Actually the convention states quite clearly:

> Do not create extra branches unless you do need to patch the original sources.

(see https://github.com/alisw/alidist/#guidelines-for-handling-externals-sources). Since this is the case here, I think using the hash is the correct thing to do (and regardless, according to @sawenzel the current tag is not the correct one).