### PR TITLE
Bump XRootD version to v4.10.0 for JALiEn and disable xrdpy bindings

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -10,7 +10,7 @@ env:
 overrides:
   XRootD:
     version: "%(tag_basename)s_JALIEN"
-    tag: "v4.8.6"
+    tag: "v4.10.0"
     source: https://github.com/xrootd/xrootd
     build_requires:
       - CMake

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -23,6 +23,7 @@ cmake "$SOURCEDIR"                                      \
       -DCMAKE_INSTALL_LIBDIR=lib                        \
       -DENABLE_CRYPTO=ON                                \
       -DENABLE_PERL=OFF                                 \
+      -DENABLE_PYTHON=OFF                               \
       -DENABLE_KRB5=OFF                                 \
       -DENABLE_READLINE=OFF                             \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                 \


### PR DESCRIPTION
The XRootD can be upgraded to v4.10.0 on all platforms when we disable Python bindings. The bindings will be re-enabled after we merge the fix into XRootD upstream. This commit affects JAliEn builds only.