### PR TITLE
Do not set MANPATH.

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -159,7 +159,6 @@ module load BASE/1.0 FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION ${DDS_VERSION
 setenv O2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv VMCWORKDIR \$::env(O2_ROOT)/share
 prepend-path PATH \$::env(O2_ROOT)/bin
-prepend-path MANPATH \$::env(O2_ROOT)/share/man
 prepend-path LD_LIBRARY_PATH \$::env(O2_ROOT)/lib
 prepend-path ROOT_INCLUDE_PATH \$::env(O2_ROOT)/include
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(O2_ROOT)/lib")


### PR DESCRIPTION
If MANPATH is set to simply o2 dir it will hide regular paths used by
man, so once that module is loaded a simple `man ls` will fail for
instance, which is pretty annoying.

man is smart enough to look in nearby directories of the directories in
PATH, so `man o2` will work just fine.

@matthiasrichter might want to confirm this though, as I guess he was one of the man pages advocates ;-) )