### PR TITLE
Add OpenSSL version check

### DIFF
--- a/openssl.sh
+++ b/openssl.sh
@@ -4,7 +4,7 @@ tag: OpenSSL_1_0_2o
 source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
+  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER >= 0x10100000L\n#error \"System's GCC cannot be used: we need OpenSSL 1.0.x to build XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -xc++ - -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Extends current check in such a way that OpenSSL <1.1.0
is required, otherwise OpenSSL will be built by alibuild.
This is required to build xrootd 3.3.6.

@Atlantic777