### PR TITLE
Bump configuration to v2.1.0

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -1,6 +1,6 @@
 package: Configuration
 version: "%(tag_basename)s"
-tag:  v2.0.2
+tag:  v2.1.0
 requires:
   - curl
   - boost


### PR DESCRIPTION
This is required by Readout `v0.14.0`.