### PR TITLE
Correctly pick up CXX standard in roounfold.sh

### DIFF
--- a/roounfold.sh
+++ b/roounfold.sh
@@ -6,8 +6,9 @@ requires:
  - ROOT
  - boost
 ---
-cmake $SOURCEDIR                          \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+cmake $SOURCEDIR                              \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \
+      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD} \
       -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j$JOBS} install
 make test


### PR DESCRIPTION
Fixing compile error on Ubuntu 16.04 with `aliBuild build AliPhysics defaults=o2`. In this case, the compilation did not use (or pickup) the correct C++ standard and failed.
I believe that similar things should be done for every recipe using cmake.