### PR TITLE
Support FairRoot repo split

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -49,9 +49,23 @@ overrides:
     tag: "v3.0.2"
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
+    requires:
+      - arrow
+      - FairRoot
+      - DDS
+      - Vc
+      - hijing
+      - HepMC3
+      - Configuration
+      - Monitoring
+      - ms_gsl
+      - FairMQ
     build_requires:
       - ms_gsl
       - lcov
+      - RapidJSON
+      - googlebenchmark
+      - AliTPCCommon
   CMake:
     version: "%(tag_basename)s"
     tag: "v3.11.0"

--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -1,6 +1,6 @@
 package: FairLogger
 version: "%(tag_basename)s"
-tag: v1.1.0
+tag: v1.2.0
 source: https://github.com/FairRootGroup/FairLogger
 build_requires:
  - CMake

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.2.1
+tag: v1.2.4
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
There are other remaining problems with the current FairRoot `dev` branch which are unrelated to the repo split (I believe).

@sawenzel Just a headsup: `FairRun` and `FairRootManager` API has changed which breaks at least `o2::steer::O2RunAna`. I am not so familiar with these classes, so I leave the fix to someone else.

Tested with AliceO2Group/AliceO2#1107 applied (Fedora 27 only, GCC 7.3.1)