### PR TITLE
Change standard to build boost from 14 to 17

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -51,8 +51,8 @@ if [[ ! $BOOST_PYTHON ]]; then
 fi
 
 if [[ $CXXSTD && $CXXSTD -ge 17 ]]; then
-  # Use C++14: https://github.com/boostorg/system/issues/26#issuecomment-413631998
-  CXXSTD=14
+  # Use C++17: https://github.com/boostorg/system/issues/26#issuecomment-413631998
+  CXXSTD=17
 fi
 
 TMPB2=$BUILDDIR/tmp-boost-build

--- a/boost.sh
+++ b/boost.sh
@@ -51,7 +51,7 @@ if [[ ! $BOOST_PYTHON ]]; then
 fi
 
 if [[ $CXXSTD && $CXXSTD -ge 17 ]]; then
-  # Use C++17: https://github.com/boostorg/system/issues/26#issuecomment-413631998
+  # Use C++17 : https://github.com/boostorg/system/issues/26#issuecomment-413631998
   CXXSTD=17
 fi
 

--- a/boost.sh
+++ b/boost.sh
@@ -51,7 +51,7 @@ if [[ ! $BOOST_PYTHON ]]; then
 fi
 
 if [[ $CXXSTD && $CXXSTD -ge 17 ]]; then
-  # Use C++17 : https://github.com/boostorg/system/issues/26#issuecomment-413631998
+  # Use C++17: https://github.com/boostorg/system/issues/26#issuecomment-413631998
   CXXSTD=17
 fi
 


### PR DESCRIPTION
Given that brew updated boost to 1.69, most people will have to rebuild boost (we force version 1.68). However, boost 1.68 does not build on Mac, it gives an error : 
```
./boost/asio/ip/basic_resolver_entry.hpp:54:7: error: no type named 'string_view' in namespace 'boost::asio'; did you mean 'std::string_view'?
      BOOST_ASIO_STRING_VIEW_PARAM host, BOOST_ASIO_STRING_VIEW_PARAM service)
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      std::string_view
```