### PR TITLE
Switch back to 64bit JDK for JAliEn on Linux

### DIFF
--- a/jdk.sh
+++ b/jdk.sh
@@ -18,7 +18,7 @@ JDK_PLATFORM=linux
 if [[ $JDK_PLATFORM == osx ]]; then
   URL="https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz"
 else
-  URL="https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_i686.tar.gz"  
+  URL="https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz"  
 fi
 
 mkdir -p "$INSTALLROOT"


### PR DESCRIPTION
Switch back to 64bit JDKs because 32bit libraries aren't available on the build nodes.