### PR TITLE
Speedup O2 compilation on recent macOS

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -20,6 +20,7 @@ source: https://github.com/AliceO2Group/AliceO2
 prepend_path:
   ROOT_INCLUDE_PATH: "$O2_ROOT/include"
 incremental_recipe: |
+  unset DYLD_LIBRARY_PATH
   cmake --build . -- ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   # install the compilation database so that we can post-check the code
@@ -92,6 +93,7 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
   CXXFLAGS="${CXXFLAGS} -Werror"
 fi
 
+unset DYLD_LIBRARY_PATH
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                        \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                                             \
       -DCMAKE_MODULE_PATH="$SOURCEDIR/cmake/modules;$FAIRROOT_ROOT/share/fairbase/cmake/modules;$FAIRROOT_ROOT/share/fairbase/cmake/modules_old"  \


### PR DESCRIPTION
`DYLD_LIBRARY_PATH` lookups are extremely slow on recent macOS version. Since `DYLD_LIBRARY_PATH` is not really needed at build time because we do the correct rpath relocation on macOS, we drop it from the O2 build instructions. We do not do it globally, because things like generators might actually require it to perform a correct build as well.