### PR TITLE
Add libtirpc

### DIFF
--- a/libtirpc.sh
+++ b/libtirpc.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "libtirpc-1-1-4"
 source: git://git.linux-nfs.org/projects/steved/libtirpc.git
 build_requires:
-  - CMake
+  - autotools
   - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e

--- a/libtirpc.sh
+++ b/libtirpc.sh
@@ -1,0 +1,32 @@
+package: libtirpc
+version: "%(tag_basename)s"
+tag: "libtirpc-1-1-4"
+source: git://git.linux-nfs.org/projects/steved/libtirpc.git
+build_requires:
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
+---
+#!/bin/bash -e
+(cd ${SOURCEDIR} && ./bootstrap)
+${SOURCEDIR}/configure --enable-shared=no --prefix=${INSTALLROOT}
+make ${JOBS+-j $JOBS} install
+rm -rf ${INSTALLROOT}/share
+
+# Modulefile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv LIBTIRPC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(LIBTIRPC_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LIBTIRPC_ROOT)/lib")
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/libtirpc.sh
+++ b/libtirpc.sh
@@ -7,8 +7,9 @@ build_requires:
   - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
-(cd ${SOURCEDIR} && ./bootstrap)
-${SOURCEDIR}/configure --enable-shared=no --prefix=${INSTALLROOT}
+rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
+./bootstrap
+./configure --enable-shared=no --prefix=${INSTALLROOT}
 make ${JOBS+-j $JOBS} install
 rm -rf ${INSTALLROOT}/share
 

--- a/libtirpc.sh
+++ b/libtirpc.sh
@@ -11,7 +11,7 @@ rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 ./bootstrap
 ./configure --enable-shared=no --prefix=${INSTALLROOT}
 make ${JOBS+-j $JOBS} install
-rm -rf ${INSTALLROOT}/share
+rm -rf ${INSTALLROOT}/share "${INSTALLROOT}"/lib/*.la "${INSTALLROOT}"/lib/pkgconfig
 
 # Modulefile
 mkdir -p etc/modulefiles


### PR DESCRIPTION
starting with glibc 2.28 rpc.h is no longer part of glibc
and instead of /usr/include/rpc/rpc.h it is found in libtirpc
package in /usr/include/tirpc/rpc/rpc.h