### PR TITLE
Bump AliRoot to v5-09-34 + AliTPCCommon to v1.3.1

### DIFF
--- a/alitpccommon.sh
+++ b/alitpccommon.sh
@@ -1,6 +1,6 @@
 package: AliTPCCommon
 version: "%(tag_basename)s"
-tag: alitpccommon-v1.2
+tag: alitpccommon-v1.3.1
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake

--- a/defaults-alo.sh
+++ b/defaults-alo.sh
@@ -21,8 +21,6 @@ disable:
   - Ppconsul
   - ApMon-CPP
 overrides:
-  AliTPCCommon:
-    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -19,8 +19,6 @@ disable:
   - hijing
   - HepMC3
 overrides:
-  AliTPCCommon:
-    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -10,8 +10,6 @@ disable:
   - AliEn-Runtime
   - AliRoot
 overrides:
-  AliTPCCommon:
-    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-ninja.sh
+++ b/defaults-o2-ninja.sh
@@ -12,8 +12,6 @@ disable:
   - Ppconsul
   - ApMon-CPP
 overrides:
-  AliTPCCommon:
-    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2-prod.sh
+++ b/defaults-o2-prod.sh
@@ -8,8 +8,6 @@ env:
 disable:
   - AliEn-Runtime
 overrides:
-  AliTPCCommon:
-    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -11,8 +11,6 @@ disable:
   - Ppconsul
   - ApMon-CPP
 overrides:
-  AliTPCCommon:
-    tag: alitpccommon-v1.3.1
   autotools:
     tag: v1.5.0
   boost:

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -7,10 +7,10 @@ env:
 overrides:
   AliRoot:
     version: "%(tag_basename)s"
-    tag: v5-09-33
+    tag: v5-09-34
   AliPhysics:
     version: "%(tag_basename)s"
-    tag: v5-09-33-01
+    tag: v5-09-34-01
 ---
 # To be used with aliBuild option `--defaults prod-latest`.
 #

--- a/defaults-pwgmmtest.sh
+++ b/defaults-pwgmmtest.sh
@@ -30,10 +30,10 @@ overrides:
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
   AliRoot:
     version: "%(commit_hash)s_PWGMMTEST"
-    tag: v5-09-33
+    tag: v5-09-34
   AliPhysics:
     version: "%(commit_hash)s_PWGMMTEST"
-    tag: v5-09-33-01
+    tag: v5-09-34-01
   AGILe:
     version: "%(tag_basename)s_PWGMMTEST"
     source: https://github.com/alipwgmm/agile

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -35,10 +35,10 @@ overrides:
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
   AliRoot:
     version: "%(commit_hash)s_ROOT6"
-    tag: v5-09-33
+    tag: v5-09-34
   AliPhysics:
     version: "%(commit_hash)s_ROOT6"
-    tag: v5-09-33-01
+    tag: v5-09-34-01
   GEANT4:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git

--- a/defaults-user-root6.sh
+++ b/defaults-user-root6.sh
@@ -12,14 +12,14 @@ overrides:
       which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-9].*|3.10.*) exit 1 ;; esac
   AliRoot:
     version: "%(tag_basename)s"
-    tag: v5-09-33
+    tag: v5-09-34
     requires:
       - ROOT
       - fastjet:(?!.*ppc64)
       - Vc
   AliPhysics:
     version: "%(tag_basename)s"
-    tag: v5-09-33-01
+    tag: v5-09-34-01
   GCC-Toolchain:
     tag: v7.3.0-alice1
     prefer_system_check: |

--- a/defaults-user.sh
+++ b/defaults-user.sh
@@ -7,14 +7,14 @@ env:
 overrides:
   AliRoot:
     version: "%(tag_basename)s"
-    tag: v5-09-33
+    tag: v5-09-34
     requires:
       - ROOT
       - fastjet:(?!.*ppc64)
       - Vc
   AliPhysics:
     version: "%(tag_basename)s"
-    tag: v5-09-33-01
+    tag: v5-09-34-01
 ---
 # To be used with aliBuild option `--defaults user`.
 #


### PR DESCRIPTION
Realign Run2's AliTPCCommon to v1.3.1 (same as O2). Downgraded in #1216 due to
incompatibilities.