### PR TITLE
Fix for lhapdf pdfsets needed for generator packages

### DIFF
--- a/lhapdf-pdfsets.sh
+++ b/lhapdf-pdfsets.sh
@@ -5,7 +5,7 @@ build_requires:
 ---
 #!/bin/bash -ex
 
-PDFSETS="cteq6l1 MMHT2014lo68cl MMHT2014nlo68cl cteq66"
+PDFSETS="cteq6l1 MMHT2014lo68cl MMHT2014nlo68cl cteq66 CT10nlo"
 if [ ! -d $INSTALLROOT/share/LHAPDF ]; then mkdir -p $INSTALLROOT/share/LHAPDF; fi
 pushd $INSTALLROOT/share/LHAPDF
   REPO=https://lhapdf.hepforge.org/downloads?f=pdfsets/6.2.1

--- a/lhapdf-pdfsets.sh
+++ b/lhapdf-pdfsets.sh
@@ -6,9 +6,17 @@ build_requires:
 #!/bin/bash -ex
 
 PDFSETS="cteq6l1 MMHT2014lo68cl MMHT2014nlo68cl cteq66"
-lhapdf --pdfdir=$INSTALLROOT/share/LHAPDF  \
-       --listdir=$LHAPDF_ROOT/share/LHAPDF \
-       install $PDFSETS
+if [ ! -d $INSTALLROOT/share/LHAPDF ]; then mkdir -p $INSTALLROOT/share/LHAPDF; fi
+pushd $INSTALLROOT/share/LHAPDF
+  REPO=https://lhapdf.hepforge.org/downloads?f=pdfsets/6.2.1
+  for P in $PDFSETS; do
+    PDFPACK=$(printf "%s.tar.gz" $P)
+    PDFEXT=$(printf "%s/%s" $REPO $PDFPACK)
+    curl $PDFEXT --output $PDFPACK
+    tar xzvf $PDFPACK
+    rm -rf $PDFPACK
+  done
+popd
 
 # Check if PDF sets were really installed
 for P in $PDFSETS; do

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -10,7 +10,7 @@ requires:
 build_requires:
  - autotools
 env:
-  PYTHONPATH: $LHAPDF_ROOT/lib/python2.7/site-packages
+  PYTHONPATH: $LHAPDF_ROOT/lib64/python2.7/site-packages
 ---
 #!/bin/bash -ex
 case $ARCHITECTURE in
@@ -66,7 +66,7 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSI
 setenv LHAPDF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(LHAPDF_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(LHAPDF_ROOT)/lib
-prepend-path PYTHONPATH \$::env(LHAPDF_ROOT)/lib/python2.7/site-packages
+prepend-path PYTHONPATH \$::env(LHAPDF_ROOT)/lib64/python2.7/site-packages
 prepend-path LHAPDF_DATA_PATH \$::env(LHAPDF_ROOT)/share/LHAPDF
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LHAPDF_ROOT)/lib")
 EoF

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -10,6 +10,7 @@ requires:
 build_requires:
  - autotools
 env:
+  PYTHONPATH: $LHAPDF_ROOT/lib/python2.7/site-packages
   PYTHONPATH: $LHAPDF_ROOT/lib64/python2.7/site-packages
 ---
 #!/bin/bash -ex
@@ -66,6 +67,7 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSI
 setenv LHAPDF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(LHAPDF_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(LHAPDF_ROOT)/lib
+prepend-path PYTHONPATH \$::env(LHAPDF_ROOT)/lib/python2.7/site-packages
 prepend-path PYTHONPATH \$::env(LHAPDF_ROOT)/lib64/python2.7/site-packages
 prepend-path LHAPDF_DATA_PATH \$::env(LHAPDF_ROOT)/share/LHAPDF
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LHAPDF_ROOT)/lib")

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -17,11 +17,14 @@ rsync -a --exclude '**/.git' $SOURCEDIR/ ./
 make ${JOBS+-j $JOBS} all
 make install
 
-PDFSETS="cteq6l cteq6ll CT10 CT10nlo MSTW2008nnlo EPS09LOR_208 EPS09NLOR_208"
+PDFSETS="cteq6lg CT10 CT10nlo MSTW2008nnlo_mcrange EPS09LOR_208 EPS09NLOR_208"
 pushd $INSTALLROOT/share/lhapdf
-  $INSTALLROOT/bin/lhapdf-getdata $PDFSETS
+  PDFREPO=https://www.hepforge.org/downloads/lhapdf/pdfsets/5.9.1
   # Check if PDF sets were really installed
   for P in $PDFSETS; do
+    PDFFILE=$(printf "%s.LHgrid" $P)
+    PDFSOURCE=$(printf "%s/%s" $PDFREPO $PDFFILE)
+    curl $PDFSOURCE --output $PDFFILE
     ls ${P}*
   done
 popd


### PR DESCRIPTION
Issues in pdfsets:
- LHAPDF5 was downloading pdfsets from LHAPDF6, which are incompatible. The LHAPDF version 
   needs to be specified in the address for the download
- Avoid using lhapdf / lhapdf-getdata script for downloading as it runs into errors, rather download explicitly via curl.
- Issue with PYTHONPATH for LHAPDF6: On some platforms the site-package is installed in lib64 
  instead of lib, which results in lhapdf script failing due to missing python bindings. Unless the 
  directory for the site packages can be handled automatically both options need to be added to the 
  PYTHONPATH.

Without the fixes the installation of generators (i.e. POWHEG/HERWIG) run into build errors when getting the pdfsets