### PR TITLE
Explicit Python3 support in ROOT, add compile_commands to AliRoot and AliPhysics

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -13,6 +13,17 @@ prepend_path:
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+  cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}
+  DEVEL_SOURCES="`readlink $SOURCEDIR || echo $SOURCEDIR`"
+  # This really means we are in development mode. We need to make sure we
+  # use the real path for sources in this case. We also copy the
+  # compile_commands.json file so that IDEs can make use of it directly, this
+  # is a departure from our "no changes in sourcecode" policy, but for a good reason
+  # and in any case the file is in gitignore.
+  if [ "$DEVEL_SOURCES" != "$SOURCEDIR" ]; then
+    perl -p -i -e "s|$SOURCEDIR|$DEVEL_SOURCES|" compile_commands.json
+    ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
+  fi
   [[ $CMAKE_BUILD_TYPE == COVERAGE ]] && mkdir -p "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/" && rsync -acv --filter='+ */' --filter='+ *.cpp' --filter='+ *.cc' --filter='+ *.h' --filter='+ *.gcno' --filter='- *' "$BUILDDIR/" "$WORK_DIR/$ARCHITECTURE/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
@@ -29,6 +40,7 @@ fi
 
 cmake "$SOURCEDIR"                                                 \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                        \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                           \
       -DROOTSYS="$ROOT_ROOT"                                       \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}  \
       ${ALIEN_RUNTIME_ROOT:+-DALIEN="$ALIEN_RUNTIME_ROOT"}         \
@@ -41,6 +53,20 @@ cmake "$SOURCEDIR"                                                 \
 make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 # ctest will succeed if no load_library tests were found
 ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
+
+# install the compilation database so that we can post-check the code
+cp compile_commands.json ${INSTALLROOT}
+
+DEVEL_SOURCES="`readlink $SOURCEDIR || echo $SOURCEDIR`"
+# This really means we are in development mode. We need to make sure we
+# use the real path for sources in this case. We also copy the
+# compile_commands.json file so that IDEs can make use of it directly, this
+# is a departure from our "no changes in sourcecode" policy, but for a good reason
+# and in any case the file is in gitignore.
+if [ "$DEVEL_SOURCES" != "$SOURCEDIR" ]; then
+  perl -p -i -e "s|$SOURCEDIR|$DEVEL_SOURCES|" compile_commands.json
+  ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
+fi
 
 [[ $CMAKE_BUILD_TYPE == COVERAGE ]]                                                       \
   && mkdir -p "$WORK_DIR/${ARCHITECTURE}/profile-data/AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION/"  \

--- a/root.sh
+++ b/root.sh
@@ -60,6 +60,7 @@ fi
 
 # Disable Python for non-ROOT 6 builds
 [[ -d $SOURCEDIR/interpreter/llvm ]] || NO_PYTHON=1
+[[ $(python  'import sys; sys.exit(0 if sys.version_info[0] > 2 else 1)') -eq 0 ]] && [[ ! $NO_PYTHON ]] && IS_PYTHON3=1
 
 if [[ $ALICE_DAQ ]]; then
   # DAQ requires static ROOT, only supported by ./configure (not CMake).
@@ -103,6 +104,7 @@ else
         -Dpcre=OFF                                                                       \
         -Dbuiltin_pcre=ON                                                                \
         ${NO_PYTHON:+-Dpython=OFF}                                                       \
+        ${IS_PYTHON3:+-Dpython3=ON}                                                      \
         ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
         -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
         -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \
@@ -112,6 +114,7 @@ else
         ${OPENSSL_ROOT:+-DOPENSSL_ROOT=$OPENSSL_ROOT}                                    \
         ${OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIR=$OPENSSL_ROOT/include}                     \
         ${LIBXML2_ROOT:+-DLIBXML2_ROOT=$LIBXML2_ROOT}                                    \
+        ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                                                 \
         ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                                                 \
         -Dpgsql=OFF                                                                      \
         -Dminuit2=ON                                                                     \
@@ -129,8 +132,8 @@ else
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}
-            ${ALIEN_RUNTIME_ROOT:+alien monalisa}"
-  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 gviz"
+            ${ALIEN_RUNTIME_ROOT:+alien monalisa} ${IS_PYTHON3:+python python3}"
+  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 gviz ${NO_PYTHON:+python python3}"
 
   if [[ $ENABLE_COCOA ]]; then
     FEATURES="$FEATURES builtin_freetype"


### PR DESCRIPTION
This adds the generation of the compile_commands to AliRoot and AliPhysics (just like it is done in O2).
Moreover I added a check on the python3 support in ROOT, to be sure that if PYTHON3 is available the proper option is enabled.

Cheers,
Max