### PR TITLE
Remove explicit flag for Monitoring

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -128,7 +128,6 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                               \
       ${ALITPCCOMMON_ROOT:+-DALITPCCOMMON_DIR=$ALITPCCOMMON_ROOT}                           \
-      ${MONITORING_VERSION:+-DMonitoring_ROOT=$MONITORING_ROOT}                             \
       ${CONFIGURATION_VERSION:+-DConfiguration_ROOT=$CONFIGURATION_ROOT}                    \
       ${LIBINFOLOGGER_VERSION:+-DInfoLogger_ROOT=$LIBINFOLOGGER_ROOT}                       \
       ${COMMON_O2_VERSION:+-DCommon_O2_ROOT=$COMMON_O2_ROOT}                                \

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -30,7 +30,6 @@ cmake $SOURCEDIR                                              \
       -DBOOST_ROOT=$BOOST_ROOT                                \
       -DCommon_ROOT=$COMMON_O2_ROOT                           \
       -DDataSampling_ROOT=$DATASAMPLING_ROOT                  \
-      -DMonitoring_ROOT=$MONITORING_ROOT                      \
       -DConfiguration_ROOT=$CONFIGURATION_ROOT                \
       -DInfoLogger_ROOT=$INFOLOGGER_ROOT                      \
       -DO2_ROOT=$O2_ROOT                                      \


### PR DESCRIPTION
It is not needed anymore thanks to the use of modern cmake in monitoring.