### PR TITLE
Reduce ROOT CMake CXX INTERFACE COMPILE FEATURE from 17 to 14 to be compatible with CUDA

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -32,6 +32,10 @@ incremental_recipe: |
          "$INSTALLROOT/etc/plugins/TSystem/P030_TAlienSystem.C" \
          "$INSTALLROOT/etc/plugins/TFile/P070_TAlienFile.C"
 
+  # Reduce ROOT C++ Standard Interface Requirement to C++14 for CUDA compatibility
+  sed -i.deleteme -e "s/cxx_std_17/cxx_std_14/" "$INSTALLROOT/cmake/ROOTConfig-targets.cmake" || true
+  find . -name '*.deleteme' -exec rm -f '{}' \; || true
+
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/bash -e
@@ -176,6 +180,8 @@ fi
 
 # Make some CMake files used by other projects relocatable
 sed -i.deleteme -e "s!$BUILDDIR!$INSTALLROOT!g" $(find "$INSTALLROOT" -name '*.cmake') || true
+# Reduce ROOT C++ Standard Interface Requirement to C++14 for CUDA compatibility
+sed -i.deleteme -e "s/cxx_std_17/cxx_std_14/" "$INSTALLROOT/cmake/ROOTConfig-targets.cmake" || true
 find . -name '*.deleteme' -exec rm -f '{}' \; || true
 
 rm -vf "$INSTALLROOT/etc/plugins/TGrid/P010_TAlien.C"         \


### PR DESCRIPTION
This is an alternative to AliceO2Group/AliceO2#2186
It just replaces all ROOT CXX requirements from 17 to 14 in our alidist recipe.

I have to say I do not like this hack either, but it is much better than adding tens of manual include dependencies in O2. And after spending quite some time searching for the solution, I think there are only the following possibilities (out of which I like this PR best):
- The much more intrusive PR AliceO2Group/AliceO2#2186 (which handles all includes for CUDA compilation manually in O2).
- This PR, which hacks the ROOT C++17 requirements out (This does not change anything, as we anyway set the CXX standard manually).
- Go back from modern CMake for ROOT to the old style, using ROOT_INCLUDE_DIRS and ROOT_LIBRARIES instead of the targets.
- Go back from modern CMake with CUDA as language to FindCUDA (which is deprecated), since this does not do the language feature check (since it does not consider CUDA a language).
- Implement a new feature in CMake which allows to manually specify compiler and compile flags for language dialects unknown to CMake (rather long term, since it would need to be developed, and we'd need to bump the CMake version eventually).

Finally, I'd like to mention that the same problem will hit us with any dependency that will impose a CXX standard on CMake library interface level. So far, only ROOT does this. If this happens in the future, we'd have to apply the same hack as well.

@ktf @ihrivnac @aphecetche @dberzano : Please let me know what you think. If there are no objections, I'd suggest we go ahead with this solution, since it is not a dramatic hack. It will be mandatory for ROOT 6.18, and also for ROOT 6.16 it will allow me to remove some workarounds.