### PR TITLE
Bump ROOT 6 for Run 2 tests

### DIFF
--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -17,8 +17,8 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x070300)\n#error \"System's GCC cannot be used: we need at least GCC 7.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "v6-14-00+git_%(short_hash)s"
-    tag: "77868d9d46aefa79abbe34776c3617c80c48374b"
+    version: "v6-14-02+git_%(short_hash)s"
+    tag: "a8cc688c984fec81a3deeacdcec020c0aa93880c"
     source: https://github.com/root-mirror/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)


### PR DESCRIPTION
Does not affect O2 and Run 2 stable ROOT 6 versions