### PR TITLE
python: support python 3.5

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -36,15 +36,18 @@ PIP_REQUIREMENTS=(
   "PyYAML==5.1              yaml"
   "scikit-learn==0.20.3     sklearn"
   "scipy==1.2.1             scipy"
-  "seaborn==0.9.0           seaborn"
-  "sklearn-evaluation==0.4  sklearn_evaluation"
   "uproot==3.4.18           uproot"
-  "xgboost==0.82            xgboost")
+  )
 
 if python3 -c 'import sys; exit(1 if 1000*sys.version_info.major + sys.version_info.minor > 3006 else 0)' && [[ $ARCHITECTURE != slc6* ]]; then
   # Install some ML-specific packages only with Python 3.6 at the moment
-  PIP_REQUIREMENTS+=("Keras==2.2.4        keras"
-                     "tensorflow==1.13.1  tensorflow")
+  PIP_REQUIREMENTS+=(
+    "seaborn==0.9.0           seaborn"
+    "sklearn-evaluation==0.4  sklearn_evaluation"
+    "Keras==2.2.4             keras"
+    "tensorflow==1.13.1       tensorflow"
+    "xgboost==0.82            xgboost"
+  )
 else
   echo "WARNING: Not installing Keras and TensorFlow"
 fi

--- a/python.sh
+++ b/python.sh
@@ -16,7 +16,7 @@ env:
   PYTHONPATH: "$PYTHON_ROOT/lib/python/site-packages"
 prefer_system: "(?!slc5)"
 prefer_system_check:
-  python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3, 6) else 0)' && pip3 --help > /dev/null && printf '#include "pyconfig.h"' | cc -c $(python-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
+  python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3, 5) else 0)' && pip3 --help > /dev/null && printf '#include "pyconfig.h"' | cc -c $(python-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
 ---
 #!/bin/bash -ex
 


### PR DESCRIPTION
This moves more packages to be build with python 3.6 and accepts python
3.5 as system package (as found on Ubuntu 16.4).