### PR TITLE
Export the relevant variables

### DIFF
--- a/treelite.sh
+++ b/treelite.sh
@@ -37,6 +37,9 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0
 # Our environment
 set osname [uname sysname]
+setenv TREELITE_RELEASE \$version
+setenv TREELITE_VERSION $PKGVERSION
+setenv TREELITE_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(TREELITE_RELEASE)
 prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
 prepend-path ROOT_INCLUDE_PATH \$::env(BASEDIR)/$PKGNAME/\$version/include
 prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib


### PR DESCRIPTION
Ciao @ktf ,
thanks to @fcatalan92 I realised that there is a bug in the interplay between the AliPhysics recipe and the treelite one, this should be fixing the issue.
An alternative fix would be removing the check on the `TREELITE_VERSION` env variable in the aliphysics recipe, tell me if you prefer that solution I don't have a strong opinion.

Cheers,
Max 