### PR TITLE
Fix for: undefined reference to `_gfortran_stop_numeric_f08'

### DIFF
--- a/aliroot.sh
+++ b/aliroot.sh
@@ -52,6 +52,7 @@ fi
 cmake $SOURCEDIR                                                     \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                          \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                             \
+      -DCMAKE_Fortran_COMPILER=gfortran                              \
       -DROOTSYS="$ROOT_ROOT"                                         \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                      \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}    \


### PR DESCRIPTION
Without this fix, on Ubuntu, the aliroot compilation uses /usr/bin/f95 which leads to trouble with libgfortran when linking.

This seems to be a side-effect/result of the decision to compile root without fortran, and this commit https://github.com/alisw/alidist/pull/1563 

NB: not tested on Max OSX; probably should be checked there with the new xcode, since there was apparently some issue with gfortran there.