### PR TITLE
Do not install boost's CMake config files, since they break some stupid dependent packages

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -100,6 +100,10 @@ b2 -q                                            \
    ${CXXSTD:+cxxstd=$CXXSTD}                     \
    install
 
+# Remove CMake Config files, some of our dependent packages pick them up, but fail to use them
+# So for now we rely on the boost module FindBoost which comes with CMake
+rm -Rf "$INSTALLROOT"/lib/cmake
+
 # If boost_python is enabled, check if it was really compiled
 [[ $BOOST_PYTHON ]] && ls -1 "$INSTALLROOT"/lib/*boost_python* > /dev/null
 


### PR DESCRIPTION
As of boost 1.70.0, boost automatically installs CMake Config files.
Dependent packages pick them up, instead of the CMake Module file that comes with CMake.
This leads to 2 problems:
1. Packages e.g. Ppconsul are unable to work with the CMake Config, and thus fail to set library and include paths. By chance, they still work if boost 1.70 is a system installation, since it automatically finds headers and libraries.
2. In the way we build boost, the CMake Config files seem to be broken. At least, requiring some of the boost libraries in `find_package(Boost)` fails, despite the library being present. I couldn't figure out why. With my (and MacOS brew) system boost, this problem does not appear, since the Boost Config files are correct.

The solution for now: we just delete the config files before we install them. Dependent packages will pick up CMakes boost module as it was before. This should be fixed in the future but not on this Friday evening.