### PR TITLE
Bump AliTPCCommon to v2.3.2.1 - Update flatOject with verison from Ruben

### DIFF
--- a/alitpccommon.sh
+++ b/alitpccommon.sh
@@ -1,6 +1,6 @@
 package: AliTPCCommon
 version: "%(tag_basename)s"
-tag: alitpccommon-v2.3.2
+tag: alitpccommon-v2.3.2.1
 source: https://github.com/AliceO2Group/AliTPCCommon
 build_requires:
   - CMake


### PR DESCRIPTION
Minor change in AliTPCCommon containing new version of FlatObject header, should be used by the LUT class AliceO2Group/AliceO2#1263