### PR TITLE
Fix JDK check on multiuser systems

### DIFF
--- a/jdk.sh
+++ b/jdk.sh
@@ -4,7 +4,7 @@ build_requires:
   - curl
 prefer_system: .*
 prefer_system_check: |
-  cd /tmp && printf "public class verAliBuild { public static void main(String[] args) { if (Integer.parseInt((System.getProperty(\"java.version\")+\".\").split(\"\\\\\.\")[0]) < 10) System.exit(42); } }" > verAliBuild.java && javac verAliBuild.java && java verAliBuild && rm -f verAliBuild.{java,class}
+  X=$(mktemp -d); cd $X && printf "public class verAliBuild { public static void main(String[] args) { if (Integer.parseInt((System.getProperty(\"java.version\")+\".\").split(\"\\\\\.\")[0]) < 10) System.exit(42); } }" > verAliBuild.java && javac verAliBuild.java && java verAliBuild && rm -rf $X
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
Creating a file under `/tmp` directly was not ideal and could have led to
clashes on multiuser systems