### PR TITLE
Downgrade AliTPCCommon to v1.2 for Run2 software

### DIFF
--- a/alitpccommon.sh
+++ b/alitpccommon.sh
@@ -1,6 +1,6 @@
 package: AliTPCCommon
 version: "%(tag_basename)s"
-tag: alitpccommon-v1.3.1
+tag: alitpccommon-v1.2
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -21,6 +21,8 @@ disable:
   - Ppconsul
   - ApMon-CPP
 overrides:
+  AliTPCCommon:
+    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -19,6 +19,8 @@ disable:
   - hijing
   - HepMC3
 overrides:
+  AliTPCCommon:
+    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -10,6 +10,8 @@ disable:
   - AliEn-Runtime
   - AliRoot
 overrides:
+  AliTPCCommon:
+    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-ninja.sh
+++ b/defaults-o2-ninja.sh
@@ -12,6 +12,8 @@ disable:
   - Ppconsul
   - ApMon-CPP
 overrides:
+  AliTPCCommon:
+    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-prod.sh
+++ b/defaults-o2-prod.sh
@@ -8,6 +8,8 @@ env:
 disable:
   - AliEn-Runtime
 overrides:
+  AliTPCCommon:
+    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -11,6 +11,8 @@ disable:
   - Ppconsul
   - ApMon-CPP
 overrides:
+  AliTPCCommon:
+    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:


### PR DESCRIPTION
* O2 chains will use v1.3.1
* Run2 software will use v1.2