### PR TITLE
Exclude running the FairMQ.Protocols test suite

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -48,7 +48,9 @@ cmake $SOURCEDIR                                                 \
       -DCMAKE_INSTALL_BINDIR=bin
 
 cmake --build . ${JOBS:+-- -j$JOBS}
-ctest ${JOBS:+-j$JOBS}
+# Exclude running the protocols test suite for now, because it needs certain
+# hardcoded TCP ports to be unused, which is sometimes not the case.
+ctest -E "FairMQ.Protocols" ${JOBS:+-j$JOBS}
 cmake --build . --target install ${JOBS:+-- -j$JOBS}
 
 # ModuleFile


### PR DESCRIPTION
User reports accumulate that the hardcoded TCP ports in the test
suite are in use on their machines, see AliceO2Group/AliceO2#1212 and FairRootGroup/FairMQ#47.