### PR TITLE
Bump AliEn-ROOT-Legacy (TAlien) to 0.1.1

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -1,6 +1,6 @@
 package: AliEn-ROOT-Legacy
 version: "%(tag_basename)s"
-tag: "0.1.0"
+tag: "0.1.1"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
   - CMake


### PR DESCRIPTION
This version fixes the issue with creating the XML collections.
The way how we generate the collections in the AliRoot analysis plugin
recently changed and this this will fix it.