### PR TITLE
Use initial-exec as threading model for G4(MT) mode

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -31,7 +31,7 @@ cmake $SOURCEDIR                                    \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"        \
   -DCMAKE_INSTALL_LIBDIR="lib"                      \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo                 \
-  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"  \
+  -DGEANT4_BUILD_TLS_MODEL:STRING="initial-exec"    \
   -DGEANT4_ENABLE_TESTING=OFF                       \
   -DBUILD_SHARED_LIBS=ON                            \
   -DGEANT4_INSTALL_EXAMPLES=OFF                     \


### PR DESCRIPTION
There is a performance problem with `global-dynamic` as reported in https://alice.its.cern.ch/jira/browse/O2-172 and
`initial-exec` is the suggested and working solution.

Note that this change does not affect any production as it will only take effect when MT is enabled (which is not the case by default yet).