### PR TITLE
Add RAPID_JSON_HOME variable to module file

### DIFF
--- a/rapidjson.sh
+++ b/rapidjson.sh
@@ -26,7 +26,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0
 # Our environment
-prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
-prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
+setenv RAPID_JSON_HOME \$::env(BASEDIR)/$PKGNAME/\$version 
+prepend-path PATH \$::env(RAPID_JSON_HOME)/bin
+prepend-path LD_LIBRARY_PATH \$::env(RAPID_JSON_HOME)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(RAPID_JSON_HOME)/lib")
 EoF


### PR DESCRIPTION
exports the base directory of rapidJSON as environment variable RAPID_JSON_HOME, additions to PATH and LD_LIBRARY_PATH are derived from it. This allows easier development of applications inside the alienv environment. 