### PR TITLE
Lint DYLD_LIBRARY_PATH out of our recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ script: |
     [[ -e $X ]] || continue
     echo Linting $X
     scripts/lint-recipes $X || ERR="$ERR $X"
+    # This should really be cleaned up, since macOS cleans any DYLD_LIBRARY_PATH
+    # when launching children processes, making it completely irrelevant.
+    # In any case we correctly handle rpath in our macOS builds.
+    grep DYLD_LIBRARY_PATH $X && ERR="$ERR $X"
     [[ $X == defaults-*.sh ]] && continue
 
     # If a recipe is not a system requirement, it must have a Modulefile


### PR DESCRIPTION
If we are using it, there is something wrong going on.