### PR TITLE
Add AliEn-ROOT-Legacy as dep for AliRoot

### DIFF
--- a/defaults-user-root6.sh
+++ b/defaults-user-root6.sh
@@ -15,6 +15,7 @@ overrides:
       - ROOT
       - fastjet:(?!.*ppc64)
       - Vc
+      - AliEn-ROOT-Legacy
   AliPhysics:
     version: "%(tag_basename)s"
     tag: v5-09-46-01


### PR DESCRIPTION
The defaults user-root6 overrides list of AliRoot dependencies. It needs to be updated to include the AliEn-ROOT-Legacy.