### PR TITLE
[WIP] Rename AliTPCCommon to AliGPU and bump to 2.5.0

### DIFF
--- a/aligpu.sh
+++ b/aligpu.sh
@@ -1,6 +1,6 @@
-package: AliTPCCommon
+package: AliGPU
 version: "%(tag_basename)s"
-tag: alitpccommon-v2.3.2.1
+tag: aligpu-v2.5.0
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake
@@ -27,5 +27,5 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0
-setenv ALITPCCOMMON_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv ALIGPU_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 EoF

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -11,7 +11,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
-  - AliTPCCommon
+  - AliGPU
 env:
   ALICE_ROOT: "$ALIROOT_ROOT"
 prepend_path:
@@ -59,7 +59,7 @@ cmake $SOURCEDIR                                                     \
       ${FASTJET_ROOT:+-DFASTJET="$FASTJET_ROOT"}                     \
       ${DPMJET_ROOT:+-DDPMJET="$DPMJET_ROOT"}                        \
       ${ZEROMQ_ROOT:+-DZEROMQ=$ZEROMQ_ROOT}                          \
-      ${ALITPCCOMMON_ROOT:+-DALITPCCOMMON_DIR=$ALITPCCOMMON_ROOT}    \
+      ${ALIGPU_ROOT:+-DALIGPU_DIR=$ALIGPU_ROOT}                      \
       ${ALICE_DAQ:+-DDA=ON -DDARPM=ON -DdaqDA=$DAQ_DALIB}            \
       ${ALICE_DAQ:+-DAMORE_CONFIG=$AMORE_CONFIG}                     \
       ${ALICE_DAQ:+-DDATE_CONFIG=$DATE_CONFIG}                       \

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -28,7 +28,7 @@ overrides:
       - ninja
       - RapidJSON
       - googlebenchmark
-      - AliTPCCommon
+      - AliGPU
       - cub
   FairRoot:
     version: dev

--- a/o2.sh
+++ b/o2.sh
@@ -19,7 +19,7 @@ requires:
 build_requires:
   - RapidJSON
   - googlebenchmark
-  - AliTPCCommon
+  - AliGPU
   - cub
 source: https://github.com/AliceO2Group/AliceO2
 prepend_path:
@@ -152,7 +152,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                                             \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                               \
-      ${ALITPCCOMMON_ROOT:+-DALITPCCOMMON_DIR=$ALITPCCOMMON_ROOT}                           \
+      ${ALIGPU_ROOT:+-DALIGPU_DIR=$ALIGPU_ROOT}                                             \
       ${MONITORING_VERSION:+-DMonitoring_ROOT=$MONITORING_ROOT}                             \
       ${CONFIGURATION_VERSION:+-DConfiguration_ROOT=$CONFIGURATION_ROOT}                    \
       ${LIBINFOLOGGER_VERSION:+-DInfoLogger_ROOT=$LIBINFOLOGGER_ROOT}                       \
@@ -196,7 +196,7 @@ setenv O2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv VMCWORKDIR \$::env(O2_ROOT)/share
 prepend-path PATH \$::env(O2_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(O2_ROOT)/lib
-prepend-path ROOT_INCLUDE_PATH \$::env(O2_ROOT)/include/AliTPCCommon
+prepend-path ROOT_INCLUDE_PATH \$::env(O2_ROOT)/include/AliGPU
 prepend-path ROOT_INCLUDE_PATH \$::env(O2_ROOT)/include
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(O2_ROOT)/lib")
 EoF

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -16,7 +16,7 @@ cp "${O2_ROOT}"/compile_commands.json .
 # We will try to setup a list of files to be checked by using 2 specific Git commits to compare
 
 # Heuristically guess source directory
-O2_SRC=$(python -c 'import json,sys,os; sys.stdout.write( os.path.commonprefix([ x["file"] for x in json.loads(open("compile_commands.json").read()) if not "G__" in x["file"] and x["file"].endswith(".cxx") and not "/AliTPCCommon/" in x["file"] ]) )')
+O2_SRC=$(python -c 'import json,sys,os; sys.stdout.write( os.path.commonprefix([ x["file"] for x in json.loads(open("compile_commands.json").read()) if not "G__" in x["file"] and x["file"].endswith(".cxx") and not "/AliGPU/" in x["file"] ]) )')
 [[ -e "$O2_SRC"/CMakeLists.txt && -d "$O2_SRC"/.git ]]
 
 # We have something to compare our working directory to (ALIBUILD_BASE_HASH). We check only the


### PR DESCRIPTION
Gets rid of all AliHLT... naming in AliTPCCommon.
Must be merged together with alisw/AliRoot#888 and AliceO2Group/AliceO2#1591.
Must be synchronized with new AliRoot release in order not to break AliPhysics pull requests.
See: https://alice.its.cern.ch/jira/browse/ALIROOT-8188