### PR TITLE
Add missing build requirements for ROOT

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -40,6 +40,8 @@ overrides:
       - "GCC-Toolchain:(?!osx)"
       - libpng
       - lzma
+      - libxml2
+      - OpenSSL
   AliRoot:
     version: "%(commit_hash)s_O2"
     requires:

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -41,7 +41,8 @@ overrides:
       - libpng
       - lzma
       - libxml2
-      - OpenSSL
+      - "OpenSSL:(?!osx)"
+      - "osx-system-openssl:(osx.*)"
   AliRoot:
     version: "%(commit_hash)s_O2"
     requires:


### PR DESCRIPTION
Building ROOT on a fresh Ubuntu systems reveals
that there is an actual build dependency on libxml2 and ssl.
This dependency is not reported by aliDoctor and the build fails
when these libraries are not installed.

This commit fixes the problem by explicitely declaring
the dependency for o2.

Please correct as necessary and extend to other defaults etc.