### PR TITLE
Vc: build vc in any case

### DIFF
--- a/vc.sh
+++ b/vc.sh
@@ -6,9 +6,6 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
-prefer_system: (?!slc5)
-prefer_system_check: |
-  printf "#include <Vc/version.h>\n#if Vc_VERSION_CHECK(1,3,2) > Vc_VERSION_NUMBER\n#error Incorrect Vc version\n#endif" | c++ -xc++ - -c -M 2>&1
 ---
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT -DBUILD_TESTING=OFF


### PR DESCRIPTION
Our version of Vc contains a fix for GCC which is not in any of the official v1.3.x releases, making using Vc from the system impossible.