### PR TITLE
bump ReadoutCard

### DIFF
--- a/readoutcard.sh
+++ b/readoutcard.sh
@@ -1,6 +1,6 @@
 package: ReadoutCard
 version: "%(tag_basename)s"
-tag: v0.9.20
+tag: v0.9.21
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
v0.9.21 - change cxx standard to 17 + Python3