### PR TITLE
Adding RooUnfold to AliPhysics in build and module

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -43,6 +43,7 @@ cmake "$SOURCEDIR"                                                 \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}  \
       ${ALIEN_RUNTIME_ROOT:+-DALIEN="$ALIEN_RUNTIME_ROOT"}         \
       ${FASTJET_ROOT:+-DFASTJET="$FASTJET_ROOT"}                   \
+      ${ROOUNFOLD_ROOT:+-DROOUNFOLD="$ROOUNFOLD_ROOT"}             \
       ${CGAL_ROOT:+-DCGAL="$CGAL_ROOT"}                            \
       ${MPFR_ROOT:+-DMPFR="$MPFR_ROOT"}                            \
       ${GMP_ROOT:+-DGMP="$GMP_ROOT"}                               \
@@ -77,7 +78,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION
+module load BASE/1.0 AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION ${ROOUNFOLD_VERSION:+RooUnfold/$ROOUNFOLD_VERSION-$ROOUNFOLD_REVISION}
 # Our environment
 setenv ALIPHYSICS_VERSION \$version
 setenv ALIPHYSICS_RELEASE \$::env(ALIPHYSICS_VERSION)


### PR DESCRIPTION
Enabling builds of AliPhysics with RooUnfold and
include it also in the modulefile. This is necessary
in order to have access to RooUnfold classes in
AliPhysics, needed in order to fill ND response
matrices on the grid.