### PR TITLE
o2checkcode: enable aliceO2-namespace-naming check

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -43,8 +43,9 @@ ThinCompilationsDatabase.py -exclude-files '(?:.*G\_\_.*\.cxx|.*\.pb.cc)' ${O2_C
 cp thinned_compile_commands.json compile_commands.json
 
 # List of explicitely enabled C++ checks (make sure they are all green)
-CHECKS="${O2_CHECKER_CHECKS:--*,\
-aliceO2-member-name\
+CHECKS="${O2_CHECKER_CHECKS:--*\
+,aliceO2-member-name\
+,aliceO2-namespace-naming\
 ,modernize-avoid-bind\
 ,modernize-deprecated-headers\
 ,modernize-make-shared\

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -43,24 +43,24 @@ ThinCompilationsDatabase.py -exclude-files '(?:.*G\_\_.*\.cxx|.*\.pb.cc)' ${O2_C
 cp thinned_compile_commands.json compile_commands.json
 
 # List of explicitely enabled C++ checks (make sure they are all green)
-CHECKS="${O2_CHECKER_CHECKS:--*\
-,aliceO2-member-name\
-,aliceO2-namespace-naming\
-,modernize-avoid-bind\
-,modernize-deprecated-headers\
-,modernize-make-shared\
-,modernize-raw-string-literal\
-,modernize-redundant-void-arg\
-,modernize-replace-auto-ptr\
-,modernize-replace-random-shuffle\
-,modernize-return-braced-init-list\
-,modernize-shrink-to-fit\
-,modernize-unary-static-assert\
-,modernize-use-equals-default\
-,modernize-use-noexcept\
-,modernize-use-nullptr\
-,modernize-use-override\
-,modernize-use-transparent-functors\
+CHECKS="${O2_CHECKER_CHECKS:--*         \
+,aliceO2-member-name                    \
+,aliceO2-namespace-naming               \
+,modernize-avoid-bind                   \
+,modernize-deprecated-headers           \
+,modernize-make-shared                  \
+,modernize-raw-string-literal           \
+,modernize-redundant-void-arg           \
+,modernize-replace-auto-ptr             \
+,modernize-replace-random-shuffle       \
+,modernize-return-braced-init-list      \
+,modernize-shrink-to-fit                \
+,modernize-unary-static-assert          \
+,modernize-use-equals-default           \
+,modernize-use-noexcept                 \
+,modernize-use-nullptr                  \
+,modernize-use-override                 \
+,modernize-use-transparent-functors     \
 ,modernize-use-uncaught-exceptions}"
 
 # Run C++ checks


### PR DESCRIPTION
@sawenzel I'd like to apply the following patch to `o2codechecker` after it is switched to clang 8 and before this PR is merged, so that namespaces outside `::o2::` are not checked.
```diff
diff --git a/aliceO2/NamespaceNamingCheck.cpp b/aliceO2/NamespaceNamingCheck.cpp
index 3f020dd..016b095 100644
--- a/aliceO2/NamespaceNamingCheck.cpp
+++ b/aliceO2/NamespaceNamingCheck.cpp
@@ -9,6 +9,7 @@
 
 #include "NamespaceNamingCheck.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchersMacros.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include <regex>
 #include <string>
@@ -17,6 +18,13 @@
 using namespace clang::ast_matchers;
 
 namespace clang {
+namespace ast_matchers {
+AST_MATCHER_P(UsingDirectiveDecl, nominatedNamespace,
+              internal::Matcher<NamespaceDecl>, InnerMatcher)
+{
+  return InnerMatcher.matches(*Node.getNominatedNamespace(), Finder, Builder);
+}
+} // namespace ast_matchers
 namespace tidy {
 namespace aliceO2 {
  
@@ -42,18 +50,26 @@ bool isOutsideOfTargetScope(std::string filename)
 
 void NamespaceNamingCheck::registerMatchers(MatchFinder *Finder) {
   const auto validNameMatch = matchesName( std::string("::") + VALID_NAME_REGEX + "$" );
+  const auto inO2NSMatch = matchesName("^::o2::");
 
   // matches namespace declarations that have invalid name
   Finder->addMatcher(namespaceDecl(allOf(
+    inO2NSMatch,
     unless(validNameMatch),
     unless(isAnonymous())
     )).bind("namespace-decl"), this);
   // matches usage of namespace
-  Finder->addMatcher(nestedNameSpecifierLoc(loc(nestedNameSpecifier(specifiesNamespace(unless(validNameMatch)
-    )))).bind("namespace-usage"), this );
+  Finder->addMatcher(nestedNameSpecifierLoc(loc(nestedNameSpecifier(specifiesNamespace(allOf(
+    inO2NSMatch,
+    unless(validNameMatch)
+    ))))).bind("namespace-usage"), this);
   // matches "using namespace" declarations
-  Finder->addMatcher(usingDirectiveDecl(unless(isImplicit()
-    )).bind("using-namespace"), this);
+  Finder->addMatcher(usingDirectiveDecl(allOf(
+    unless(isImplicit()),
+    nominatedNamespace(allOf(
+      inO2NSMatch,
+      unless(validNameMatch)
+    )))).bind("using-namespace"), this);
 }
 
 void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
@@ -112,11 +128,6 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
     std::string newName(MatchedUsingNamespace->getNominatedNamespace()->getDeclName().getAsString());
     std::string oldName=newName;
 
-    if( std::regex_match(newName, std::regex(VALID_NAME_REGEX)) )
-    {
-      return;
-    }
-
     if(fixNamespaceName(newName))
     {
       diag(MatchedUsingNamespace->getLocation(), "namespace %0 does not follow the underscore convention")
```