### PR TITLE
Align ROOT options of *next-root6

### DIFF
--- a/defaults-user-next-root6.sh
+++ b/defaults-user-next-root6.sh
@@ -40,6 +40,8 @@ overrides:
       - FreeType:(?!osx)
       - Python-modules
       - "GCC-Toolchain:(?!osx)"
+      - libpng
+      - lzma
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | gcc  -I$(brew --prefix gsl)/include -xc++ - -o /dev/null


### PR DESCRIPTION
There is no reason to have different options. By using the same, most of the
cached builds for `next-root6` will also work for `user-next-root6`.