### PR TITLE
DDS: workaround issue with wn_bin on macOS

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -25,7 +25,14 @@ cmake $SOURCEDIR                                                         \
 JOBS=$((${JOBS:-1}*2/5))
 [[ $JOBS -gt 0 ]] || JOBS=1
 
+# This is needed because https://github.com/Homebrew/homebrew-core/pull/35735
+# seems to break the creation of the tarball.
+case $ARCHITECTURE in
+  osx*)
 make -j$JOBS wn_bin
+  ;;
+esac
+
 make -j$JOBS install
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
See also discussion at https://alice-talk.web.cern.ch/t/o2-build-failing-on-mojave-in-dds/198/4