### PR TITLE
Fix cgal and fastjet build with c++17 on MacOS

### DIFF
--- a/cgal.sh
+++ b/cgal.sh
@@ -1,5 +1,5 @@
 package: cgal
-version: "v4.6.3"
+version: "4.6.3"
 requires:
   - boost
 build_requires:
@@ -15,17 +15,15 @@ case $ARCHITECTURE in
     [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
   ;;
 esac
-PKGID=35136
-URL="https://gforge.inria.fr/frs/download.php/file/${PKGID}/"
+URL="https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$PKGVERSION/CGAL-$PKGVERSION.tar.xz"
 
-curl -kLo cgal.tar.bz2 "$URL"
-tar xjf cgal.tar.bz2
+curl -kLo cgal.tar.xz "$URL"
+tar xJf cgal.tar.xz
 cd CGAL-*
 
 if [[ "$BOOST_ROOT" != '' ]]; then
   export LDFLAGS="-L$BOOST_ROOT/lib"
   export LD_LIBRARY_PATH="$BOOST_ROOT/lib:$LD_LIBRARY_PATH"
-  export DYLD_LIBRARY_PATH="$BOOST_ROOT/lib:$DYLD_LIBRARY_PATH"
 fi
 
 export MPFR_LIB_DIR="${MPFR_ROOT}/lib"
@@ -87,5 +85,4 @@ module load BASE/1.0 ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}
 setenv CGAL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(CGAL_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(CGAL_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(CGAL_ROOT)/lib")
 EoF

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -29,6 +29,10 @@ overrides:
     version: "%(commit_hash)s_O2"
   ROOT:
     tag: "v6-18-04" 
+  cgal:
+    version: "4.11"
+  fastjet:
+    tag: "v3.3.2_1.041-alice1"
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/fastjet.sh
+++ b/fastjet.sh
@@ -24,7 +24,7 @@ printf "void main() {}" | c++ -xc ${BOOST_ROOT:+-L$BOOST_ROOT/lib} -lboost_threa
   || BOOST_LIBS="${BOOST_ROOT+-L$BOOST_ROOT/lib} -lboost_thread-mt"
 BOOST_LIBS="$BOOST_LIBS -lboost_system"
 
-rsync -a --delete --cvs-exclude $SOURCEDIR/ ./
+rsync -a --delete --cvs-exclude --exclude .git $SOURCEDIR/ ./
 
 # FastJet
 pushd fastjet
@@ -79,5 +79,4 @@ setenv FASTJET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(FASTJET_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(FASTJET_ROOT)/lib
 prepend-path ROOT_INCLUDE_PATH \$::env(FASTJET_ROOT)/include
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FASTJET_ROOT)/lib")
 EoF


### PR DESCRIPTION
@sawenzel : I had the same issue now, this PR fixes the build at least for cgal.
I thought it is simpler this way than forking cgal in github alisw.

Btw: There are some more c++17 problems in fastjet, which uses random_shuffle, which has been removed. Besides, AliRoot builds on macos with defaults o2 for me.