### PR TITLE
Drop xrootd from alien-runtime dependencies

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -3,11 +3,12 @@ version: "%(tag_basename)s"
 tag: "0.1.3"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
+  - ROOT
+  - XRootD
+  - xalienfs
+build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
-  - ROOT
-build_requires:
-  - xalienfs
   - Alice-GRID-Utils
 append_path:
   ROOT_PLUGIN_PATH: "$ALIEN_ROOT_LEGACY_ROOT/etc/plugins"
@@ -70,7 +71,10 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ROOT/${ROOT_VERSION}-${ROOT_REVISION}
+module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
+                     ROOT/${ROOT_VERSION}-${ROOT_REVISION}                                                  \\
+                     XRootD/${XROOTD_VERSION}-${XROOTD_REVISION}                                            \\
+                     xalienfs/${XALIENFS_VERSION}-${XALIENFS_REVISION}
 
 # Our environment
 setenv ALIEN_ROOT_LEGACY_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -10,10 +10,7 @@ build_requires:
  - "osx-system-openssl:(osx.*)"
  - AliEn-CAs
  - ApMon-CPP
- - XRootD
  - UUID
-prepend_path:
-  PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
 env:
   X509_CERT_DIR: "$ALIEN_RUNTIME_ROOT/globus/share/certificates"
 ---
@@ -43,10 +40,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
-setenv ALIEN_RUNTIME_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALIEN_RUNTIME_ROOT)/lib")
-prepend-path PATH \$::env(ALIEN_RUNTIME_ROOT)/bin
-prepend-path PERLLIB \$::env(ALIEN_RUNTIME_ROOT)/lib/perl
-setenv X509_CERT_DIR \$::env(ALIEN_RUNTIME_ROOT)/globus/share/certificates
+set ALIEN_RUNTIME_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$ALIEN_RUNTIME_ROOT/lib
+prepend-path PATH \$ALIEN_RUNTIME_ROOT/bin
+setenv X509_CERT_DIR \$ALIEN_RUNTIME_ROOT/globus/share/certificates
 EoF

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -11,14 +11,6 @@ overrides:
     version: "%(tag_basename)s_JALIEN"
     tag: "v4.10.0"
     source: https://github.com/xrootd/xrootd
-    build_requires:
-      - CMake
-    requires:
-      - "GCC-Toolchain:(?!osx)"
-      - "OpenSSL:(?!osx)"
-      - "osx-system-openssl:(osx.*)"
-      - ApMon-CPP
-      - libxml2
   JDK:
     version: "12.0.1_JALIEN"
   libxml2:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -8,6 +8,7 @@ env:
   CMAKE_GENERATOR: "Ninja"
   GEANT4_BUILD_MULTITHREADED: "ON"
 disable:
+  - AliEn-Runtime
   - AliRoot
 overrides:
   ROOT:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -8,7 +8,6 @@ env:
   CMAKE_GENERATOR: "Ninja"
   GEANT4_BUILD_MULTITHREADED: "ON"
 disable:
-  - AliEn-Runtime
   - AliRoot
 overrides:
   ROOT:
@@ -43,6 +42,10 @@ overrides:
   msgpack:
     version: "v3.1.1"
     tag: cpp-3.1.1
+  XRootD:
+    version: "%(tag_basename)s_O2"
+    tag: "v4.10.0"
+    source: https://github.com/xrootd/xrootd
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -31,6 +31,10 @@ overrides:
     version: "4.12.2"
   fastjet:
     tag: "v3.3.2_1.041-alice1"
+  XRootD:
+    version: "%(tag_basename)s_O2"
+    tag: "v4.10.0"
+    source: https://github.com/xrootd/xrootd
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -29,6 +29,7 @@ overrides:
       - FreeType:(?!osx)
       - "MySQL:slc7.*"
       - GCC-Toolchain:(?!osx)
+      - XRootD
     build_requires:
       - CMake
       - "Xcode:(osx.*)"

--- a/defaults-pwgmmtest.sh
+++ b/defaults-pwgmmtest.sh
@@ -19,6 +19,7 @@ overrides:
       - "GCC-Toolchain:(?!osx)"
       - libpng
       - lzma
+      - XRootD
   GSL:
     prefer_system_check: |
       printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | c++ -I$(brew --prefix gsl)/include -xc++ - -o /dev/null

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -29,6 +29,7 @@ overrides:
       - FreeType:(?!osx)
       - "MySQL:slc7.*"
       - GCC-Toolchain:(?!osx)
+      - XRootD
     build_requires:
       - CMake
       - "Xcode:(osx.*)"

--- a/defaults-user.sh
+++ b/defaults-user.sh
@@ -31,6 +31,7 @@ overrides:
       - FreeType:(?!osx)
       - "MySQL:slc7.*"
       - GCC-Toolchain:(?!osx)
+      - XRootD
     build_requires:
       - CMake
       - "Xcode:(osx.*)"

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -45,10 +45,10 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ROOT/${ROOT_VERSION}-${ROOT_REVISION}
 
 # Our environment
-setenv JALIEN_ROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(JALIEN_ROOT_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(JALIEN_ROOT_ROOT)/lib
-append-path ROOT_PLUGIN_PATH \$::env(JALIEN_ROOT_ROOT)/etc/plugins
-prepend-path ROOT_INCLUDE_PATH \$::env(JALIEN_ROOT_ROOT)/include
+set JALIEN_ROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$JALIEN_ROOT_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$JALIEN_ROOT_ROOT/lib
+append-path ROOT_PLUGIN_PATH \$JALIEN_ROOT_ROOT/etc/plugins
+prepend-path ROOT_INCLUDE_PATH \$JALIEN_ROOT_ROOT/include
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/root.sh
+++ b/root.sh
@@ -16,6 +16,7 @@ requires:
   - libxml2
   - "OpenSSL:(?!osx)"
   - "osx-system-openssl:(osx.*)"
+  - XRootD
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
@@ -77,10 +78,9 @@ case $ARCHITECTURE in
 esac
 
 if [[ $ALIEN_RUNTIME_VERSION ]]; then
-  # AliEn-Runtime: we take OpenSSL, XRootD and libxml2 from there, in case they
+  # AliEn-Runtime: we take OpenSSL and libxml2 from there, in case they
   # were not taken from the system
   OPENSSL_ROOT=${OPENSSL_ROOT:+$ALIEN_RUNTIME_ROOT}
-  XROOTD_ROOT=${XROOTD_VERSION:+$ALIEN_RUNTIME_ROOT}
   LIBXML2_ROOT=${LIBXML2_VERSION:+$ALIEN_RUNTIME_ROOT}
 fi
 [[ $SYS_OPENSSL_ROOT ]] && OPENSSL_ROOT=$SYS_OPENSSL_ROOT

--- a/root.sh
+++ b/root.sh
@@ -228,9 +228,9 @@ setenv ROOT_RELEASE \$version
 setenv ROOT_BASEDIR \$::env(BASEDIR)/$PKGNAME
 setenv ROOTSYS \$::env(ROOT_BASEDIR)/\$::env(ROOT_RELEASE)
 
-set ROOTSYS  \$::env(ROOTSYS)
-prepend-path PYTHONPATH \$ROOTSYS/lib
-prepend-path PATH \$ROOTSYS/bin
-prepend-path LD_LIBRARY_PATH \$ROOTSYS/lib
+set ROOT_ROOT  \$::env(ROOTSYS)
+prepend-path PYTHONPATH \$ROOT_ROOT/lib
+prepend-path PATH \$ROOT_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$ROOT_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/root.sh
+++ b/root.sh
@@ -227,8 +227,10 @@ module load BASE/1.0 ${ALIEN_RUNTIME_VERSION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSI
 setenv ROOT_RELEASE \$version
 setenv ROOT_BASEDIR \$::env(BASEDIR)/$PKGNAME
 setenv ROOTSYS \$::env(ROOT_BASEDIR)/\$::env(ROOT_RELEASE)
-prepend-path PYTHONPATH \$::env(ROOTSYS)/lib
-prepend-path PATH \$::env(ROOTSYS)/bin
-prepend-path LD_LIBRARY_PATH \$::env(ROOTSYS)/lib
+
+set ROOTSYS  \$::env(ROOTSYS)
+prepend-path PYTHONPATH \$ROOTSYS/lib
+prepend-path PATH \$ROOTSYS/bin
+prepend-path LD_LIBRARY_PATH \$ROOTSYS/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -63,5 +63,4 @@ module load BASE/1.0 XRootD/${XROOTD_VERSION}-${XROOTD_REVISION}             \\
 # Our environment
 set XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$XALIENFS_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$XALIENFS_ROOT/lib
 EoF

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -14,6 +14,9 @@ build_requires:
  - libperl
 prepend_path:
  PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
+env:
+  GSHELL_ROOT: "$XALIENFS_ROOT"
+  GSHELL_NO_GCC: "1"
 ---
 #!/bin/bash -e
 [[ ! $SWIG_ROOT ]] && SWIG_LIB=`swig -swiglib`
@@ -61,7 +64,11 @@ module load BASE/1.0 XRootD/${XROOTD_VERSION}-${XROOTD_REVISION}             \\
             AliEn-Runtime/${ALIEN_RUNTIME_VERSION}-${ALIEN_RUNTIME_REVISION}
 
 # Our environment
-setenv XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$::env(XALIENFS_ROOT)/lib
-prepend-path PATH \$::env(XALIENFS_ROOT)/bin
+set XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+
+setenv GSHELL_ROOT \$XALIENFS_ROOT
+setenv GSHELL_NO_GCC 1
+
+prepend-path LD_LIBRARY_PATH \$XALIENFS_ROOT/lib
+prepend-path PATH \$XALIENFS_ROOT/bin
 EoF

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -13,7 +13,7 @@ build_requires:
  - UUID
  - libperl
 prepend_path:
- - PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
+ PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
 ---
 #!/bin/bash -e
 [[ ! $SWIG_ROOT ]] && SWIG_LIB=`swig -swiglib`

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -61,6 +61,7 @@ module load BASE/1.0 XRootD/${XROOTD_VERSION}-${XROOTD_REVISION}             \\
             AliEn-Runtime/${ALIEN_RUNTIME_VERSION}-${ALIEN_RUNTIME_REVISION}
 
 # Our environment
-set XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$XALIENFS_ROOT/bin
+setenv XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(XALIENFS_ROOT)/lib
+prepend-path PATH \$::env(XALIENFS_ROOT)/bin
 EoF


### PR DESCRIPTION
As discussed with @Atlantic777, we need to drop those in order to be able to break the circular dependency when building xrootd python bindings.