### PR TITLE
Fix kfparticle CXX std

### DIFF
--- a/kfparticle.sh
+++ b/kfparticle.sh
@@ -11,6 +11,8 @@ build_requires:
 ---
 #!/bin/bash -e
 
+sed -i "s/set (CMAKE_CXX_STANDARD 11)//" $SOURCEDIR/CMakeLists.txt
+
 cmake $SOURCEDIR                                        \
       ${VC_VERSION:+-DVc_INCLUDE_DIR=$VC_ROOT/include}  \
       ${VC_VERSIOM:+-DVc_LIBRARIES=$VCROOT/lib/libVc.a} \

--- a/kfparticle.sh
+++ b/kfparticle.sh
@@ -1,7 +1,7 @@
 package: KFParticle
-version: "%(short_hash)s"
-tag: "v1.1"
-source: https://git.cbm.gsi.de/m.zyzak/KFParticle.git
+version: "alice-v1.1-1"
+tag: "alice/v1.1-1"
+source: https://github.com/alisw/KFParticle
 requires:
   - ROOT
   - "GCC-Toolchain:(?!osx)"
@@ -10,8 +10,6 @@ build_requires:
   - CMake
 ---
 #!/bin/bash -e
-
-sed -i "s/set (CMAKE_CXX_STANDARD 11)//" $SOURCEDIR/CMakeLists.txt
 
 cmake $SOURCEDIR                                        \
       ${VC_VERSION:+-DVc_INCLUDE_DIR=$VC_ROOT/include}  \


### PR DESCRIPTION
KFParticle unconditionally overrides the CXX std to C++11, which fails to build with ROOT, if ROOT was built with a higher standard, which breaks our O2 defaults.
I asked Maksim and Ivan and apparently they do not want to fix this upstream for the time being.
So I propose we apply this fix.