### PR TITLE
RapidJSON: do not expose bogus runtime paths

### DIFF
--- a/rapidjson.sh
+++ b/rapidjson.sh
@@ -26,7 +26,4 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0
 # Our environment
-prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
-prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
 EoF


### PR DESCRIPTION
RapidJSON is actually headers only. Proper fix would actually be to use RapidJSON as `build_requires` only.