### PR TITLE
add boost to ROOT INCLUDE PATH

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -9,6 +9,8 @@ build_requires:
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include \"boost/version.hpp\"\n# if (BOOST_VERSION < 105900)\n#error \"Cannot use system's boost. Boost > 1.59.00 required.\"\n#endif\nint main(){}" | gcc -I$(brew --prefix boost)/include -xc++ - -o /dev/null
+prepend_path:
+  ROOT_INCLUDE_PATH: "$BOOST_ROOT/include"
 ---
 #!/bin/bash -e
 
@@ -83,5 +85,6 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSI
 # Our environment
 setenv BOOST_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(BOOST_ROOT)/lib
+prepend-path ROOT_INCLUDE_PATH \$::env(BOOST_ROOT)/include
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BOOST_ROOT)/lib")
 EoF


### PR DESCRIPTION
Hi @dberzano @ktf 

Also the aliBuild-installed boost needs to be added to the ROOT_INCLUDE_PATH 
to have the macros compilable. Otherwise we get e.g.:
```.x /home/shahoian/alice/sw/ubuntu1710_x86-64/O2/dev-1/share/macro/run_match_TPCITS.C+(...
...
In file included from /home/shahoian/alice/sw/ubuntu1710_x86-64/O2/dev-1/share/macro/run_match_TPCITS.C:14:
In file included from /home/shahoian/alice/sw/ubuntu1710_x86-64/O2/dev-1/include/GlobalTracking/MatchTPCITS.h:25:
In file included from /home/shahoian/alice/sw/ubuntu1710_x86-64/O2/dev-1/include/DataFormatsTPC/TrackTPC.h:18:
/home/shahoian/alice/sw/ubuntu1710_x86-64/O2/dev-1/include/DataFormatsTPC/Cluster.h:18:10: fatal error: 'boost/serialization/base_object.hpp' file not found
```
