### PR TITLE
Set LD_LIBRARY_PATH as a CMake variable so ctest (of macros) works al…

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -168,8 +168,10 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${ARROW_ROOT:+-DARROW_HOME=$ARROW_ROOT}                                               \
       -Dbenchmark_DIR=${GOOGLEBENCHMARK_ROOT}/lib/cmake/benchmark                           \
       ${GLFW_ROOT:+-DGLFW_LOCATION=$GLFW_ROOT}                                              \
-      ${FMT_ROOT:+-DFMT_ROOT=${FMT_ROOT}}                                                    \
-      ${CUB_ROOT:+-DCUB_ROOT=$CUB_ROOT}
+      ${FMT_ROOT:+-DFMT_ROOT=${FMT_ROOT}}                                                   \
+      ${CUB_ROOT:+-DCUB_ROOT=$CUB_ROOT}                                                     \
+      ${LD_LIBRARY_PATH:+-DLD_LIBRARY_PATH=${LD_LIBRARY_PATH}}
+
 
 cmake --build . -- ${JOBS+-j $JOBS} install
 


### PR DESCRIPTION
…so with SIP enabled

This is not critical nor urgent (as the recommended configuration is to disable SIP) but might be considered at some point (once https://github.com/AliceO2Group/AliceO2/pull/2172 is in, anyway). Without this a ctest fails on most of the macros because an empty LD_LIBRARY_PATH is passed to the root process launching the macro.