### PR TITLE
Fix loading of platform-specific toolchain

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -144,7 +144,7 @@ module load BASE/1.0
 regexp -- "^(.*)/.*\$" [module-info name] dummy mod_name
 if { "\$mod_name" == "GCC-Toolchain" } {
   module load Toolchain/GCC-${PKGVERSION//-*}
-  if { [is-loaded Toolchain] } { break }
+  if { [is-loaded Toolchain] } { continue }
   set base_path \$::env(BASEDIR)
 } else {
   # Loading Toolchain: autodetect prefix


### PR DESCRIPTION
In order to support several builds with the same build set on Linux,
a GCC-Toolchain Modulefile for one platform has instructions to stop loading
itself and load a more appropriate implementation for the current runtime
platform.

This allows, for instance, CC7-produced binaries to work on Ubuntu: when
deployed on CVMFS, the CC7 binaries will be loaded, plus the Ubuntu-compiled
GCC-Toolchain.

`modulecmd` might however get confused by the use of the keyword `break` to
stop loading a module; `break` works but - as per the documentation - does not
register the current module as loaded. `continue` does the same but performs the
registration. Since the module is _actually_ loaded (as it sets environment
variables), `modulecmd` needs to know that this is the case in order to properly
create the `export` commands for the shell.

Using `break` led to GCC-Toolchain deployments that work most of the time, and
by chance, but we found cases of broken behaviour that are fixed by this.