### PR TITLE
Bump Rivet to 2.7.0

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.6.0-alice1"
+tag: "2.7.0-alice1"
 source: https://github.com/alisw/rivet
 requires:
   - GSL

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,6 +1,6 @@
 package: YODA
 version: "%(tag_basename)s"
-tag: "v1.7.0"
+tag: "v1.7.4"
 source: https://github.com/alisw/yoda
 requires:
   - boost


### PR DESCRIPTION
requires YODA 1.7.4