### PR TITLE
nanomsg: move to 1.1.3

### DIFF
--- a/nanomsg.sh
+++ b/nanomsg.sh
@@ -1,6 +1,5 @@
 package: nanomsg
-version: v1.0.0+git_%(short_hash)s
-tag: c52f1bedca6b72fb31b473929d99f2fe90a13445
+version:  1.1.3
 source: https://github.com/nanomsg/nanomsg
 build_requires:
   - CMake


### PR DESCRIPTION
Apparently this is required by latest FairMQ.