### PR TITLE
Bump generator versions

### DIFF
--- a/ampt.sh
+++ b/ampt.sh
@@ -1,6 +1,6 @@
 package: AMPT
 version: "%(tag_basename)s"
-tag: "v1.26t7-v2.26t7-alice1"
+tag: "v1.26t7b-v2.26t7b-alice1"
 source: https://github.com/alisw/ampt
 requires:
  - "GCC-Toolchain:(?!osx)"

--- a/therminator2.sh
+++ b/therminator2.sh
@@ -1,6 +1,6 @@
 package: Therminator2
 version: "%(tag_basename)s"
-tag: "v2.0.3-alice1"
+tag: "v2.0.3-alice2"
 source: https://github.com/alisw/therminator
 requires:
  - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
In this PR we bump the following versions:
- Therminator -> v2.0.3-alice2
- AMPT -> v1.26t7b-v2.26t7b-alice1

We would then also need a new version of AliGenerators deployed to cvmfs, which then also includes an update for Pythia8:
- Pythia -> 8.235
(which is already merged in alidist).