### PR TITLE
New recipe for Monte Carlo step logger

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,7 @@ geant*              @alisw/simulation-experts
 vmc*                @alisw/simulation-experts
 vgm*                @alisw/simulation-experts
 vecgeom*            @alisw/simulation-experts
+mcsteplogger*       @alisw/simulation-experts
 
 # Muon Run3 Reconstruction Task Force
 alo*                @alisw/mrrtf

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,0 +1,40 @@
+package: MCStepLogger
+version: "%(tag_basename)s"
+tag: master
+source: https://github.com/AliceO2Group/VMCStepLogger.git
+requires:
+  - "GCC-Toolchain:(?!osx)"
+  - ROOT
+  - boost
+build_requires:
+  - CMake
+---
+
+#!/bin/bash -e
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
+          ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \
+          -DROOT_DIR=${ROOT_ROOT}                      \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${ROOT_VERSION:+ROOT/$ROOT_VERSION-$ROOT_REVISION}
+# Our environment
+set osname [uname sysname]
+setenv MCSTEPLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(MCSTEPLOGGER_ROOT)/lib
+EoF


### PR DESCRIPTION
New recipe needed after this logger was separated from O2
in order to commonly be of use to AliRoot, O2, and in fact any
implementation of a VMC.