### PR TITLE
Overhaul of Protobuf&gRPC recipes to build them with CMake

### DIFF
--- a/c-ares.sh
+++ b/c-ares.sh
@@ -1,0 +1,38 @@
+package: c-ares
+version: "v1.15.0"
+tag: cares-1_15_0
+build_requires:
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+source: https://github.com/c-ares/c-ares
+prefer_system: false
+incremental_recipe: |
+  make ${JOBS:+-j$JOBS} install
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+---
+#!/bin/bash -e
+
+cmake $SOURCEDIR -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+make ${JOBS:+-j$JOBS} install
+
+
+
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+set CARES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$CARES_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$CARES_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$CARES_ROOT/lib")
+EoF

--- a/coconut.sh
+++ b/coconut.sh
@@ -1,6 +1,6 @@
 package: coconut
 version: "%(tag_basename)s"
-tag: "v0.6.2"
+tag: "v0.6.3"
 build_requires:
   - golang
   - protobuf

--- a/control-core.sh
+++ b/control-core.sh
@@ -1,6 +1,6 @@
 package: Control-Core
 version: "%(tag_basename)s"
-tag: "v0.6.2"
+tag: "v0.6.3"
 build_requires:
   - golang
   - protobuf

--- a/control-occplugin.sh
+++ b/control-occplugin.sh
@@ -1,6 +1,6 @@
 package: Control-OCCPlugin
 version: "%(tag_basename)s"
-tag: "v0.6.2"
+tag: "v0.6.3"
 requires:
   - FairMQ
   - FairLogger

--- a/control.sh
+++ b/control.sh
@@ -1,5 +1,5 @@
 package: Control
-version: "v0.6.2"
+version: "v0.6.3"
 requires:
   - golang
   - Control-Core

--- a/grpc.sh
+++ b/grpc.sh
@@ -21,20 +21,18 @@ git checkout "$GIT_TAG"
 git submodule update --init
 popd
 
-opts=(
-    -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
-    -DgRPC_PROTOBUF_PACKAGE_TYPE="CONFIG"
-    -DgRPC_BUILD_TESTS=OFF
-    -DBUILD_SHARED_LIBS=ON
-    -DgRPC_SSL_PROVIDER=package
-    -DgRPC_ZLIB_PROVIDER=package
-    -DgRPC_GFLAGS_PROVIDER=packet
-    -DgRPC_PROTOBUF_PROVIDER=package
-    -DgRPC_BENCHMARK_PROVIDER=packet
-    -DgRPC_CARES_PROVIDER=package
-)
+cmake $SOURCEDIR \
+  -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+  -DgRPC_PROTOBUF_PACKAGE_TYPE="CONFIG" \
+  -DgRPC_BUILD_TESTS=OFF \
+  -DBUILD_SHARED_LIBS=ON \
+  -DgRPC_SSL_PROVIDER=package \
+  -DgRPC_ZLIB_PROVIDER=package \
+  -DgRPC_GFLAGS_PROVIDER=packet \
+  -DgRPC_PROTOBUF_PROVIDER=package \
+  -DgRPC_BENCHMARK_PROVIDER=packet \
+  -DgRPC_CARES_PROVIDER=package \
 
-cmake $SOURCEDIR "${opts[@]}"
 make ${JOBS:+-j$JOBS} install
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/grpc.sh
+++ b/grpc.sh
@@ -21,17 +21,17 @@ git checkout "$GIT_TAG"
 git submodule update --init
 popd
 
-cmake $SOURCEDIR \
-  -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+cmake $SOURCEDIR                        \
+  -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
   -DgRPC_PROTOBUF_PACKAGE_TYPE="CONFIG" \
-  -DgRPC_BUILD_TESTS=OFF \
-  -DBUILD_SHARED_LIBS=ON \
-  -DgRPC_SSL_PROVIDER=package \
-  -DgRPC_ZLIB_PROVIDER=package \
-  -DgRPC_GFLAGS_PROVIDER=packet \
-  -DgRPC_PROTOBUF_PROVIDER=package \
-  -DgRPC_BENCHMARK_PROVIDER=packet \
-  -DgRPC_CARES_PROVIDER=package \
+  -DgRPC_BUILD_TESTS=OFF                \
+  -DBUILD_SHARED_LIBS=ON                \
+  -DgRPC_SSL_PROVIDER=package           \
+  -DgRPC_ZLIB_PROVIDER=package          \
+  -DgRPC_GFLAGS_PROVIDER=packet         \
+  -DgRPC_PROTOBUF_PROVIDER=package      \
+  -DgRPC_BENCHMARK_PROVIDER=packet      \
+  -DgRPC_CARES_PROVIDER=package
 
 make ${JOBS:+-j$JOBS} install
 

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -1,17 +1,19 @@
 package: protobuf
-version: v3.5.2
+version: v3.7.1
 source: https://github.com/google/protobuf
 build_requires:
- - autotools
+ - CMake
  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include \"google/protobuf/stubs/common.h\"\n#if (GOOGLE_PROTOBUF_VERSION < 3000000)\n#error \"At least protobuf 3.0.0 is required.\"\n#endif\nint main(){}" | c++ -I$(brew --prefix protobuf)/include -Wno-deprecated-declarations -xc++ - -o /dev/null && protoc -h &> /dev/null
 ---
 
-rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .
-autoreconf -ivf
-./configure --prefix="$INSTALLROOT"
+cmake $SOURCEDIR/cmake \
+    -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+    -Dprotobuf_BUILD_TESTS=NO \
+    -Dprotobuf_MODULE_COMPATIBLE=YES \
+    -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j $JOBS}
 make install
 

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -9,10 +9,10 @@ prefer_system_check: |
   printf "#include \"google/protobuf/stubs/common.h\"\n#if (GOOGLE_PROTOBUF_VERSION < 3000000)\n#error \"At least protobuf 3.0.0 is required.\"\n#endif\nint main(){}" | c++ -I$(brew --prefix protobuf)/include -Wno-deprecated-declarations -xc++ - -o /dev/null && protoc -h &> /dev/null
 ---
 
-cmake $SOURCEDIR/cmake \
+cmake $SOURCEDIR/cmake                  \
     -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
-    -Dprotobuf_BUILD_TESTS=NO \
-    -Dprotobuf_MODULE_COMPATIBLE=YES \
+    -Dprotobuf_BUILD_TESTS=NO           \
+    -Dprotobuf_MODULE_COMPATIBLE=YES    \
     -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j $JOBS}
 make install


### PR DESCRIPTION
* Bumped Protobuf to 3.7.1
* Added recipe for c-ares which needs to be built as a dependency of gRPC (note that this is not a new dependency, it is simply built out of gRPC's tree)
* Bumped gRPC to 1.19.1, removed lots of build hacks and switched to upstream (alisw fork not needed any more)
* Bumped AliECS to 0.6.3 which was [released](https://github.com/AliceO2Group/Control/releases/tag/v0.6.3) simultaneously to adapt to Protobuf&gRPC changes.

Also see https://github.com/AliceO2Group/AliceO2/pull/1880