### PR TITLE
Work around hardcoded FairRoot paths in PCM

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -70,11 +70,8 @@ cmake $SOURCEDIR                                                                
 
 cmake --build . -- -j$JOBS install
 
-INCLUDE_TREE="$INSTALLROOT/include_tree"
-mkdir -p $INCLUDE_TREE
-SUBDIRS="source sink field event sim steer"
-for dir in $SUBDIRS; do
-    ln -sf "../include" $INCLUDE_TREE/$dir
+for DIR in source sink field event sim steer; do
+    ln -nfs ../include $INSTALLROOT/include/$DIR
 done
 
 # Modulefile
@@ -113,6 +110,5 @@ setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig
 prepend-path PATH \$::env(FAIRROOT_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib
 prepend-path ROOT_INCLUDE_PATH \$::env(FAIRROOT_ROOT)/include
-prepend-path ROOT_INCLUDE_PATH \$::env(FAIRROOT_ROOT)/include_tree
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib")
 EoF

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -70,6 +70,13 @@ cmake $SOURCEDIR                                                                
 
 cmake --build . -- -j$JOBS install
 
+INCLUDE_TREE="$INSTALLROOT/include_tree"
+mkdir -p $INCLUDE_TREE
+SUBDIRS="source sink field event sim steer"
+for dir in $SUBDIRS; do
+    ln -sf "../include" $INCLUDE_TREE/$dir
+done
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
@@ -106,5 +113,6 @@ setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig
 prepend-path PATH \$::env(FAIRROOT_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib
 prepend-path ROOT_INCLUDE_PATH \$::env(FAIRROOT_ROOT)/include
+prepend-path ROOT_INCLUDE_PATH \$::env(FAIRROOT_ROOT)/include_tree
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRROOT_ROOT)/lib")
 EoF

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -70,8 +70,9 @@ cmake $SOURCEDIR                                                                
 
 cmake --build . -- -j$JOBS install
 
+# Work around hardcoded paths in PCM
 for DIR in source sink field event sim steer; do
-    ln -nfs ../include $INSTALLROOT/include/$DIR
+  ln -nfs ../include $INSTALLROOT/include/$DIR
 done
 
 # Modulefile


### PR DESCRIPTION
The present workaround creates a directory `include_tree` alongside `include` in the install directory. `include_tree` contains a number of directory symlinks, all of which point back to `include`: this way we make sure that no matter what FairRoot header is requested by its build dir path, the `#include` statement will find its way to the right file.
We also add the `include_tree` directory to `ROOT_INCLUDE_PATH`.

I am fully aware of the horror of what I'm doing here, but at the moment we are stuck with barely functional FairRoot when using RPMs and CVMFS, which blocks system integration efforts.

Fixes #1194.

This should be removed once FairRoot fixes their build system. 