### PR TITLE
Add support for arrow 0.12.0

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: v0.12.0-alice2
-tag: apache-arrow-0.12.0-alice2
+version: v0.12.0-alice3
+tag: apache-arrow-0.12.0-alice3
 source: https://github.com/alisw/arrow
 requires:
   - boost

--- a/arrow.sh
+++ b/arrow.sh
@@ -1,14 +1,15 @@
 package: arrow
-version: v0.10.0-alice1
-tag: apache-arrow-0.10.0-alice1
+version: v0.12.0-alice2
+tag: apache-arrow-0.12.0-alice2
 source: https://github.com/alisw/arrow
 requires:
   - boost
+  - lz4
+  - thrift
 build_requires:
   - zlib
   - flatbuffers
   - CMake
-  - "GCC-Toolchain:(?!osx)"
 env:
   ARROW_HOME: "$ARROW_ROOT"
 ---
@@ -30,24 +31,28 @@ esac
 # Taken from our stack, linked dynamically (needed at runtime):
 #   boost
 
-cmake $SOURCEDIR/cpp                       \
-      -DARROW_BUILD_BENCHMARKS=OFF         \
-      -DARROW_BUILD_TESTS=OFF              \
-      -DARROW_JEMALLOC=OFF                 \
-      -DARROW_HDFS=OFF                     \
-      -DARROW_IPC=ON                       \
-      -DFLATBUFFERS_HOME=$FLATBUFFERS_ROOT \
-      -DCMAKE_INSTALL_LIBDIR="lib"         \
-      -DARROW_USE_SSE=ON                   \
-      -DARROW_WITH_LZ4=ON                  \
-      -DARROW_WITH_SNAPPY=OFF              \
-      -DARROW_WITH_GRPC=OFF                \
-      -DARROW_WITH_ZSTD=OFF                \
-      -DARROW_WITH_ZLIB=ON                 \
-      -DARROW_NO_DEPRECATED_API=ON         \
-      -DBOOST_ROOT=$BOOST_ROOT             \
-      -DARROW_WITH_BROTLI=ON               \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT  \
+cmake $SOURCEDIR/cpp                             \
+      -DARROW_BUILD_BENCHMARKS=OFF               \
+      -DARROW_BUILD_TESTS=OFF                    \
+      -DARROW_USE_GLOG=OFF                       \
+      -DARROW_JEMALLOC=OFF                       \
+      -DARROW_HDFS=OFF                           \
+      -DARROW_IPC=ON                             \
+      -DARROW_PARQUET=ON                         \
+      -DTHRIFT_HOME=${THRIFT_ROOT}               \
+      -DFLATBUFFERS_HOME=$FLATBUFFERS_ROOT       \
+      -DCMAKE_INSTALL_LIBDIR="lib"               \
+      -DARROW_WITH_LZ4=ON                        \
+      -DLZ4_HOME=${LZ4_ROOT}                     \
+      -DLZ4_INCLUDE_DIR=${LZ4_ROOT}/include      \
+      -DLZ4_STATIC_LIB=${LZ4_ROOT}/lib/liblz4.a  \
+      -DARROW_WITH_SNAPPY=OFF                    \
+      -DARROW_WITH_ZSTD=OFF                      \
+      -DARROW_WITH_ZLIB=ON                       \
+      -DARROW_NO_DEPRECATED_API=ON               \
+      -DBOOST_ROOT=$BOOST_ROOT                   \
+      -DARROW_WITH_BROTLI=ON                     \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT        \
       -DARROW_PYTHON=OFF
 
 make ${JOBS:+-j $JOBS}

--- a/lz4.sh
+++ b/lz4.sh
@@ -1,10 +1,34 @@
 package: lz4
 version: "%(tag_basename)s"
-source: https://github.com/Cyan4973/lz4
-tag: r131
+tag: v1.8.3
+source: https://github.com/lz4/lz4
 build_requires:
  - "GCC-Toolchain:(?!osx)"
-system_requirement: ".*"
-system_requirement_check: |
+prefer_system: ".*"
+prefer_system_check: |
   printf "#include <lz4.h>\n" | gcc -xc++ -I$(brew --prefix lz4)/include - -c -M 2>&1
 ---
+
+rsync -av --delete --exclude="**/.git" $SOURCEDIR/ ./
+make -j ${JOBS+-j $JOBS}
+make PREFIX=$INSTALLROOT INCLUDEDIR=$INSTALLROOT/include install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
+prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
+EoF

--- a/thrift.sh
+++ b/thrift.sh
@@ -1,10 +1,60 @@
 package: thrift
 version: "%(tag_basename)s"
-tag: 0.9.3
-source: https://git-wip-us.apache.org/repos/asf/thrift.git
+tag: 0.12.0
+source: https://github.com/apache/thrift
+requires:
+  - boost
 build_requires:
- - "GCC-Toolchain:(?!osx)"
-system_requirement: ".*"
-system_requirement_check: |
+  - "GCC-Toolchain:(?!osx)"
+  - "OpenSSL:(?!osx)"
+  - yacc-like
+prefer_system: ".*"
+prefer_system_check: |
   thrift --version
 ---
+
+case $ARCHITECTURE in
+  osx*) 
+    export PATH=$(brew --prefix bison)/bin:$PATH
+    OPENSSL_ROOT=$(brew --prefix openssl)
+  ;;
+esac
+rsync -a --delete --exclude="**/.git" $SOURCEDIR/ ./
+./bootstrap.sh
+./configure --prefix ${INSTALLROOT}     \
+            --with-boost=${BOOST_ROOT}  \
+            --without-erlang            \
+            --without-haskell           \
+            --without-perl              \
+            --without-python \
+            --without-php               \
+            --without-php_extension     \
+            --without-ruby              \
+            --without-qt                \
+            --enable-libs               \
+            --disable-tests              \
+            --disable-plugin             \
+            --disable-tutorial           \
+            --with-openssl=${OPENSSL_ROOT}
+make CPPFLAGS="-I${BOOST_ROOT}/include ${CPPFLAGS}" CXXFLAGS="-Wno-macro-redefined -Wno-register ${CXXFLAGS}" ${JOBS:+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
+prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
+EoF


### PR DESCRIPTION
* Also enable support for parquet, which is now shipped with arrow
* Build our own lz4 and thrift packages, rather than consider them
  system dependencies.