### PR TITLE
linter: accept "unset DYLD_LIBRARY_PATH"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script: |
     # This should really be cleaned up, since macOS cleans any DYLD_LIBRARY_PATH
     # when launching children processes, making it completely irrelevant.
     # In any case we correctly handle rpath in our macOS builds.
-    grep DYLD_LIBRARY_PATH $X && ERR="$ERR $X"
+    grep -v "unset DYLD_LIBRARY_PATH" | grep DYLD_LIBRARY_PATH $X && ERR="$ERR $X"
     [[ $X == defaults-*.sh ]] && continue
 
     # If a recipe is not a system requirement, it must have a Modulefile


### PR DESCRIPTION
In principle this is also unneeded, but let's keep it for now.