### PR TITLE
Add explicit OpenSSL dependency to cpprestsdk

### DIFF
--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -17,7 +17,6 @@ case $ARCHITECTURE in
   ;;
 esac
 
-
 cmake "$SOURCEDIR/Release"                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT               \
       -DBUILD_TESTS=OFF                                 \

--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -13,7 +13,7 @@ build_requires:
 case $ARCHITECTURE in
   osx*) 
     [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
+    [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl)
   ;;
 esac
 

--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -25,8 +25,7 @@ cmake "$SOURCEDIR/Release"                              \
       -DCMAKE_CXX_FLAGS=-Wno-error=conversion           \
       -DCPPREST_EXCLUDE_WEBSOCKETS=ON                   \
       ${BOOST_VERSION:+-DBOOST_ROOT=$BOOST_ROOT}        \
-      ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
-
+      ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}
 
 make ${JOBS:+-j $JOBS}
 make install

--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -11,20 +11,21 @@ build_requires:
 #!/bin/sh
 
 case $ARCHITECTURE in
-    osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-          [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
-          ;;
+  osx*) 
+    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
+    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
+  ;;
 esac
 
 
-cmake "$SOURCEDIR/Release"                      \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
-      -DBUILD_TESTS=OFF                         \
-      -DBUILD_SAMPLES=OFF                       \
-      -DCMAKE_BUILD_TYPE=Debug                  \
-      -DCMAKE_CXX_FLAGS=-Wno-error=conversion   \
-      -DCPPREST_EXCLUDE_WEBSOCKETS=ON \
-      ${BOOST_VERSION:+-DBOOST_ROOT=$BOOST_ROOT} \
+cmake "$SOURCEDIR/Release"                              \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT               \
+      -DBUILD_TESTS=OFF                                 \
+      -DBUILD_SAMPLES=OFF                               \
+      -DCMAKE_BUILD_TYPE=Debug                          \
+      -DCMAKE_CXX_FLAGS=-Wno-error=conversion           \
+      -DCPPREST_EXCLUDE_WEBSOCKETS=ON                   \
+      ${BOOST_VERSION:+-DBOOST_ROOT=$BOOST_ROOT}        \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
 
 

--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -4,14 +4,18 @@ tag: master
 source: https://github.com/Microsoft/cpprestsdk
 requires:
 - boost
+- OpenSSL:(?!osx)
 build_requires:
 - CMake
 ---
 #!/bin/sh
 
 case $ARCHITECTURE in
-  osx*) BOOST_ROOT=$(brew --prefix boost) ;;
+    osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
+          [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
+          ;;
 esac
+
 
 cmake "$SOURCEDIR/Release"                      \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
@@ -19,7 +23,10 @@ cmake "$SOURCEDIR/Release"                      \
       -DBUILD_SAMPLES=OFF                       \
       -DCMAKE_BUILD_TYPE=Debug                  \
       -DCMAKE_CXX_FLAGS=-Wno-error=conversion   \
-      -DCPPREST_EXCLUDE_WEBSOCKETS=ON
+      -DCPPREST_EXCLUDE_WEBSOCKETS=ON \
+      ${BOOST_VERSION:+-DBOOST_ROOT=$BOOST_ROOT} \
+      ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
+
 
 make ${JOBS:+-j $JOBS}
 make install
@@ -36,7 +43,9 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0                                                          \\
+            ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}            \\
+            ${OPENSSL_VERSION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}
 # Our environment
 setenv CPPRESTSDK_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(CPPRESTSDK_ROOT)/lib64


### PR DESCRIPTION
This prevents it from grabbing the system version, leading to the linking of two versions of the library down the line in JiskefetApiCpp