### PR TITLE
Bump QC to 0.15.2

### DIFF
--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -1,6 +1,6 @@
 package: QualityControl
 version: "%(tag_basename)s"
-tag: v0.14.2
+tag: v0.15.2
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Needed for the Cmake migration of AliceO2 (see PR https://github.com/AliceO2Group/AliceO2/pull/2170)