### PR TITLE
Bump to llvm/clang 7.0

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -1,7 +1,7 @@
 package: Clang
 version: "7.0"
-source: https://github.com/alisw/clang
 tag: master
+source: https://github.com/alisw/clang
 build_requires:
  - CMake
 ---

--- a/clang.sh
+++ b/clang.sh
@@ -1,5 +1,5 @@
 package: Clang
-version: "3.9"
+version: "7.0"
 source: https://github.com/alisw/clang
 tag: master
 build_requires:

--- a/clang.sh
+++ b/clang.sh
@@ -1,6 +1,6 @@
 package: Clang
-version: "7.0"
-tag: master
+version: "7.0.0"
+tag: v7.0.0
 source: https://github.com/alisw/clang
 build_requires:
  - CMake


### PR DESCRIPTION
Necessary to resolve https://alice.its.cern.ch/jira/browse/O2-412;
Needs to be merge **after** https://github.com/alisw/clang/pull/2 and a new tag has been created.