### PR TITLE
fairroot: force use of correct CXX standard

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -66,6 +66,8 @@ cmake $SOURCEDIR                                                                
       ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_LIBRARY=$PROTOBUF_ROOT/lib/libprotoc.$SONAME}      \
       ${PROTOBUF_ROOT:+-DProtobuf_INCLUDE_DIR=$PROTOBUF_ROOT/include}                       \
       ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc}              \
+      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                               \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 cmake --build . -- -j$JOBS install


### PR DESCRIPTION
Fairroot internally (may) set the standard back to C++11 even though we use C++17 globally.
This is fixed by using the proper `CMAKE_CXX_STANDARD`. 

I believe that we should do similary for all our recipes.

Fixes compile problem discussed here: 

https://github.com/FairRootGroup/FairRoot/pull/864