### PR TITLE
Vc: fix issue with XCode 10.2

### DIFF
--- a/vc.sh
+++ b/vc.sh
@@ -1,7 +1,7 @@
 package: Vc
 version: "%(tag_basename)s"
-tag: 1.3.3-alice2
-source: https://github.com/alisw/Vc.git
+tag: 1.4.1
+source: https://github.com/VcDevel/Vc.git
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:


### PR DESCRIPTION
Bumping to 1.4.1 seems to solve compilation issues. This also moves back to the official sources.