### PR TITLE
Add ROOT_INCLUDE_PATH to GEANT3

### DIFF
--- a/geant3.sh
+++ b/geant3.sh
@@ -8,8 +8,9 @@ build_requires:
   - "Xcode:(osx.*)"
 source: https://github.com/vmc-project/geant3
 prepend_path:
-  "LD_LIBRARY_PATH": "$GEANT3_ROOT/lib64"
-  "DYLD_LIBRARY_PATH": "$GEANT3_ROOT/lib64"
+  LD_LIBRARY_PATH: "$GEANT3_ROOT/lib64"
+  DYLD_LIBRARY_PATH: "$GEANT3_ROOT/lib64"
+  ROOT_INCLUDE_PATH: "$GEANT3_ROOT/include/TGeant3"
 ---
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \


### PR DESCRIPTION
Same rationale as #1300. Note that in this case we had already the proper export in the Modulefile, but not in the recipe itself.