### PR TITLE
bump jalien to 1.0.5

### DIFF
--- a/jalien.sh
+++ b/jalien.sh
@@ -1,6 +1,6 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.0.4"
+tag: "1.0.5"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
  - JDK


### PR DESCRIPTION
Main fix is ZIP archive storing of ROOT files (disabling compression to make it fully ROOT-compatible)