### PR TITLE
Bump Monitoring to 1.9.3

### DIFF
--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v1.9.2
+tag: v1.9.3
 requires:
   - curl
   - boost


### PR DESCRIPTION
Installs library to `lib` instead of `lib64` on CC7.