### PR TITLE
Update arrow to 0.14.1

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -1,7 +1,7 @@
 package: arrow
-version: v0.12.0-alice6
-tag: apache-arrow-0.12.0-alice6
-source: https://github.com/alisw/arrow
+version: v0.14.1
+tag: apache-arrow-0.14.1
+source: https://github.com/apache/arrow
 requires:
   - boost
   - lz4
@@ -10,6 +10,7 @@ build_requires:
   - zlib
   - flatbuffers
   - CMake
+  - double-conversion
 env:
   ARROW_HOME: "$ARROW_ROOT"
 ---
@@ -34,6 +35,9 @@ esac
 #   boost
 
 cmake $SOURCEDIR/cpp                                         \
+      -DARROW_DEPENDENCY_SOURCE=SYSTEM                       \
+      -DCMAKE_BUILD_TYPE=Release                             \
+      -DBUILD_SHARED_LIBS=TRUE                               \
       -DARROW_BUILD_BENCHMARKS=OFF                           \
       -DARROW_BUILD_TESTS=OFF                                \
       -DARROW_USE_GLOG=OFF                                   \
@@ -42,11 +46,11 @@ cmake $SOURCEDIR/cpp                                         \
       -DARROW_IPC=ON                                         \
       ${THRIFT_ROOT:+-DARROW_PARQUET=ON}                     \
       ${THRIFT_ROOT:+-DTHRIFT_HOME=${THRIFT_ROOT}}           \
-      ${FLATBUFFERS_ROOT:+-DFLATBUFFERS_HOME=${FLATBUFFERS_ROOT}} \
+      ${FLATBUFFERS_ROOT:+-DFlatbuffers_ROOT=${FLATBUFFERS_ROOT}} \
       -DCMAKE_INSTALL_LIBDIR="lib"                           \
       -DARROW_WITH_LZ4=ON                                    \
       ${RAPIDJSON_ROOT:+-DRAPIDJSON_HOME=${RAPIDJSON_ROOT}}  \
-      ${LZ4_ROOT:+-DLZ4_HOME=${LZ4_ROOT}}                    \
+      ${LZ4_ROOT:+-DLZ4_ROOT=${LZ4_ROOT}}                    \
       ${LZ4_ROOT:+-DLZ4_INCLUDE_DIR=${LZ4_ROOT}/include}     \
       ${LZ4_ROOT:+-DLZ4_STATIC_LIB=${LZ4_ROOT}/lib/liblz4.a} \
       -DARROW_WITH_SNAPPY=OFF                                \

--- a/double-conversion.sh
+++ b/double-conversion.sh
@@ -1,0 +1,42 @@
+package: double-conversion
+version: v3.1.5
+source: https://github.com/google/double-conversion
+build_requires:
+  - CMake
+---
+
+mkdir -p $INSTALLROOT
+
+# Downloaded by CMake, built, and linked statically (not needed at runtime):
+#   zlib, lz4, brotli
+#
+# Taken from our stack, linked statically (not needed at runtime):
+#   flatbuffers
+#
+# Taken from our stack, linked dynamically (needed at runtime):
+#   boost
+
+cmake $SOURCEDIR                          \
+      -DBUILD_TESTING=OFF                 \
+      -DBUILD_SHARED_LIBS=OFF             \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+
+make ${JOBS:+-j $JOBS} install
+
+# Trivial module file to keep the linter happy.
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+EoF

--- a/flatbuffers.sh
+++ b/flatbuffers.sh
@@ -1,5 +1,5 @@
 package: flatbuffers
-version: v1.10.0
+version: v1.11.0
 source: https://github.com/google/flatbuffers
 requires:
   - zlib

--- a/lz4.sh
+++ b/lz4.sh
@@ -12,6 +12,11 @@ prefer_system_check: |
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ ./
 make -j ${JOBS+-j $JOBS}
 make PREFIX=$INSTALLROOT INCLUDEDIR=$INSTALLROOT/include install
+case $ARCHITECTURE in
+  osx*)
+    install_name_tool -id liblz4.dylib $INSTALLROOT/lib/liblz4.dylib
+  ;;
+esac
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
* Pick up double-conversion from our own installation.
* Move to use Release builds
* double-conversion: init at v3.1.5
* Force usage of our own tools