### PR TITLE
Bump FairRoot to the split version

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -5,6 +5,7 @@ env:
   CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "14"
+  CMAKE_GENERATOR: "Ninja"
 disable:
   - AliEn-Runtime
   - AliRoot
@@ -49,20 +50,9 @@ overrides:
     tag: "v3.5.2"
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
-    requires:
-      - arrow
-      - FairRoot
-      - DDS
-      - Vc
-      - hijing
-      - HepMC3
-      - Configuration
-      - Monitoring
-      - ms_gsl
-      - FairMQ
     build_requires:
-      - ms_gsl
       - lcov
+      - ninja
       - RapidJSON
       - googlebenchmark
       - AliTPCCommon
@@ -75,15 +65,9 @@ overrides:
     version: dev
     tag: dev
     source: https://github.com/FairRootGroup/FairRoot
-    requires:
-      - generators
-      - simulation
-      - ROOT
-      - boost
-      - protobuf
-      - "GCC-Toolchain:(?!osx)"
-      - FairLogger
-      - FairMQ
+    build_requires:
+      - googletest
+      - ninja
   GEANT4:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,6 +1,6 @@
 package: FairRoot
 version: "%(short_hash)s"
-tag: "3b01d287cdd3a52cac981fab4a122e8a81ad4f4c"
+tag: "5300e7be8a757da3abde3344020656839a4ee06f"
 source: https://github.com/FairRootGroup/FairRoot
 requires:
   - generators
@@ -11,6 +11,8 @@ requires:
   - boost
   - protobuf
   - DDS
+  - FairLogger
+  - FairMQ
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - googletest

--- a/o2.sh
+++ b/o2.sh
@@ -11,6 +11,7 @@ requires:
   - Configuration
   - Monitoring
   - ms_gsl
+  - FairMQ
 build_requires:
   - RapidJSON
   - googlebenchmark


### PR DESCRIPTION
* Remove specific overrides (FairMQ/FairLogger) from defaults-o2-dev-fairroot
  (now changes are in o2.sh and fairroot.sh)
* Bump FairRoot version
* Build "dev" FairRoot using Ninja for testing