### PR TITLE
Prevent setting CPLUS_INCLUDE_PATH on mac

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -67,7 +67,10 @@ cd $BUILDDIR/tools/build
 # the ABI suffix. E.g. ../include/python3 rather than ../include/python3m.
 # This is causing havok on different combinations of Ubuntu / Anaconda
 # installations.
-export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:$(python3 -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+case $ARCHITECTURE in
+  osx*)  ;;
+  *) export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:$(python3 -c 'import sysconfig; print(sysconfig.get_path("include"))')" ;;
+esac
 bash bootstrap.sh $TOOLSET
 mkdir -p $TMPB2
 ./b2 install --prefix=$TMPB2


### PR DESCRIPTION
Fixing alisw/alidist#1656: In case boost and
python3 are taken from homebrew a collision
in the boost headers might happen as brew
installs a more recent boost version. As python
support is in any case currently disabled on
macOS dropping propagating the include path
for the python headers is safe on this platform.