### PR TITLE
PWGPP-528 - integrate RootInteractive into recipe

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -97,7 +97,7 @@ fi
 MATPLOTLIB_TAG="3.0.3"
 if [[ $ARCHITECTURE != slc* ]]; then
   # Simply get it via pip in most cases
-  env PYTHONUSERBASE=$INSTALLROOT pip3 install  "matplotlib==$MATPLOTLIB_TAG"
+  env PYTHONUSERBASE=$INSTALLROOT pip3 install  --user "matplotlib==$MATPLOTLIB_TAG"
 else
 
   # We are on a RHEL-compatible OS. We compile it ourselves, and link it to our dependencies

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -59,6 +59,12 @@ fi
 for P in "${PIP_REQUIREMENTS[@]}"; do
   echo $P | cut -d' ' -f1
 done > requirements.txt
+# FIXME: required because of the newly introduced dependency on scikit-garden requires
+# a numpy to be installed separately
+# See also:
+#   https://github.com/scikit-garden/scikit-garden/issues/23
+env PYTHONUSERBASE="$INSTALLROOT" pip3 install --user -IU numpy
+
 env PYTHONUSERBASE="$INSTALLROOT" pip3 install --user -IU -r requirements.txt
 
 # Find the proper Python lib library and export it

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -49,6 +49,7 @@ if python3 -c 'import sys; exit(1 if 1000*sys.version_info.major + sys.version_i
     "xgboost==0.82            xgboost"
     "dryable==1.0.3           dryable"
     "responses==0.10.6         responses"
+    "RootInteractive==0.0.7    RootInteractive"
   )
 else
   echo "WARNING: Not installing Keras and TensorFlow"
@@ -96,7 +97,7 @@ fi
 MATPLOTLIB_TAG="3.0.3"
 if [[ $ARCHITECTURE != slc* ]]; then
   # Simply get it via pip in most cases
-  env PYTHONUSERBASE=$INSTALLROOT pip3 install --user "matplotlib==$MATPLOTLIB_TAG"
+  env PYTHONUSERBASE=$INSTALLROOT pip3 install  "matplotlib==$MATPLOTLIB_TAG"
 else
 
   # We are on a RHEL-compatible OS. We compile it ourselves, and link it to our dependencies

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -97,7 +97,7 @@ fi
 MATPLOTLIB_TAG="3.0.3"
 if [[ $ARCHITECTURE != slc* ]]; then
   # Simply get it via pip in most cases
-  env PYTHONUSERBASE=$INSTALLROOT pip3 install  --user "matplotlib==$MATPLOTLIB_TAG"
+  env PYTHONUSERBASE=$INSTALLROOT pip3 install --user "matplotlib==$MATPLOTLIB_TAG"
 else
 
   # We are on a RHEL-compatible OS. We compile it ourselves, and link it to our dependencies


### PR DESCRIPTION
Dear @dberzano and @ktf 

As we agreed during alice OFFLINE week I made RootInteractive  a pip package and I patched
alidist recipies to use that package.  **I would like to ask for review.**

### Modifications and test - see (long) JIRA PWGPP-528
* modification and pytests:
  * [Modification and pytest output]
* some integration test output
  * [JIRA TPC QA example from pytest]

[Modification and pytest output]: https://alice.its.cern.ch/jira/browse/PWGPP-528?focusedCommentId=231029&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-231029

[JIRA TPC QA example from pytest]:https://alice.its.cern.ch/jira/browse/PWGPP-528?focusedCommentId=231030&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-231030

### Integration with virtualenv. Questions and ask for help
Until now, I tested only the setup **without alidock.**
I would like to ask you about the implementation as I use virtual env.

* I would like to use RootInteractive/AliRoot/AliPhysics  sourcing from cvmfs
  * Ideally people should be  able to run and modify tutoraial exploring  data using JUPYER notebook
  * Write interactive dashboard using reciies from interactive tutorials

* Is it possible to integrate virtual environment officially into aliBuild, or do you prefer one alidock - one environment? 
  * In the ML project of my wife (https://www.embl.de/research/units/cbb/kreshuk/) they have virtual environment within alidock
  * My current implementation is "working" hack


Regards
Marian





