### PR TITLE
lhapdf: remove unused deps and disable python if only python3 is avail.

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -3,8 +3,6 @@ version: "%(tag_basename)s"
 tag: v6.2.1-alice2
 source: https://github.com/alisw/LHAPDF
 requires:
- - yaml-cpp
- - boost
  - Python-modules
  - "GCC-Toolchain:(?!osx)"
 build_requires:
@@ -16,8 +14,6 @@ env:
 case $ARCHITECTURE in
   osx*)
     # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $YAML_CPP_ROOT ]] && YAML_CPP_ROOT=`brew --prefix yaml-cpp`
-    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
     [[ ! $AUTOTOOLS_ROOT ]] && PATH=$PATH:`brew --prefix gettext`/bin
   ;;
   *)
@@ -27,20 +23,15 @@ esac
 
 rsync -a --exclude '**/.git' $SOURCEDIR/ ./
 
-case $PKGVERSION in
-  v6.0*) WITH_YAML_CPP="--with-yaml-cpp=${YAML_CPP_ROOT}"
-esac
-
-if [[ "$BOOST_ROOT" != '' ]]; then
-  export LDFLAGS="$EXTRA_LD_FLAGS -L${BOOST_ROOT}/lib"
-  export CXXFLAGS="-I${BOOST_ROOT}/include"
-fi
 export LIBRARY_PATH="$LD_LIBRARY_PATH"
 
+if python -c 'import sys; exit(0 if sys.version_info.major >=3 else 1)'; then
+        # LHAPDF not yet ready for Python3
+        DISABLE_PYTHON=1
+fi
+
 autoreconf -ivf
-./configure --prefix=$INSTALLROOT \
-            ${BOOST_ROOT:+--with-boost="$BOOST_ROOT"} \
-            $WITH_YAML_CPP
+./configure --prefix=$INSTALLROOT ${DISABLE_PYTHON:+--disable-python}
 
 make ${JOBS+-j $JOBS} all
 make install
@@ -72,9 +63,7 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
-                     ${PYTHON_MODULES_ROOT:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION} \\
-                     ${YAML_CPP_VERSION:+yaml-cpp/$YAML_CPP_VERSION-$YAML_CPP_REVISION} \\
-                     ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}
+                     ${PYTHON_MODULES_ROOT:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION} 
 # Our environment
 setenv LHAPDF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(LHAPDF_ROOT)/bin


### PR DESCRIPTION
Since 6.2.0 LHAPDF no longer depends on boost or yaml.

Have to disable python if the only available python is python3, as
LHAPDF is not yet ready for Python3.