### PR TITLE
Use the same variable to enable and check Alien

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -148,7 +148,7 @@ else
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http fortran
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${CXX17:+cxx17}
-            ${XROOTD_ROOT:+xrootd} ${ALIEN_RUNTIME_ROOT:+alien monalisa} ${ROOT_HAS_PYTHON:+python}
+            ${XROOTD_ROOT:+xrootd} ${ALIEN_RUNTIME_VERSION:+alien monalisa} ${ROOT_HAS_PYTHON:+python}
             ${ARROW_VERSION:+arrow}"
   NO_FEATURES="root7 ${LZMA_VERSION:+builtin_lzma} ${LIBPNG_VERSION:+builtin_png} krb5 gviz
                ${ROOT_HAS_NO_PYTHON:+python} builtin_davix davix"


### PR DESCRIPTION
If you have both O2 and AliRoot in the same working environment $ALIEN_RUNTIME_ROOT might be set while $ALIEN_RUNTIME_VERSION is not while compiling O2.
With this fix you prevent having alien NOT added to the configuration but checked afterwards (that was breaking ROOT compilation with o2 defaults in some configurations of the working directory/env).