### PR TITLE
bump fairmq

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.2.6
+tag: v1.2.7.1
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
This bumps fairmq to 1.2.7.1 containing an important bug fix. See https://github.com/FairRootGroup/FairMQ/issues/83.