### PR TITLE
Improve ROOT 6 recipe

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -37,6 +37,7 @@ COMPILER_CXX=c++
 COMPILER_LD=c++
 [[ "$CXXFLAGS" == *'-std=c++11'* ]] && CXX11=1 || true
 [[ "$CXXFLAGS" == *'-std=c++14'* ]] && CXX14=1 || true
+[[ "$CXXFLAGS" == *'-std=c++17'* ]] && CXX17=1 || true
 
 case $ARCHITECTURE in
   osx*)
@@ -55,8 +56,8 @@ if [[ $ALIEN_RUNTIME_VERSION ]]; then
   OPENSSL_ROOT=${OPENSSL_ROOT:+$ALIEN_RUNTIME_ROOT}
   XROOTD_ROOT=${XROOTD_VERSION:+$ALIEN_RUNTIME_ROOT}
   LIBXML2_ROOT=${LIBXML2_VERSION:+$ALIEN_RUNTIME_ROOT}
-  [[ $SYS_OPENSSL_ROOT ]] && OPENSSL_ROOT=$SYS_OPENSSL_ROOT
 fi
+[[ $SYS_OPENSSL_ROOT ]] && OPENSSL_ROOT=$SYS_OPENSSL_ROOT
 
 if [[ -d $SOURCEDIR/interpreter/llvm ]]; then
   # ROOT 6+: enable Python
@@ -95,7 +96,7 @@ if [[ $ALICE_DAQ ]]; then
     --disable-alien                     \
     --enable-mysql
   FEATURES="builtin_freetype builtin_pcre minuit2 pythia6 roofit
-            soversion ${CXX11:+cxx11} ${CXX14:+cxx14} mysql xml"
+            soversion ${CXX11:+cxx11} ${CXX14:+cxx14} ${CXX17:+cxx17} mysql xml"
   NO_FEATURES="ssl alien"
 else
   # Standard ROOT build
@@ -109,6 +110,7 @@ else
         ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$XROOTD_ROOT}                                   \
         ${CXX11:+-Dcxx11=ON}                                                             \
         ${CXX14:+-Dcxx14=ON}                                                             \
+        ${CXX17:+-Dcxx17=ON}                                                             \
         -Dfreetype=ON                                                                    \
         -Dbuiltin_freetype=OFF                                                           \
         -Dpcre=OFF                                                                       \
@@ -138,11 +140,15 @@ else
         ${ALIEN_RUNTIME_VERSION:+-Dmonalisa=ON}                                          \
         -Dkrb5=OFF                                                                       \
         -Dgviz=OFF                                                                       \
+        -Dbuiltin_davix=OFF                                                              \
+        -Ddavix=OFF                                                                      \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
-            pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}
-            ${ALIEN_RUNTIME_ROOT:+alien monalisa} ${ROOT_HAS_PYTHON:+python} ${ARROW_VERSION:+arrow}"
-  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 gviz ${ROOT_HAS_NO_PYTHON:+python}"
+            pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${CXX17:+cxx17}
+            ${XROOTD_ROOT:+xrootd} ${ALIEN_RUNTIME_ROOT:+alien monalisa} ${ROOT_HAS_PYTHON:+python}
+            ${ARROW_VERSION:+arrow}"
+  NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 gviz
+               ${ROOT_HAS_NO_PYTHON:+python} builtin_davix davix"
 
   if [[ $ENABLE_COCOA ]]; then
     FEATURES="$FEATURES builtin_freetype"


### PR DESCRIPTION
* Fix incorrect OpenSSL detection for O2 on macOS
* Disable DAVIX (which currently ignores OpenSSL and breaks)
* Add ability to build with C++17 (to be enabled via defaults)