### PR TITLE
Add dependencies required by the ITS GPU builds

### DIFF
--- a/cub.sh
+++ b/cub.sh
@@ -1,0 +1,24 @@
+package: cub
+version: "%(tag_basename)s"
+tag: v1.8.0
+source: https://github.com/NVlabs/cub.git
+---
+#!/bin/bash -e
+rsync -a --delete --exclude='**/.git' --delete-excluded "$SOURCEDIR/" "$INSTALLROOT/"
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+setenv CUB_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+EoF

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -66,6 +66,7 @@ overrides:
       - RapidJSON
       - googlebenchmark
       - AliTPCCommon
+      - cub
   CMake:
     version: "%(tag_basename)s"
     tag: "v3.11.0"

--- a/defaults-o2-ninja.sh
+++ b/defaults-o2-ninja.sh
@@ -99,6 +99,7 @@ overrides:
       - RapidJSON
       - googlebenchmark
       - AliTPCCommon
+      - cub
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/o2.sh
+++ b/o2.sh
@@ -19,6 +19,7 @@ build_requires:
   - RapidJSON
   - googlebenchmark
   - AliTPCCommon
+  - cub
 source: https://github.com/AliceO2Group/AliceO2
 prepend_path:
   ROOT_INCLUDE_PATH: "$O2_ROOT/include"
@@ -135,7 +136,8 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       -DRAPIDJSON_INCLUDEDIR=${RAPIDJSON_ROOT}/include                                      \
       ${ARROW_ROOT:+-DARROW_HOME=$ARROW_ROOT}                                               \
       -Dbenchmark_DIR=${GOOGLEBENCHMARK_ROOT}/lib/cmake/benchmark                           \
-      ${GLFW_ROOT:+-DGLFW_LOCATION=$GLFW_ROOT}
+      ${GLFW_ROOT:+-DGLFW_LOCATION=$GLFW_ROOT}                                              \
+      ${CUB_ROOT:+-DCUB_ROOT=$CUB_ROOT}
 
 
 cmake --build . -- ${JOBS+-j $JOBS} install


### PR DESCRIPTION
Hi @dberzano ,

this header only package will be required as a dependency of O2 for building the ITS CUDA tracker.
No other PR depends on this so... low priority.

Cheers!
Max