### PR TITLE
Add root include paths for geant3 / AliRoot-Pythia8

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -108,6 +108,7 @@ setenv ALICE_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(ALIROOT_RELEASE)
 prepend-path PATH \$::env(ALICE_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ALICE_ROOT)/lib
 prepend-path ROOT_INCLUDE_PATH \$::env(ALICE_ROOT)/include
+prepend-path ROOT_INCLUDE_PATH \$::env(ALICE_ROOT)/include/Pythia8
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALICE_ROOT)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/geant3.sh
+++ b/geant3.sh
@@ -39,5 +39,6 @@ setenv GEANT3DIR \$::env(GEANT3_ROOT)
 setenv G3SYS \$::env(GEANT3_ROOT)
 prepend-path PATH \$::env(GEANT3_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(GEANT3_ROOT)/lib64
+prepend-path ROOT_INCLUDE_PATH \$::env(GEANT3_ROOT)/include/TGeant3
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT3_ROOT)/lib64")
 EoF


### PR DESCRIPTION
ROOT 6 needs the include files, and the include paths are not set in the ROOT_INCLUDE_PATH variable in the modulefiles. This fixes it for Pythia8 in AliRoot build, and for Geant3. Sufficient for my setup, we might have a similar problem with other generators.