### PR TITLE
Move RapidJSON as builddep for Configuration

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -5,9 +5,9 @@ requires:
   - curl
   - boost
   - "GCC-Toolchain:(?!osx)"
-  - RapidJSON
   - "Ppconsul:(?!osx)"
 build_requires:
+  - RapidJSON
   - CMake
 source: https://github.com/AliceO2Group/Configuration
 incremental_recipe: |


### PR DESCRIPTION
RapidJSON is not needed at runtime as already reflected by the Modulefile as it
is a header-only library