### PR TITLE
Make OpenSSL not a dependency on macOS

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -48,7 +48,7 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - libxml2
-      - OpenSSL
+      - OpenSSL:(?!osx)
       - "GCC-Toolchain:(?!osx)"
       - libpng
       - lzma

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -39,7 +39,7 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - libxml2
-      - OpenSSL
+      - OpenSSL:(?!osx)
       - "GCC-Toolchain:(?!osx)"
       - libpng
       - lzma


### PR DESCRIPTION
Fixes #1249