### PR TITLE
Bump AliTPCCommon to v1.4.1 - fix MacOS compilation

### DIFF
--- a/alitpccommon.sh
+++ b/alitpccommon.sh
@@ -1,6 +1,6 @@
 package: AliTPCCommon
 version: "%(tag_basename)s"
-tag: alitpccommon-v1.4
+tag: alitpccommon-v1.4.1
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake


### PR DESCRIPTION
@ktf @dberzano Fix for macos compile issue reported by Giulio
@martenole: As it is kind of urgent, I slightly changed the TRD class to make it compile.