### PR TITLE
Prep work for cmake migration

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -53,7 +53,7 @@ incremental_recipe: |
     # Clean up old coverage data and tests logs
     find . -name "*.gcov" -o -name "*.gcda" -delete
     # cleanup ROOT files created by tests in build area
-    find $PWD -path $PWD/stage -prune -o -name "*.root" -delete
+    find $PWD -not \( -path $PWD/stage -prune \) -name \*.root -exec rm {} \;
     rm -rf test_logs
     TESTERR=
     ctest -E test_Framework --output-on-failure ${JOBS+-j $JOBS} || TESTERR=$?
@@ -222,7 +222,7 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
   find . -name "*.gcov" -o -name "*.gcda" -delete
   rm -rf test_logs
   # cleanup ROOT files created by tests in build area
-  find $PWD -path $PWD/stage -prune -o -name "*.root" -delete
+  find $PWD -not \( -path $PWD/stage -prune \) -name \*.root -exec rm {} \;
   TESTERR=
   ctest -E test_Framework --output-on-failure ${JOBS+-j $JOBS} || TESTERR=$?
   ctest -R test_Framework --output-on-failure || TESTERR=$?

--- a/o2.sh
+++ b/o2.sh
@@ -222,7 +222,7 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
   find . -name "*.gcov" -o -name "*.gcda" -delete
   rm -rf test_logs
   # cleanup ROOT files created by tests in build area
-  find $PWD -name "*.root" -delete
+  find $PWD -path $PWD/stage -prune -o -name "*.root" -delete
   TESTERR=
   ctest -E test_Framework --output-on-failure ${JOBS+-j $JOBS} || TESTERR=$?
   ctest -R test_Framework --output-on-failure || TESTERR=$?

--- a/o2.sh
+++ b/o2.sh
@@ -53,7 +53,7 @@ incremental_recipe: |
     # Clean up old coverage data and tests logs
     find . -name "*.gcov" -o -name "*.gcda" -delete
     # cleanup ROOT files created by tests in build area
-    find $PWD -name "*.root" -delete
+    find $PWD -path $PWD/stage -prune -o -name "*.root" -delete
     rm -rf test_logs
     TESTERR=
     ctest -E test_Framework --output-on-failure ${JOBS+-j $JOBS} || TESTERR=$?


### PR DESCRIPTION
I've tried hard to ensure that my cmake migration requires the minimum amount of changes compared to the existing so it's easy to test, but I'm afraid I'd need one change in this recipe though. 

In the new scheme the tests are meant be ran from the build directory directly (i.e. before install) (but can still be ran after install, though I generally don't see the point). This is possible because there's now a "stage" area in the build tree which mimics the install area somehow (not a lot different from the current situation, just that build/bin build/lib are now build/stage/bin and build/stage/lib). But that stage area also contains important data files (e.g. the magnetic field) that are inputs for some tests, and which are unfortunately wiped out by the o2.sh recipe. This PR fixes this.

(this is one of the reasons for the failure of https://github.com/AliceO2Group/AliceO2/pull/2100 - not the only one unfortunately ;-) )