### PR TITLE
Enable examples in FairMQ builds

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -43,7 +43,7 @@ cmake $SOURCEDIR                                                 \
       -DDISABLE_COLOR=ON                                         \
       -DBUILD_DDS_PLUGIN=ON                                      \
       -DBUILD_NANOMSG_TRANSPORT=ON                               \
-      -DBUILD_EXAMPLES=OFF                                       \
+      -DBUILD_EXAMPLES=ON                                        \
       -DCMAKE_INSTALL_LIBDIR=lib                                 \
       -DCMAKE_INSTALL_BINDIR=bin
 


### PR DESCRIPTION
Useful in this phase to also build FairMQ examples, so I can then use them from RPMs in VMs.