### PR TITLE
Add a dummy name to fool platform detection logic

### DIFF
--- a/crmc.sh
+++ b/crmc.sh
@@ -1,5 +1,5 @@
 package: CRMC
-version: "%(tag_basename)s"
+version: "%(tag_basename)s-correctHepMC"
 tag: v1.7.0
 source: https://github.com/alisw/crmc.git
 requires:


### PR DESCRIPTION
This is an attempt to avoid having the old sl5 build picked up on lxplus.