### PR TITLE
Build Python's own libffi

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -61,7 +61,6 @@ fi
 ./configure --prefix=$INSTALLROOT \
             --enable-shared       \
             --with-system-expat   \
-            --with-system-ffi     \
             --enable-unicode=ucs4
 make  # no multicore
 make install


### PR DESCRIPTION
Prevents "libffi.so.5 not found" problem if running on a platform different than
the build one.