### PR TITLE
Allow to compile aliroot/aliphysics with ninja

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -11,7 +11,7 @@ env:
 prepend_path:
   ROOT_INCLUDE_PATH: "$ALIPHYSICS_ROOT/include"
 incremental_recipe: |
-  make ${JOBS:+-j$JOBS} install
+  cmake --build . -- ${JOBS:+-j$JOBS} install
   ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
   cp -v compile_commands.json ${INSTALLROOT}
   DEVEL_SOURCES="$(readlink "$SOURCEDIR" || echo "$SOURCEDIR")"
@@ -37,6 +37,7 @@ cmake "$SOURCEDIR"                                                 \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                        \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                           \
       -DROOTSYS="$ROOT_ROOT"                                       \
+      ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                    \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}  \
       ${ALIEN_RUNTIME_ROOT:+-DALIEN="$ALIEN_RUNTIME_ROOT"}         \
       ${FASTJET_ROOT:+-DFASTJET="$FASTJET_ROOT"}                   \
@@ -45,7 +46,7 @@ cmake "$SOURCEDIR"                                                 \
       ${GMP_ROOT:+-DGMP="$GMP_ROOT"}                               \
       -DALIROOT="$ALIROOT_ROOT"
 
-make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
+cmake --build . -- ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 # ctest will succeed if no load_library tests were found
 ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
 

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -18,7 +18,7 @@ prepend_path:
   ROOT_INCLUDE_PATH: "$ALIROOT_ROOT/include"
 source: https://github.com/alisw/AliRoot
 incremental_recipe: |
-  make ${JOBS:+-j$JOBS} install
+  cmake --build . -- ${JOBS:+-j$JOBS} install
   ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
   cp -v ${BUILDDIR}/compile_commands.json ${INSTALLROOT}
   DEVEL_SOURCES="$(readlink "$SOURCEDIR" || echo "$SOURCEDIR")"
@@ -53,6 +53,7 @@ cmake $SOURCEDIR                                                     \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                          \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                             \
       -DROOTSYS="$ROOT_ROOT"                                         \
+      ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                      \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}    \
       ${ALIEN_RUNTIME_ROOT:+-DALIEN="$ALIEN_RUNTIME_ROOT"}           \
       ${FASTJET_ROOT:+-DFASTJET="$FASTJET_ROOT"}                     \
@@ -68,7 +69,7 @@ cmake $SOURCEDIR                                                     \
       ${ALICE_SHUTTLE:+-DSHUTTLE=ON -DApMon=$ALIEN_RUNTIME_ROOT}     \
       -DOCDB_INSTALL=PLACEHOLDER
 
-make ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
+cmake --build . -- ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 # ctest will succeed if no load_library tests were found
 ctest -R load_library --output-on-failure ${JOBS:+-j $JOBS}
 [[ $ALICE_DAQ && ! $ALICE_DISABLE_DA_RPMS ]] && { make daqDA-all-rpm && make ${JOBS+-j $JOBS} install; }

--- a/defaults-root6-ninja.sh
+++ b/defaults-root6-ninja.sh
@@ -18,7 +18,6 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x070300)\n#error \"System's GCC cannot be used: we need at least GCC 7.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   ROOT:
-    version: "%(tag_basename)s"
     tag: "v6-10-08"
     source: https://github.com/root-mirror/root
     requires:
@@ -41,12 +40,16 @@ overrides:
   AliRoot:
     version: "%(commit_hash)s_ROOT6"
     tag: v5-09-38
-    build-requires:
+    build_requires:
+      - CMake
+      - "Xcode:(osx.*)"
+      - AliTPCCommon
       - ninja
   AliPhysics:
     version: "%(commit_hash)s_ROOT6"
     tag: v5-09-38-01
     build-requires:
+      - "Xcode:(osx.*)"
       - ninja
   GEANT4:
     tag: v10.3.3

--- a/defaults-root6-ninja.sh
+++ b/defaults-root6-ninja.sh
@@ -1,0 +1,60 @@
+package: defaults-root6-ninja
+version: v1
+env:
+  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CFLAGS: "-fPIC -g -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+  CMAKE_GENERATOR: "Ninja"
+overrides:
+  CMake:
+    version: "%(tag_basename)s"
+    tag: "v3.11.0"
+    prefer_system_check: |
+      which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-9].*|3.10.*) exit 1 ;; esac
+  GCC-Toolchain:
+    tag: v7.3.0-alice1
+    prefer_system_check: |
+      set -e
+      which gfortran || { echo "gfortran missing"; exit 1; }
+      which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x070300)\n#error \"System's GCC cannot be used: we need at least GCC 7.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
+  ROOT:
+    version: "%(tag_basename)s"
+    tag: "v6-10-08"
+    source: https://github.com/root-mirror/root
+    requires:
+      - AliEn-Runtime:(?!.*ppc64)
+      - GSL
+      - opengl:(?!osx)
+      - Xdevel:(?!osx)
+      - FreeType:(?!osx)
+      - Python-modules
+      - "GCC-Toolchain:(?!osx)"
+      - libpng
+      - lzma
+    build_requires:
+      - CMake
+      - "Xcode:(osx.*)"
+      - ninja
+  GSL:
+    prefer_system_check: |
+      printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null
+  AliRoot:
+    version: "%(commit_hash)s_ROOT6"
+    tag: v5-09-38
+    build-requires:
+      - ninja
+  AliPhysics:
+    version: "%(commit_hash)s_ROOT6"
+    tag: v5-09-38-01
+    build-requires:
+      - ninja
+  GEANT4:
+    tag: v10.3.3
+    source: https://gitlab.cern.ch/geant4/geant4.git
+  GEANT4_VMC:
+    tag: "v3-5"
+    source: https://github.com/vmc-project/geant4_vmc
+---
+# This file is included in any build recipe and it's only used to set
+# environment variables. Which file to actually include can be defined by the
+# "--defaults" option of alibuild.

--- a/defaults-root6-ninja.sh
+++ b/defaults-root6-ninja.sh
@@ -17,6 +17,15 @@ overrides:
       set -e
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x070300)\n#error \"System's GCC cannot be used: we need at least GCC 7.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
+  XRootD:
+    build_requires:
+      - CMake
+      - "OpenSSL:(?!osx)"
+      - "osx-system-openssl:(osx.*)"
+      - ApMon-CPP
+      - libxml2
+      - "GCC-Toolchain:(?!osx)"
+      - ninja
   ROOT:
     tag: "v6-10-08"
     source: https://github.com/root-mirror/root

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -29,8 +29,7 @@ cmake "$SOURCEDIR"                                      \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"     \
       -DZLIB_ROOT=$ZLIB_ROOT
-make ${JOBS:+-j$JOBS}
-make install
+cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
This PR introduces the possibility to compile aliroot/aliphysics with ninja.
Ninja is used only if the dedicated default (defaults-root6-ninja) is used. Otherwise, make will be used as default.
I tested that this PR has no impact whatsoever on the current workflow, unless the new default is explicitly called.