### PR TITLE
Bump geant4_vmc to v3-5-p2:

### DIFF
--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -45,7 +45,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p2"
     source: https://github.com/vmc-project/geant4_vmc
 ---
 # This file is included in any build recipe and it's only used to set

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -85,7 +85,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p2"
     source: https://github.com/vmc-project/geant4_vmc
   vgm:
     tag: "v4-4"

--- a/defaults-o2-ninja.sh
+++ b/defaults-o2-ninja.sh
@@ -82,7 +82,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p2"
     source: https://github.com/vmc-project/geant4_vmc
   vgm:
     tag: "v4-4"

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -73,7 +73,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p2"
     source: https://github.com/vmc-project/geant4_vmc
   vgm:
     tag: "v4-4"

--- a/defaults-root6-ninja.sh
+++ b/defaults-root6-ninja.sh
@@ -64,7 +64,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p2"
     source: https://github.com/vmc-project/geant4_vmc
 ---
 # This file is included in any build recipe and it's only used to set

--- a/defaults-root6.sh
+++ b/defaults-root6.sh
@@ -42,7 +42,7 @@ overrides:
     tag: v10.3.3
     source: https://gitlab.cern.ch/geant4/geant4.git
   GEANT4_VMC:
-    tag: "v3-5"
+    tag: "v3-5-p2"
     source: https://github.com/vmc-project/geant4_vmc
 ---
 # This file is included in any build recipe and it's only used to set


### PR DESCRIPTION
This version conatains several fixes needed for O2 Geant4 simulation.