### PR TITLE
WIP: Fix JAliEn-ROOT build on MacOS

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -10,7 +10,7 @@ env:
 overrides:
   XRootD:
     version: "%(tag_basename)s_JALIEN"
-    tag: "v4.9.1"
+    tag: "v4.8.6"
     source: https://github.com/xrootd/xrootd
     build_requires:
       - CMake

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.3.0"
+tag: "0.4.0"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -9,6 +9,7 @@ build_requires:
   - json-c
   - CMake
   - "GCC-Toolchain:(?!osx)"
+  - zlib
 append_path:
   ROOT_PLUGIN_PATH: "$JALIEN_ROOT_ROOT/etc/plugins"
 ---
@@ -21,6 +22,7 @@ cmake $SOURCEDIR                                         \
       -DROOTSYS="$ROOTSYS"                               \
       -DJSONC="$JSON_C_ROOT"                             \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
+      -DZLIB_ROOT="$ZLIB_ROOT"                           \
       -DLWS="$LIBWEBSOCKETS_ROOT"
 make ${JOBS:+-j $JOBS} install
 

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -6,6 +6,7 @@ build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
   - "OpenSSL:(?!osx)"
+  - zlib
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in
@@ -20,6 +21,7 @@ cmake $SOURCEDIR/                                                   \
       ${OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIRS=$OPENSSL_ROOT/include} \
       ${OPENSSL_ROOT:+-DOPENSSL_LIBRARIES=$OPENSSL_ROOT/lib}        \
       -DLWS_HAVE_OPENSSL_ECDH_H=OFF                                 \
+      -DZLIB_ROOT=$ZLIB_ROOT                                        \
       -DLWS_WITHOUT_TESTAPPS=ON
 make ${JOBS+-j $JOBS} install
 rm -rf $INSTALLROOT/share

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -17,6 +17,7 @@ cmake $SOURCEDIR/                                                   \
       -DCMAKE_BUILD_TYPE=RELEASE                                    \
       -DLWS_WITH_STATIC=ON                                          \
       -DLWS_WITH_SHARED=OFF                                         \
+      -DLWS_WITH_IPV6=ON                                            \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}             \
       ${OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIRS=$OPENSSL_ROOT/include} \
       ${OPENSSL_ROOT:+-DOPENSSL_LIBRARIES=$OPENSSL_ROOT/lib}        \


### PR DESCRIPTION
This PR introduces modifications needed to build JAliEn-ROOT on MacOS. The XRootD 4.9.x seems to have troubles building on some MacOS machines so we will stick to 4.8.x until we understand better what is the issue.

After this PR is merged we can trigger another special AliPhysics build with JAliEn support and publish it in CVMFS.