### PR TITLE
Add recipe for GLFW

### DIFF
--- a/glfw.sh
+++ b/glfw.sh
@@ -1,6 +1,9 @@
 package: GLFW
 version: "3.3"
 source: https://github.com/glfw/glfw.git
+build_requires:
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/sh
 
@@ -28,4 +31,6 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0
 setenv GLFW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
 EoF

--- a/glfw.sh
+++ b/glfw.sh
@@ -1,0 +1,31 @@
+package: GLFW
+version: "3.3"
+source: https://github.com/glfw/glfw.git
+---
+#!/bin/sh
+
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+  ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
+  -DBUILD_SHARED_LIBS=ON \
+  -DGLFW_BUILD_EXAMPLES=OFF \
+  -DGLFW_BUILD_TESTS=OFF \
+  -DGLFW_BUILD_DOCS=OFF
+
+cmake --build . -- ${JOBS+-j $JOBS} install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat >"$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+setenv GLFW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+EoF

--- a/glfw.sh
+++ b/glfw.sh
@@ -5,13 +5,11 @@ build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
 ---
-#!/bin/sh
-
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
-  ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
-  -DBUILD_SHARED_LIBS=ON \
-  -DGLFW_BUILD_EXAMPLES=OFF \
-  -DGLFW_BUILD_TESTS=OFF \
+  ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}          \
+  -DBUILD_SHARED_LIBS=ON                             \
+  -DGLFW_BUILD_EXAMPLES=OFF                          \
+  -DGLFW_BUILD_TESTS=OFF                             \
   -DGLFW_BUILD_DOCS=OFF
 
 cmake --build . -- ${JOBS+-j $JOBS} install
@@ -30,7 +28,5 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0
-setenv GLFW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
 EoF


### PR DESCRIPTION
Here's an attempt at #1680 

For the record, so far I'm happy with just having this recipe available, no need to propagate the dependency explicitly anywhere, as far as I'm concerned.

The way I use it : 

- I don't have glfw installed via brew
- if I do nothing special then alibuild builds o2 without glfw
- if I do `module load GLFW` (after a proper alibuild build GLFW) and then alibuild o2, as GLFW_ROOT is set, the O2 CMakeLists.txt picks it and I get an O2 build w/ GLFW. (at least it's working now on my cmake-migration-step-1 branch where I use `find_package(GLFW NAMES glfw3 CONFIG)`

