### PR TITLE
Enable cassertions and macro tests in O2 build in o2.sh depending on ALIBUILD_O2_TESTS variable

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -152,6 +152,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${PYTHIA_ROOT:+-DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include}                            \
       ${HEPMC3_ROOT:+-DHEPMC3_DIR=$HEPMC3_ROOT}                                             \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}                             \
+      ${ALIBUILD_O2_TESTS:+-DENABLE_CASSERT=ON}                                             \
       -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                                             \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                               \


### PR DESCRIPTION
@dberzano : Add cmake variable to enable the assertions, and also move the setting of CHECK_ROOTMACRO_COMPILE when ALIBUILD_O2_TESTS is set to o2.sh.

I'll update AliceO2Group/AliceO2#1799 accordingly.