### PR TITLE
Add $FAIRLOGGER_ROOT/include to ROOT_INCLUDE_PATH

### DIFF
--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -8,6 +8,8 @@ build_requires:
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+prepend_path:
+  ROOT_INCLUDE_PATH: "$FAIRLOGGER_ROOT/include"
 ---
 mkdir -p $INSTALLROOT
 
@@ -37,6 +39,7 @@ module load BASE/1.0
 # Our environment
 setenv FAIRLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(FAIRLOGGER_ROOT)/lib
+prepend-path ROOT_INCLUDE_PATH \$::env(FAIRLOGGER_ROOT)/include
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRLOGGER_ROOT)/lib")
 EoF
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
Otherwise the compilation of macros with ``#include "FairLogger.h"`` breaks with 
````
/home/shahoian/alice/sw/ubuntu1710_x86-64/FairRoot/0-2/include/FairLogger.h:18:10: fatal error: 'fairlogger/Logger.h' file not found
````