### PR TITLE
Update the detection of the python3 executable location.

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -71,6 +71,7 @@ if [[ -d $SOURCEDIR/interpreter/llvm ]]; then
   ROOT_PYTHON_FEATURES="python"
   ROOT_HAS_PYTHON=1
   # One can explicitly pick a Python version with -DPYTHON_EXECUTABLE=... -DPYTHON_INCLUDE_DIR=<path_to_Python.h>
+  PYTHON_EXECUTABLE=$( $(which python3) -c 'import sys; print(sys.executable)')
 else
   # Non-ROOT 6 builds: disable Python
   ROOT_PYTHON_FLAGS="-Dpython=OFF"
@@ -122,7 +123,7 @@ cmake $SOURCEDIR                                                                
       -Dbuiltin_davix=OFF                                                              \
       -Ddavix=OFF                                                                      \
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
-      ${ROOT_HAS_PYTHON:+-DPYTHON_EXECUTABLE=$(which python3)}                         \
+      ${ROOT_HAS_PYTHON:+-DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}}                         \
       -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
 FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
           pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${CXX17:+cxx17}

--- a/root.sh
+++ b/root.sh
@@ -71,7 +71,7 @@ if [[ -d $SOURCEDIR/interpreter/llvm ]]; then
   ROOT_PYTHON_FEATURES="python"
   ROOT_HAS_PYTHON=1
   # One can explicitly pick a Python version with -DPYTHON_EXECUTABLE=... -DPYTHON_INCLUDE_DIR=<path_to_Python.h>
-  PYTHON_EXECUTABLE=$( $(which python3) -c 'import sys; print(sys.executable)')
+  PYTHON_EXECUTABLE=$( $(realpath $(which python3)) -c 'import sys; print(sys.executable)')
 else
   # Non-ROOT 6 builds: disable Python
   ROOT_PYTHON_FLAGS="-Dpython=OFF"
@@ -123,7 +123,7 @@ cmake $SOURCEDIR                                                                
       -Dbuiltin_davix=OFF                                                              \
       -Ddavix=OFF                                                                      \
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
-      ${ROOT_HAS_PYTHON:+-DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}}                         \
+      ${ROOT_HAS_PYTHON:+-DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}}                     \
       -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
 FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http
           pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${CXX17:+cxx17}


### PR DESCRIPTION
Needed for example on systems using "shims-based" strategies to switch
between different versions of Python, like pyenv or asdf.

In those systems which python gives something like :

~/.asdf/shims/python

which is a script giving access to the right python executable, but not
directly the python executable.

Without this fix the Root cmake configuration can possibly be confused
and fails :

-- Found PythonInterp: /Users/laurent/.asdf/shims/python3 (found version
"3.6.6")
-- Found PythonLibs:
/usr/local/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib
(found version "3.7.3")
-- Looking for numpy (python package)
-- Found NUMPY:
/Users/laurent/alice/qc/sw/osx_x86-64/Python-modules/1.0-3/lib/python/site-packages/numpy/core/include
(found version "1.16.2")
CMake Error at cmake/modules/SearchInstalledSoftware.cmake:480
(message):
  Version mismatch between Python interpreter (3.6.6) and libraries
  (3.7.3).

    ROOT cannot work with this configuration.  Please specify only
      PYTHON_EXECUTABLE to CMake with an absolute path to ensure
      matching
        versions are found.