### PR TITLE
Fix JAliEn wrong GCC dependencies

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -1,14 +1,14 @@
 package: defaults-jalien
 version: v1
 overrides:
-  xrootd:
+  XRootD:
     version: "%(tag_basename)s_JALIEN"
     tag: "v4.8.5"
     source: https://github.com/xrootd/xrootd
     build_requires:
       - CMake
-      - "GCC-Toolchain:(?!osx)"
     requires:
+      - "GCC-Toolchain:(?!osx)"
       - "OpenSSL:(?!osx)"
       - "osx-system-openssl:(osx.*)"
       - ApMon-CPP
@@ -32,6 +32,10 @@ overrides:
       - "GCC-Toolchain:(?!osx)"
   ApMon-CPP:
     version: "%(tag_basename)s"
+    requires:
+      - "GCC-Toolchain:(?!osx)"
+    build_requires:
+      - autotools
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
GCC-Toolchain is a runtime dependency, not just a build dependency