### PR TITLE
Use Alice-Grid-Utils common interface for the new and legacy Grid plugins

### DIFF
--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -1,0 +1,10 @@
+package: Alice-GRID-Utils
+version: "%(tag_basename)s"
+tag: "0.0.0"
+source: https://gitlab.cern.ch/nhardi/alice-grid-utils.git
+---
+#!/bin/bash -e
+
+DST="$INSTALLROOT/include"
+mkdir -p "$DST"
+cp -v $SOURCEDIR/*.h "$DST/"

--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -8,3 +8,16 @@ source: https://gitlab.cern.ch/nhardi/alice-grid-utils.git
 DST="$INSTALLROOT/include"
 mkdir -p "$DST"
 cp -v $SOURCEDIR/*.h "$DST/"
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"

--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -1,6 +1,6 @@
 package: Alice-GRID-Utils
 version: "%(tag_basename)s"
-tag: "0.0.0"
+tag: "0.0.3"
 source: https://gitlab.cern.ch/nhardi/alice-grid-utils.git
 ---
 #!/bin/bash -e

--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -1,6 +1,6 @@
 package: Alice-GRID-Utils
 version: "%(tag_basename)s"
-tag: "0.0.3"
+tag: "0.0.6"
 source: https://gitlab.cern.ch/nhardi/alice-grid-utils.git
 ---
 #!/bin/bash -e

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -26,13 +26,15 @@ fi
 # Determine whether we are building for ROOT 5 or ROOT 6+
 [[ -x "$ROOTSYS/bin/rootcling" ]] && ROOT_MAJOR="v6-00-00" || ROOT_MAJOR="v5-00-00"
 
-cmake $SOURCEDIR                                         \
+rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR
+rsync -a $ALICE_GRID_UTILS_ROOT/include/ $BUILDDIR/inc
+
+cmake $BUILDDIR                                          \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}          \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"              \
       -DROOTSYS="$ROOTSYS"                               \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DALIEN_DIR="$XALIENFS_ROOT"                       \
-      -DAGU="$ALICE_GRID_UTILS_ROOT"                     \
       -DROOT_VERSION="$ROOT_MAJOR"
 
 cmake --build . --target install ${JOBS:+-- -j$JOBS}

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -1,6 +1,6 @@
 package: AliEn-ROOT-Legacy
 version: "%(tag_basename)s"
-tag: "0.0.7"
+tag: "0.1.0"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
   - CMake

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -8,6 +8,7 @@ requires:
   - ROOT
 build_requires:
   - xalienfs
+  - Alice-GRID-Utils
 append_path:
   ROOT_PLUGIN_PATH: "$ALIEN_ROOT_LEGACY_ROOT/etc/plugins"
 prepend_path:
@@ -31,6 +32,7 @@ cmake $SOURCEDIR                                         \
       -DROOTSYS="$ROOTSYS"                               \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DALIEN_DIR="$XALIENFS_ROOT"                       \
+      -DAGU="$ALICE_GRID_UTILS_ROOT"                     \
       -DROOT_VERSION="$ROOT_MAJOR"
 
 cmake --build . --target install ${JOBS:+-- -j$JOBS}

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -57,6 +57,8 @@ cmake $SOURCEDIR                                                     \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                      \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}    \
       ${ALIEN_RUNTIME_ROOT:+-DALIEN="$ALIEN_RUNTIME_ROOT"}           \
+      ${JALIEN_ROOT_ROOT:+-DJALIEN_LIBS=$JALIEN_ROOT_ROOT}           \
+      ${ALIEN_ROOT_LEGACY_ROOT:+-DALIEN_LIBS=$ALIEN_ROOT_LEGACY_ROOT}\
       ${FASTJET_ROOT:+-DFASTJET="$FASTJET_ROOT"}                     \
       ${DPMJET_ROOT:+-DDPMJET="$DPMJET_ROOT"}                        \
       ${ZEROMQ_ROOT:+-DZEROMQ=$ZEROMQ_ROOT}                          \

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -10,6 +10,7 @@ build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
   - zlib
+  - Alice-GRID-Utils
 append_path:
   ROOT_PLUGIN_PATH: "$JALIEN_ROOT_ROOT/etc/plugins"
 ---
@@ -23,7 +24,8 @@ cmake $SOURCEDIR                                         \
       -DJSONC="$JSON_C_ROOT"                             \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DZLIB_ROOT="$ZLIB_ROOT"                           \
-      -DLWS="$LIBWEBSOCKETS_ROOT"
+      -DLWS="$LIBWEBSOCKETS_ROOT"                        \
+      -DAGU="$ALICE_GRID_UTILS_ROOT"
 make ${JOBS:+-j $JOBS} install
 
 # Modulefile

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.4.4"
+tag: "0.5.1"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.4.2"
+tag: "0.4.4"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT
@@ -18,14 +18,17 @@ append_path:
 case $ARCHITECTURE in
   osx*) [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl) ;;
 esac
-cmake $SOURCEDIR                                         \
+
+rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR
+rsync -a $ALICE_GRID_UTILS_ROOT/include/ $BUILDDIR/inc
+
+cmake $BUILDDIR                                          \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"              \
       -DROOTSYS="$ROOTSYS"                               \
       -DJSONC="$JSON_C_ROOT"                             \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DZLIB_ROOT="$ZLIB_ROOT"                           \
-      -DLWS="$LIBWEBSOCKETS_ROOT"                        \
-      -DAGU="$ALICE_GRID_UTILS_ROOT"
+      -DLWS="$LIBWEBSOCKETS_ROOT"
 make ${JOBS:+-j $JOBS} install
 
 # Modulefile


### PR DESCRIPTION
The Alice-Grid-Utils contains the common extended interfaces - TAliceFile and TAliceCollection. The interfaces extend TFile and TGridCollection with ALICE specific methods that are used in AliRoot. The interface is implemented by both JAliEn-ROOT and AliEn-ROOT-Legacy ROOT Grid plugins.

Upcoming patch in AliRoot will remove all compile time hard dependencies on TAlienCollection and TAlienFile.