### PR TITLE
Be explicit on the boost dependency.

### DIFF
--- a/alo-aliroot.sh
+++ b/alo-aliroot.sh
@@ -5,6 +5,7 @@ requires:
   - googlebenchmark
   - AliRoot
   - RapidJSON
+  - boost
 build_requires:
   - CMake
   - flatbuffers


### PR DESCRIPTION
This way we can build without fasjet (which is the one bringing the
boost dependency otherwise)