### PR TITLE
Add O2Suite and tag O2

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -64,6 +64,7 @@ overrides:
       which cmake && case `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3 | head -n1` in [0-2]*|3.[0-9].*|3.10.*) exit 1 ;; esac
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
+    tag: dev
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -59,6 +59,7 @@ overrides:
       - ninja
   O2:
     version: "%(short_hash)s%(defaults_upper)s"
+    tag: dev
     build_requires:
       - lcov
       - ninja

--- a/defaults-o2-ninja.sh
+++ b/defaults-o2-ninja.sh
@@ -92,11 +92,13 @@ overrides:
       - googletest
       - ninja
   O2:
-     build_requires:
-       - ninja
-       - RapidJSON
-       - googlebenchmark
-       - AliTPCCommon
+    version: "%(short_hash)s"
+    tag: dev
+    build_requires:
+      - ninja
+      - RapidJSON
+      - googlebenchmark
+      - AliTPCCommon
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/o2.sh
+++ b/o2.sh
@@ -1,6 +1,6 @@
 package: O2
-version: "%(tag_basename)s"
-tag: dev
+version: "1.0.0"
+tag: "O2-1.0.0"
 requires:
   - arrow
   - FairRoot

--- a/o2suite.sh
+++ b/o2suite.sh
@@ -1,0 +1,48 @@
+package: O2Suite
+version: "1.0.0"
+tag: "O2Suite-1.0.0"
+requires:
+  - Common-O2
+  - Monitoring
+  - Configuration
+  - O2
+  - "GCC-Toolchain:(?!osx)"
+  - InfoLogger
+  - ReadoutCard
+  - Readout
+  - qcg
+  - QualityControl
+valid_defaults:
+  - o2
+  - o2-dataflow
+  - o2-dev-fairroot
+  - alo
+  - o2-prod
+  - o2-ninja
+---
+#!/bin/bash -ex
+
+MODULEFILE_DEPS=
+for RPKG in $REQUIRES; do
+  [[ $RPKG != defaults* ]] || continue
+  RPKG_UP=$(echo $RPKG|tr '[:lower:]' '[:upper:]'|tr '-' '_')
+  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
+  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
+  MODULEFILE_DEPS="${MODULEFILE_DEPS} ${RPKG}/${RPKG_VERSION}-${RPKG_REVISION}"
+done
+MODULEFILE_DEPS=$(echo $MODULEFILE_DEPS)
+
+# Modulefile
+mkdir -p $INSTALLROOT/etc/modulefiles
+cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+
+# Dependencies
+module load BASE/1.0 ${MODULEFILE_DEPS}
+EoF


### PR DESCRIPTION
* The O2Suite metapackage builds the whole O2 software components. It will be
  also used for testing the Pull Requests more accurately
* O2 has been bumped to 1.0.0. All software built with the `o2` default will
  use O2 1.0.0 as a reference. `o2-dataflow`, `o2-ninja`, `o2-dev-fairroot`
  will instead use `dev`

See O2-426.