### PR TITLE
node-gyp rebuild fails if the first python on the path is not python2

### DIFF
--- a/qcg.sh
+++ b/qcg.sh
@@ -12,8 +12,16 @@ valid_defaults:
 #!/bin/bash -e
 
 rsync -a --delete "$SOURCEDIR/QualityControl/" .
+
 ( unset PYTHONHOME PYTHONPATH PYTHONUSERBASE;
-  npm install --only=production --loglevel=verbose --no-save --no-package-lock --unsafe-perm )
+  major=$(python -c "import sys, __future__; print(sys.version_info.major);")
+  if test $major != "2"; then
+    # this hack is needed to ensure we have "python" = python2 for node-gyp
+    # which is still not python3 compliant...
+    ln -s $(which python2) $BUILDDIR/python
+    export PATH=$BUILDDIR:$PATH 
+  fi
+  npm install --only=production --loglevel=verbose --no-save --no-package-lock --unsafe-perm)
 
 mkdir -p bin
 cat > bin/qcg <<EOF


### PR DESCRIPTION
@awegrzyn 
This is kind of a follow-up on https://alice.its.cern.ch/jira/browse/OGUI-304?jql=text%20~%20%22gyp%22

The issue I had is that my working environment is a python3 virtual env, so within that env. python == python3. I do have a python2 available, but that was not enough as the gyp-mac-tool is using /usr/bin/env python as shebang. Hence this fix. 

Hopefully won't be necessary in a few months (assuming gyp supports python3 by that time)