### PR TITLE
freetype - Add pkg-config check for freetype cflags

### DIFF
--- a/freetype.sh
+++ b/freetype.sh
@@ -7,7 +7,7 @@ build_requires:
   - curl
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include <ft2build.h>\n" | c++ -xc++ - `freetype-config --cflags` -c -M 2>&1;
+  printf "#include <ft2build.h>\n" | c++ -xc++ - `if [ -x "$(which freetype-config)" ]; then freetype-config --cflags; else pkg-config freetype2 --cflags; fi` -c -M 2>&1;
   if [ $? -ne 0 ]; then printf "FreeType is missing on your system.\n * On RHEL-compatible systems you probably need: freetype freetype-devel\n * On Ubuntu-compatible systems you probably need: libfreetype6 libfreetype6-dev\n"; exit 1; fi
 ---
 #!/bin/bash -ex

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -69,7 +69,7 @@ else
   cd matplotlib-*
   cat > setup.cfg <<EOF
 [directories]
-basedirlist  = ${FREETYPE_ROOT:+$PWD/fake_freetype_root,$FREETYPE_ROOT,}${LIBPNG_ROOT:+$LIBPNG_ROOT,}${ZLIB_ROOT:+$ZLIB_ROOT,}/usr/X11R6,$(freetype-config --prefix),$(libpng-config --prefix)
+basedirlist  = ${FREETYPE_ROOT:+$PWD/fake_freetype_root,$FREETYPE_ROOT,}${LIBPNG_ROOT:+$LIBPNG_ROOT,}${ZLIB_ROOT:+$ZLIB_ROOT,}/usr/X11R6,$(if [ -x "$(which freetype-config)" ]; then freetype-config --prefix; else pkg-config --variable=prefix freetype2; fi),$(libpng-config --prefix)
 [gui_support]
 gtk = False
 gtkagg = False

--- a/xdevel.sh
+++ b/xdevel.sh
@@ -6,6 +6,6 @@ system_requirement_missing: |
    * On Ubuntu-compatible systems you probably need: libxpm-dev libxext-dev libx11-dev libxft-dev
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `freetype-config --cflags` -c -o /dev/null
+  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `if [ -x "$(which freetype-config)" ]; then freetype-config --cflags; else pkg-config freetype2 --cflags; fi` -c -o /dev/null
 ---
 


### PR DESCRIPTION
The Ubuntu 19.04 libfreetype6-dev package removes `freetype-config` and only uses the `freetype2.pc` file for use with pkg-config. This patch adds a check in freetype, xdevel, and python-modules for the `freetype-config` executable, with fallback to pkg-config if not found.

Alternatively, the check could be the shorter:
 `$((pkg-config --cflags freetype2 || freetype-config --cflags) 2>/dev/null)`
