### PR TITLE
o2: require MCStepLogger

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -15,6 +15,7 @@ requires:
   - ms_gsl
   - FairMQ
   - curl
+  - MCStepLogger
 build_requires:
   - RapidJSON
   - googlebenchmark


### PR DESCRIPTION
Since the code was externalized, we need to mention this
as a dependency.