### PR TITLE
Add recipes for golang, Control and coconut

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,11 +2,13 @@
 *                   @alisw/infrastructure-admins
 
 # Dataflow team
+coconut             @alisw/dataflow-experts
 common-o2*          @alisw/dataflow-experts
 configuration*      @alisw/dataflow-experts
 control*            @alisw/dataflow-experts
 datasampling*       @alisw/dataflow-experts
 flpproto*           @alisw/dataflow-experts
+golang              @alisw/dataflow-experts
 infologger*         @alisw/dataflow-experts
 monitoring*         @alisw/dataflow-experts
 pda*                @alisw/dataflow-experts

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,6 @@ configuration*      @alisw/dataflow-experts
 control*            @alisw/dataflow-experts
 datasampling*       @alisw/dataflow-experts
 flpproto*           @alisw/dataflow-experts
-golang              @alisw/dataflow-experts
 infologger*         @alisw/dataflow-experts
 monitoring*         @alisw/dataflow-experts
 pda*                @alisw/dataflow-experts

--- a/coconut.sh
+++ b/coconut.sh
@@ -1,0 +1,45 @@
+package: coconut
+version: "%(commit_hash)s"
+tag:  master
+build_requires:
+  - golang
+  - protobuf
+source: https://github.com/AliceO2Group/Control
+incremental_recipe: |
+  make WHAT="coconut" all
+  mkdir -p $INSTALLROOT/bin
+  cp bin/* $INSTALLROOT/bin
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+#!/bin/bash -e
+
+GOPATH=$PWD
+PATH=$GOPATH/bin:$PATH
+BUILD=$GOPATH/src/github.com/AliceO2Group/Control
+mkdir -p $BUILD
+rsync -a --delete $SOURCEDIR/ $BUILD/
+cd $BUILD
+make WHAT="coconut" all
+mkdir -p $INSTALLROOT/bin
+cp bin/* $INSTALLROOT/bin
+cd -
+
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+
+# Our environment
+set coconut_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$coconut_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$coconut_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$coconut_ROOT/lib")
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/coconut.sh
+++ b/coconut.sh
@@ -5,11 +5,6 @@ build_requires:
   - golang
   - protobuf
 source: https://github.com/AliceO2Group/Control
-incremental_recipe: |
-  make WHAT="coconut" all
-  mkdir -p $INSTALLROOT/bin
-  cp bin/* $INSTALLROOT/bin
-  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/bash -e
 
@@ -18,11 +13,11 @@ PATH=$GOPATH/bin:$PATH
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD
 rsync -a --delete $SOURCEDIR/ $BUILD/
-cd $BUILD
-make WHAT="coconut" all
-mkdir -p $INSTALLROOT/bin
-cp bin/* $INSTALLROOT/bin
-cd -
+pushd $BUILD
+  make WHAT="coconut" all
+  mkdir -p $INSTALLROOT/bin
+  rsync -a --delete bin/ $INSTALLROOT/bin
+popd
 
 mkdir -p etc/modulefiles
 cat > etc/modulefiles/$PKGNAME <<EoF
@@ -37,9 +32,9 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0
 
 # Our environment
-set coconut_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$coconut_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$coconut_ROOT/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$coconut_ROOT/lib")
+set COCONUT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$COCONUT_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$COCONUT_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$COCONUT_ROOT/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/coconut.sh
+++ b/coconut.sh
@@ -8,7 +8,7 @@ source: https://github.com/AliceO2Group/Control
 ---
 #!/bin/bash -e
 
-GOPATH=$PWD
+export GOPATH=$PWD
 PATH=$GOPATH/bin:$PATH
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD

--- a/coconut.sh
+++ b/coconut.sh
@@ -1,6 +1,6 @@
 package: coconut
 version: "%(commit_hash)s"
-tag:  master
+tag: master
 build_requires:
   - golang
   - protobuf
@@ -8,8 +8,8 @@ source: https://github.com/AliceO2Group/Control
 ---
 #!/bin/bash -e
 
-export GOPATH=$PWD
-PATH=$GOPATH/bin:$PATH
+export GOPATH=$PWD/go
+export PATH=$GOPATH/bin:$PATH
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD
 rsync -a --delete $SOURCEDIR/ $BUILD/

--- a/control-core.sh
+++ b/control-core.sh
@@ -8,7 +8,7 @@ source: https://github.com/AliceO2Group/Control
 ---
 #!/bin/bash -e
 
-GOPATH=$PWD
+export GOPATH=$PWD
 PATH=$GOPATH/bin:$PATH
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD

--- a/control-core.sh
+++ b/control-core.sh
@@ -1,0 +1,46 @@
+package: Control-Core
+version: "%(commit_hash)s"
+tag:  master
+build_requires:
+  - golang
+  - protobuf
+source: https://github.com/AliceO2Group/Control
+incremental_recipe: |
+  make WHAT="octld octl-executor" all
+  mkdir -p $INSTALLROOT/bin
+  cp bin/* $INSTALLROOT/bin
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+#!/bin/bash -e
+
+GOPATH=$PWD
+PATH=$GOPATH/bin:$PATH
+BUILD=$GOPATH/src/github.com/AliceO2Group/Control
+mkdir -p $BUILD
+rsync -a --delete $SOURCEDIR/ $BUILD/
+cd $BUILD
+make WHAT="octld octl-executor" all
+mkdir -p $INSTALLROOT/bin
+cp bin/* $INSTALLROOT/bin
+cd -
+
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 \\
+            ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
+
+# Our environment
+set Control_Core_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$Control_Core_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$Control_Core_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$Control_Core_ROOT/lib")
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/control-core.sh
+++ b/control-core.sh
@@ -1,6 +1,6 @@
 package: Control-Core
 version: "%(commit_hash)s"
-tag:  master
+tag: master
 build_requires:
   - golang
   - protobuf
@@ -8,15 +8,15 @@ source: https://github.com/AliceO2Group/Control
 ---
 #!/bin/bash -e
 
-export GOPATH=$PWD
-PATH=$GOPATH/bin:$PATH
+export GOPATH=$PWD/go
+export PATH=$GOPATH/bin:$PATH
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD
 rsync -a --delete $SOURCEDIR/ $BUILD/
 pushd $BUILD
   make WHAT="octld octl-executor" all
   mkdir -p $INSTALLROOT/bin
-  rsync -c --delete bin/ $INSTALLROOT/bin
+  rsync -a --delete bin/ $INSTALLROOT/bin
 popd
 
 mkdir -p etc/modulefiles

--- a/control-core.sh
+++ b/control-core.sh
@@ -5,11 +5,6 @@ build_requires:
   - golang
   - protobuf
 source: https://github.com/AliceO2Group/Control
-incremental_recipe: |
-  make WHAT="octld octl-executor" all
-  mkdir -p $INSTALLROOT/bin
-  cp bin/* $INSTALLROOT/bin
-  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/bash -e
 
@@ -18,11 +13,11 @@ PATH=$GOPATH/bin:$PATH
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD
 rsync -a --delete $SOURCEDIR/ $BUILD/
-cd $BUILD
-make WHAT="octld octl-executor" all
-mkdir -p $INSTALLROOT/bin
-cp bin/* $INSTALLROOT/bin
-cd -
+pushd $BUILD
+  make WHAT="octld octl-executor" all
+  mkdir -p $INSTALLROOT/bin
+  rsync -c --delete bin/ $INSTALLROOT/bin
+popd
 
 mkdir -p etc/modulefiles
 cat > etc/modulefiles/$PKGNAME <<EoF
@@ -38,9 +33,9 @@ module load BASE/1.0 \\
             ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
 
 # Our environment
-set Control_Core_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$Control_Core_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$Control_Core_ROOT/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$Control_Core_ROOT/lib")
+set CONTROL_CORE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$CONTROL_CORE_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$CONTROL_CORE_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$CONTROL_CORE_ROOT/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/control-occplugin.sh
+++ b/control-occplugin.sh
@@ -2,7 +2,8 @@ package: Control-OCCPlugin
 version: "%(commit_hash)s"
 tag:  master
 requires:
-  - FairRoot
+  - FairMQ
+  - FairLogger
   - boost
   - grpc
   - protobuf
@@ -32,7 +33,8 @@ cmake $SOURCEDIR/occplugin                                                      
       ${BOOST_ROOT:+-DBOOSTPATH=$BOOST_ROOT}                                             \
       -DGRPCPATH=${GRPC_ROOT}                                                            \
       -DPROTOBUFPATH=${PROTOBUF_ROOT}                                                    \
-      -DFAIRROOTPATH=${FAIRROOT_ROOT}
+      -DFAIRMQPATH=${FAIRMQ_ROOT}                                                        \
+      -DFAIRLOGGERPATH=${FAIRLOGGER_ROOT}
 
 make ${JOBS+-j $JOBS} prefix=$INSTALLROOT
 make prefix=$INSTALLROOT install
@@ -51,7 +53,8 @@ module load BASE/1.0 \\
             ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION} \\
             ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
             ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION} \\
-            ${FAIRROOT_VERSION:+FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION} \\
+            ${FAIRMQ_VERSION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION} \\
+            ${FAIRLOGGER_VERSION:+FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION} \\
             ${GRPC_VERSION:+grpc/$GRPC_VERSION-$GRPC_REVISION}
 
 # Our environment

--- a/control.sh
+++ b/control.sh
@@ -1,0 +1,48 @@
+package: Control
+version: "%(commit_hash)s"
+tag:  master
+requires:
+  - coconut
+build_requires:
+  - golang
+  - protobuf
+source: https://github.com/AliceO2Group/Control
+incremental_recipe: |
+  make WHAT="octld octl-executor" all
+  mkdir -p $INSTALLROOT/bin
+  cp bin/* $INSTALLROOT/bin
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+#!/bin/bash -e
+
+GOPATH=$PWD
+PATH=$GOPATH/bin:$PATH
+BUILD=$GOPATH/src/github.com/AliceO2Group/Control
+mkdir -p $BUILD
+rsync -a --delete $SOURCEDIR/ $BUILD/
+cd $BUILD
+make WHAT="octld octl-executor" all
+mkdir -p $INSTALLROOT/bin
+cp bin/* $INSTALLROOT/bin
+cd -
+
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 \\
+            ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
+
+# Our environment
+set Control_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$Control_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$Control_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$Control_ROOT/lib")
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/control.sh
+++ b/control.sh
@@ -1,30 +1,12 @@
 package: Control
-version: "%(commit_hash)s"
-tag:  master
+version: "v%(year)s%(month)s%(day)s"
 requires:
-  - coconut
-build_requires:
   - golang
-  - protobuf
-source: https://github.com/AliceO2Group/Control
-incremental_recipe: |
-  make WHAT="octld octl-executor" all
-  mkdir -p $INSTALLROOT/bin
-  cp bin/* $INSTALLROOT/bin
-  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+  - Control-Core
+  - Control-OCCPlugin
+  - coconut
 ---
 #!/bin/bash -e
-
-GOPATH=$PWD
-PATH=$GOPATH/bin:$PATH
-BUILD=$GOPATH/src/github.com/AliceO2Group/Control
-mkdir -p $BUILD
-rsync -a --delete $SOURCEDIR/ $BUILD/
-cd $BUILD
-make WHAT="octld octl-executor" all
-mkdir -p $INSTALLROOT/bin
-cp bin/* $INSTALLROOT/bin
-cd -
 
 mkdir -p etc/modulefiles
 cat > etc/modulefiles/$PKGNAME <<EoF
@@ -37,7 +19,10 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0 \\
-            ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
+            ${GOLANG_VERSION:+golang/$GOLANG_VERSION-$GOLANG_REVISION} \\
+            ${CONTROL_CORE_VERSION:+Control-Core/$CONTROL_CORE_VERSION-$CONTROL_CORE_REVISION} \\
+            ${CONTROL_OCCPLUGIN_VERSION:+Control-OCCPlugin/$CONTROL_OCCPLUGIN_VERSION-$CONTROL_OCCPLUGIN_REVISION} \\
+            ${COCONUT_VERSION:+coconut/$COCONUT_VERSION-$COCONUT_REVISION}
 
 # Our environment
 set Control_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/golang.sh
+++ b/golang.sh
@@ -8,8 +8,7 @@ prefer_system_check: |
 #!/bin/bash -e
 
 ARCH=$(uname|tr '[:upper:]' '[:lower:]')-amd64
-SOURCE=https://golang.org/dl/go$PKGVERSION.$ARCH.tar.gz
-curl -LO $SOURCE
+curl -LO https://golang.org/dl/go$PKGVERSION.$ARCH.tar.gz
 tar --strip-components=1 -C $INSTALLROOT -xzf go$PKGVERSION.$ARCH.tar.gz
 
 mkdir -p etc/modulefiles

--- a/golang.sh
+++ b/golang.sh
@@ -1,0 +1,47 @@
+package: golang
+version: "1.10.2"
+build_requires:
+  - curl
+prefer_system_check: |
+  which go && case `go version | sed -e 's/go version go//' | sed -e 's/ .*//'` in 0*|1.[0-9].*) exit 1 ;; esac
+incremental_recipe: |
+  case $ARCHITECTURE in
+    osx*) ARCH=darwin-amd64 ;;
+    *) ARCH=linux-amd64 ;;
+  esac
+  SOURCE=https://golang.org/dl/go$PKGVERSION.$ARCH.tar.gz
+  curl -LO $SOURCE
+  tar --strip-components=1 -C $INSTALLROOT -xzf go$PKGVERSION.$ARCH.tar.gz
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+#!/bin/bash -e
+
+case $ARCHITECTURE in
+  osx*) ARCH=darwin-amd64 ;;
+  *) ARCH=linux-amd64 ;;
+esac
+
+SOURCE=https://golang.org/dl/go$PKGVERSION.$ARCH.tar.gz
+curl -LO $SOURCE
+tar --strip-components=1 -C $INSTALLROOT -xzf go$PKGVERSION.$ARCH.tar.gz
+
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+
+# Our environment
+setenv GOROOT \$::env(BASEDIR)/$PKGNAME/\$version
+# NOTE: upstream requires GOROOT to be defined if installing to a nonstandard path
+prepend-path PATH \$::env(GOROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(GOROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GOROOT)/lib")
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/golang.sh
+++ b/golang.sh
@@ -3,24 +3,11 @@ version: "1.10.2"
 build_requires:
   - curl
 prefer_system_check: |
-  which go && case `go version | sed -e 's/go version go//' | sed -e 's/ .*//'` in 0*|1.[0-9].*) exit 1 ;; esac
-incremental_recipe: |
-  case $ARCHITECTURE in
-    osx*) ARCH=darwin-amd64 ;;
-    *) ARCH=linux-amd64 ;;
-  esac
-  SOURCE=https://golang.org/dl/go$PKGVERSION.$ARCH.tar.gz
-  curl -LO $SOURCE
-  tar --strip-components=1 -C $INSTALLROOT -xzf go$PKGVERSION.$ARCH.tar.gz
-  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+  case `go version | sed -e 's/go version go//' | sed -e 's/ .*//'` in 0*|1.[0-9].*) exit 1 ;; esac
 ---
 #!/bin/bash -e
 
-case $ARCHITECTURE in
-  osx*) ARCH=darwin-amd64 ;;
-  *) ARCH=linux-amd64 ;;
-esac
-
+ARCH=$(uname|tr '[:upper:]' '[:lower:]')-amd64
 SOURCE=https://golang.org/dl/go$PKGVERSION.$ARCH.tar.gz
 curl -LO $SOURCE
 tar --strip-components=1 -C $INSTALLROOT -xzf go$PKGVERSION.$ARCH.tar.gz

--- a/grpc.sh
+++ b/grpc.sh
@@ -21,14 +21,14 @@ git submodule update --init # aie aie aie
 # gRPC has a custom Makefile which readily breaks with some environment vars, better to run it in a clean environment
 env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" PATH="$PATH" USER="$USER" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" make ${JOBS:+-j$JOBS} prefix=$INSTALLROOT
 
-# Add missing symlink. Must be relative, because the directory is moved around after the build.
-# This should normally not be necessary, but it is made necessary by the issues linked in the following upstream pull request: https://github.com/grpc/grpc/pull/13500
-# Once the issue gets fixed, it should be safe to remove this workaround.
-ln -s libgrpc++.so.%(tag_basename)s $INSTALLROOT/lib/libgrpc++.so.1
-
 # ldconfig won't work if we're not running make install as root, and that's ok, we don't need it
 sed -i 's/ldconfig/true/' ./Makefile
 make prefix=$INSTALLROOT install
+
+# Add missing symlink. Must be relative, because the directory is moved around after the build.
+# This should normally not be necessary, but it is made necessary by the issues linked in the following upstream pull request: https://github.com/grpc/grpc/pull/13500
+# Once the issue gets fixed, it should be safe to remove this workaround.
+ln -s libgrpc++.so.${PKGVERSION#v} $INSTALLROOT/lib/libgrpc++.so.1
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
Contents:
  - `golang.sh` - replaces package `golang` from CentOS base repo if the latter is older than version `1.10.0`, this intentionally uses official binary tarballs from upstream (for both linux-amd64 and darwin) for a faster and more reliable build that doesn't rely on CentOS- or aliBuild-provided toolchains;
  - `coconut.sh` - the COntrol and CONfiguration UTility for the O² farm, builds with Go from repo AliceO2Group/Control (same as Control-OCCPlugin);
  - `control-core.sh` - main package for O² Control, builds with Go from repo AliceO2Group/Control (same as Control-OCCPlugin);
  - `control.sh` - metarecipe that pulls in as dependencies all of the above, plus Control-OCCPlugin which was previously merged;

\+ fixed workaround for `libgrpc++.so.1` symlink creation.