### PR TITLE
Fix xalienfs scripts relocation and dylibs on MacOS

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -1,6 +1,6 @@
 package: AliEn-ROOT-Legacy
 version: "%(tag_basename)s"
-tag: "0.0.5"
+tag: "0.0.6"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
   - CMake
@@ -42,6 +42,11 @@ for RPKG in $BUILD_REQUIRES; do
   popd
   rm -f $INSTALLROOT/etc/modulefiles/{$RPKG,$RPKG.unrelocated} || true
 done
+
+if [[ $ARCHITECTURE == osx* ]]; then
+  ln -nfs $INSTALLROOT/lib/libAliEnROOTLegacy.dylib $INSTALLROOT/lib/libAliEnROOTLegacy.so
+  ln -nfs $INSTALLROOT/lib/libXrdxAlienFs.dylib $INSTALLROOT/lib/libXrdxAlienFs.so
+fi
 
 # Modulefile
 mkdir -p etc/modulefiles

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -10,6 +10,9 @@ build_requires:
   - xalienfs
 append_path:
   ROOT_PLUGIN_PATH: "$ALIEN_ROOT_LEGACY_ROOT/etc/plugins"
+env:
+  GSHELL_ROOT: "$ALIEN_ROOT_LEGACY_ROOT"
+  GSHELL_NO_GCC: "1"
 ---
 #!/bin/bash -e
 
@@ -55,6 +58,7 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSI
 
 # Our environment
 setenv ALIEN_ROOT_LEGACY_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv GSHELL_ROOT \$::env(ALIEN_ROOT_LEGACY_ROOT)
 prepend-path PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/lib
 append-path ROOT_PLUGIN_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/etc/plugins

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -44,8 +44,13 @@ for RPKG in $BUILD_REQUIRES; do
 done
 
 if [[ $ARCHITECTURE == osx* ]]; then
-  ln -nfs $INSTALLROOT/lib/libAliEnROOTLegacy.dylib $INSTALLROOT/lib/libAliEnROOTLegacy.so
-  ln -nfs $INSTALLROOT/lib/libXrdxAlienFs.dylib $INSTALLROOT/lib/libXrdxAlienFs.so
+  # Due to some ROOT quirks, we create .so symlinks pointing to the real .dylib libs on macOS
+  for SYMLIB in "$INSTALLROOT/lib/libAliEnROOTLegacy.so" "$INSTALLROOT/lib/libXrdxAlienFs.so"; do
+    [[ ! -e "$SYMLIB" ]] || continue
+    SYMDEST=${SYMLIB%.*}
+    SYMDEST=${SYMDEST##*/}.dylib
+    ln -nfs "$SYMDEST" "$SYMLIB"
+  done
 fi
 
 # Modulefile

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -59,6 +59,7 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSI
 # Our environment
 setenv ALIEN_ROOT_LEGACY_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv GSHELL_ROOT \$::env(ALIEN_ROOT_LEGACY_ROOT)
+setenv GSHELL_NO_GCC 1
 prepend-path PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/lib
 append-path ROOT_PLUGIN_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/etc/plugins

--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -49,5 +49,4 @@ $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::e
 prepend-path PATH \$::env(ALIEN_RUNTIME_ROOT)/bin
 prepend-path PERLLIB \$::env(ALIEN_RUNTIME_ROOT)/lib/perl
 setenv X509_CERT_DIR \$::env(ALIEN_RUNTIME_ROOT)/globus/share/certificates
-setenv GSHELL_NO_GCC 1
 EoF

--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -15,8 +15,6 @@ build_requires:
 prepend_path:
   PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
 env:
-  GSHELL_ROOT: "$ALIEN_RUNTIME_ROOT"
-  GSHELL_NO_GCC: "1"
   X509_CERT_DIR: "$ALIEN_RUNTIME_ROOT/globus/share/certificates"
 ---
 #!/bin/bash -e
@@ -50,7 +48,6 @@ prepend-path LD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_ROOT)/lib")
 prepend-path PATH \$::env(ALIEN_RUNTIME_ROOT)/bin
 prepend-path PERLLIB \$::env(ALIEN_RUNTIME_ROOT)/lib/perl
-setenv GSHELL_ROOT \$::env(ALIEN_RUNTIME_ROOT)
 setenv X509_CERT_DIR \$::env(ALIEN_RUNTIME_ROOT)/globus/share/certificates
 setenv GSHELL_NO_GCC 1
 EoF


### PR DESCRIPTION
The xalienfs becomes dependency of AliEn-ROOT-Legacy and because of that the $GSHELL_ROOT environment variable should point to it as well.