### PR TITLE
o2checkcode: Explicitely list enabled checks

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -42,8 +42,25 @@ fi
 ThinCompilationsDatabase.py -exclude-files '(?:.*G\_\_.*\.cxx|.*\.pb.cc)' ${O2_CHECKCODE_CHANGEDFILES:+-use-files ${O2_CHECKCODE_CHANGEDFILES}}
 cp thinned_compile_commands.json compile_commands.json
 
-# List of enabled C++ checks (make sure they are all green)
-CHECKS="${O2_CHECKER_CHECKS:--*,modernize-*,-modernize-use-default,-modernize-pass-by-value,-modernize-use-auto,-modernize-use-bool-literals,-modernize-use-using,-modernize-loop-convert,-modernize-use-bool-literals,-modernize-make-unique,-modernize-use-default-member-init,aliceO2-member-name}"
+# List of explicitely enabled C++ checks (make sure they are all green)
+CHECKS="${O2_CHECKER_CHECKS:--*,\
+aliceO2-member-name\
+,modernize-avoid-bind\
+,modernize-deprecated-headers\
+,modernize-make-shared\
+,modernize-raw-string-literal\
+,modernize-redundant-void-arg\
+,modernize-replace-auto-ptr\
+,modernize-replace-random-shuffle\
+,modernize-return-braced-init-list\
+,modernize-shrink-to-fit\
+,modernize-unary-static-assert\
+,modernize-use-equals-default\
+,modernize-use-noexcept\
+,modernize-use-nullptr\
+,modernize-use-override\
+,modernize-use-transparent-functors\
+,modernize-use-uncaught-exceptions}"
 
 # Run C++ checks
 run_O2CodeChecker.py -clang-tidy-binary $(which O2codecheck) -header-filter=.*SOURCES.* ${O2_CHECKER_FIX:+-fix} -checks=${CHECKS} 2>&1 | tee error-log.txt


### PR DESCRIPTION
Rather then disabling certain checks, we now explicitely enumerate the
checks which are enabled. We will no longer be (implicitely) affected due to a
change in clang-tidy version (which might add more checks).

The list of enabled checks are the ones previously used.