### PR TITLE
Added GEANT4_BUILD_MULTITHREADED env variable:

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -6,6 +6,7 @@ env:
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "17"
   CMAKE_GENERATOR: "Ninja"
+  GEANT4_BUILD_MULTITHREADED: "ON"
 disable:
   - AliEn-Runtime
   - AliRoot

--- a/defaults-o2-ninja.sh
+++ b/defaults-o2-ninja.sh
@@ -6,6 +6,7 @@ env:
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "17"
   CMAKE_GENERATOR: "Ninja"
+  GEANT4_BUILD_MULTITHREADED: "ON"
 disable:
   - AliEn-Runtime
   - grpc

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -5,6 +5,7 @@ env:
   CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "17"
+  GEANT4_BUILD_MULTITHREADED: "ON"
 disable:
   - AliEn-Runtime
   - grpc

--- a/geant4.sh
+++ b/geant4.sh
@@ -27,10 +27,6 @@ env:
 
 [[ $CXXSTD > 14 ]] && CXXSTD=14 || true  # Only C++14 is supported at the moment
 
-if [ ! $GEANT4_BUILD_MULTITHREADED ]; then
-  GEANT4_BUILD_MULTITHREADED=OFF
-fi
-
 # if this variable is not defined default it to OFF
 : ${GEANT4_BUILD_MULTITHREADED:=OFF}
 

--- a/geant4.sh
+++ b/geant4.sh
@@ -27,24 +27,28 @@ env:
 
 [[ $CXXSTD > 14 ]] && CXXSTD=14 || true  # Only C++14 is supported at the moment
 
-cmake $SOURCEDIR                                    \
-  -DGEANT4_INSTALL_DATA_TIMEOUT=2000                \
-  -DCMAKE_CXX_FLAGS="-fPIC"                         \
-  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"        \
-  -DCMAKE_INSTALL_LIBDIR="lib"                      \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo                 \
-  -DGEANT4_BUILD_TLS_MODEL:STRING="initial-exec"    \
-  -DGEANT4_ENABLE_TESTING=OFF                       \
-  -DBUILD_SHARED_LIBS=ON                            \
-  -DGEANT4_INSTALL_EXAMPLES=OFF                     \
-  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT"               \
-  -DGEANT4_BUILD_MULTITHREADED=OFF                  \
-  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"          \
-  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"            \
-  -DGEANT4_USE_G3TOG4=ON                            \
-  -DGEANT4_INSTALL_DATA=ON                          \
-  -DGEANT4_USE_SYSTEM_EXPAT=OFF                     \
-  ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}           \
+if [ ! $GEANT4_BUILD_MULTITHREADED ]; then
+  GEANT4_BUILD_MULTITHREADED=OFF
+fi
+
+cmake $SOURCEDIR                                             \
+  -DGEANT4_INSTALL_DATA_TIMEOUT=2000                         \
+  -DCMAKE_CXX_FLAGS="-fPIC"                                  \
+  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                 \
+  -DCMAKE_INSTALL_LIBDIR="lib"                               \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo                          \
+  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"           \
+  -DGEANT4_ENABLE_TESTING=OFF                                \
+  -DBUILD_SHARED_LIBS=ON                                     \
+  -DGEANT4_INSTALL_EXAMPLES=OFF                              \
+  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT"                        \
+  -DGEANT4_BUILD_MULTITHREADED="$GEANT4_BUILD_MULTITHREADED" \
+  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"                   \
+  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"                     \
+  -DGEANT4_USE_G3TOG4=ON                                     \
+  -DGEANT4_INSTALL_DATA=ON                                   \
+  -DGEANT4_USE_SYSTEM_EXPAT=OFF                              \
+  ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                    \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS}

--- a/geant4.sh
+++ b/geant4.sh
@@ -32,7 +32,7 @@ if [ ! $GEANT4_BUILD_MULTITHREADED ]; then
 fi
 
 # if this variable is not defined default it to OFF
-: {GEANT4_BUILD_MULTITHREADED:=OFF}
+: ${GEANT4_BUILD_MULTITHREADED:=OFF}
 
 cmake $SOURCEDIR                                             \
   -DGEANT4_INSTALL_DATA_TIMEOUT=2000                         \

--- a/geant4.sh
+++ b/geant4.sh
@@ -40,7 +40,7 @@ cmake $SOURCEDIR                                             \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                 \
   -DCMAKE_INSTALL_LIBDIR="lib"                               \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo                          \
-  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"           \
+  -DGEANT4_BUILD_TLS_MODEL:STRING="global_dynamic"           \
   -DGEANT4_ENABLE_TESTING=OFF                                \
   -DBUILD_SHARED_LIBS=ON                                     \
   -DGEANT4_INSTALL_EXAMPLES=OFF                              \

--- a/geant4.sh
+++ b/geant4.sh
@@ -31,6 +31,9 @@ if [ ! $GEANT4_BUILD_MULTITHREADED ]; then
   GEANT4_BUILD_MULTITHREADED=OFF
 fi
 
+# if this variable is not defined default it to OFF
+: {GEANT4_BUILD_MULTITHREADED:=OFF}
+
 cmake $SOURCEDIR                                             \
   -DGEANT4_INSTALL_DATA_TIMEOUT=2000                         \
   -DCMAKE_CXX_FLAGS="-fPIC"                                  \

--- a/geant4.sh
+++ b/geant4.sh
@@ -40,7 +40,7 @@ cmake $SOURCEDIR                                             \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                 \
   -DCMAKE_INSTALL_LIBDIR="lib"                               \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo                          \
-  -DGEANT4_BUILD_TLS_MODEL:STRING="global_dynamic"           \
+  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"           \
   -DGEANT4_ENABLE_TESTING=OFF                                \
   -DBUILD_SHARED_LIBS=ON                                     \
   -DGEANT4_INSTALL_EXAMPLES=OFF                              \

--- a/readoutcard.sh
+++ b/readoutcard.sh
@@ -1,6 +1,6 @@
 package: ReadoutCard
 version: "%(tag_basename)s"
-tag: v0.8.9
+tag: v0.8.11
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
- The variable allows different setting of the GEANT4_BUILD_MULTITHREADED CMake option
- The default value "OFF" is overridden ("ON") in defaults-o2.sh and defaults-o2-dev-fairroot.sh