### PR TITLE
Make Ppconsul depend on Ninja

### DIFF
--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -52,6 +52,10 @@ overrides:
   protobuf:
     version: "%(tag_basename)s"
     tag: "v3.5.2"
+  Ppconsul:
+    build_requires:
+      - CMake
+      - ninja
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
     build_requires:


### PR DESCRIPTION
The o2-dev-fairroot default actually uses Ninja for building, so everything which uses CMake should also depend on Ninja.