### PR TITLE
Bump JAliEn-ROOT to v0.4.1

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.4.0"
+tag: "0.4.1"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Addressing the problem with missing headers at runtime, ROOT and cling couldn't find them even when ROOT_INCLUDE_PATH was set properly. The problem seems to be the project layout at build time which is now changed in JAliEn-ROOT repository. The workaround was to split src/ and inc/ directories.