### PR TITLE
Bump AliTPCCommon to v1.3.2

### DIFF
--- a/alitpccommon.sh
+++ b/alitpccommon.sh
@@ -1,6 +1,6 @@
 package: AliTPCCommon
 version: "%(tag_basename)s"
-tag: alitpccommon-v1.3.1
+tag: alitpccommon-v1.3.2
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake


### PR DESCRIPTION
Version bump of AliTPCCommon
- bug fix in space charge code (fix compiler warnings), needed for O2 PR AliceO2Group/AliceO2#1278
- Adjust Tracking OuterParam interface in preparation for an upcoming O2 PR