### PR TITLE
Bump Rivet to 2.7.2

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.7.1-alice1"
+tag: "2.7.2-alice1"
 source: https://github.com/alisw/rivet
 requires:
   - GSL


### PR DESCRIPTION
minor bug fix release (needed also for HI analyses)