### PR TITLE
Bump cgal, fixes MacOS issue with C++17

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -30,7 +30,7 @@ overrides:
   ROOT:
     tag: "v6-18-04" 
   cgal:
-    version: "4.11"
+    version: "4.12.2"
   fastjet:
     tag: "v3.3.2_1.041-alice1"
 ---


### PR DESCRIPTION
@jolopezl : Seems to be a problem that affected only MacOS with C++17, it should be fixed after this version bump. Could you try if it works for you?