### PR TITLE
arrow: enable Gandiva and Parquet support

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -6,11 +6,15 @@ requires:
   - boost
   - lz4
   - RapidJSON
+  - thrift
+  - LLVM
+  - protobuf
 build_requires:
   - zlib
   - flatbuffers
   - CMake
   - double-conversion
+  - re2
 env:
   ARROW_HOME: "$ARROW_ROOT"
 ---
@@ -19,10 +23,18 @@ mkdir -p $INSTALLROOT
 case $ARCHITECTURE in
   osx*)
     # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $FLATBUFFERS_ROOT ]] && FLATBUFFERS_ROOT=$(brew --prefix flatbuffers)
+    [[ ! $FLATBUFFERS_ROOT ]] && FLATBUFFERS_ROOT=$(dirname $(dirname $(which flatc)))
     [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-    [[ ! $LZ4_ROOT ]] && LZ4_ROOT=$(brew --prefix lz4)
+    [[ ! $LZ4_ROOT ]] && LZ4_ROOT=$(dirname $(dirname $(which lz4)))
+    [[ ! $PROTOBUF_ROOT ]] && PROTOBUF_ROOT=$(dirname $(dirname $(which protoc)))
+    [[ ! -d $FLATBUFFERS_ROOT ]] && unset FLATBUFFERS_ROOT
+    [[ ! -d $BOOST_ROOT ]] && unset BOOST_ROOT
+    [[ ! -d $LZ4_ROOT ]] && unset LZ4_ROOT
+    [[ ! -d $PROTOBUF_ROOT ]] && unset PROTOBUF_ROOT
+    MACOSX_RPATH=OFF
+    SONAME=dylib
   ;;
+  *) SONAME=so ;;
 esac
 
 # Downloaded by CMake, built, and linked statically (not needed at runtime):
@@ -33,34 +45,40 @@ esac
 #
 # Taken from our stack, linked dynamically (needed at runtime):
 #   boost
-
-cmake $SOURCEDIR/cpp                                         \
-      -DARROW_DEPENDENCY_SOURCE=SYSTEM                       \
-      -DCMAKE_BUILD_TYPE=Release                             \
-      -DBUILD_SHARED_LIBS=TRUE                               \
-      -DARROW_BUILD_BENCHMARKS=OFF                           \
-      -DARROW_BUILD_TESTS=OFF                                \
-      -DARROW_USE_GLOG=OFF                                   \
-      -DARROW_JEMALLOC=OFF                                   \
-      -DARROW_HDFS=OFF                                       \
-      -DARROW_IPC=ON                                         \
-      ${THRIFT_ROOT:+-DARROW_PARQUET=ON}                     \
-      ${THRIFT_ROOT:+-DTHRIFT_HOME=${THRIFT_ROOT}}           \
-      ${FLATBUFFERS_ROOT:+-DFlatbuffers_ROOT=${FLATBUFFERS_ROOT}} \
-      -DCMAKE_INSTALL_LIBDIR="lib"                           \
-      -DARROW_WITH_LZ4=ON                                    \
-      ${RAPIDJSON_ROOT:+-DRAPIDJSON_HOME=${RAPIDJSON_ROOT}}  \
-      ${LZ4_ROOT:+-DLZ4_ROOT=${LZ4_ROOT}}                    \
-      ${LZ4_ROOT:+-DLZ4_INCLUDE_DIR=${LZ4_ROOT}/include}     \
-      ${LZ4_ROOT:+-DLZ4_STATIC_LIB=${LZ4_ROOT}/lib/liblz4.a} \
-      -DARROW_WITH_SNAPPY=OFF                                \
-      -DARROW_WITH_ZSTD=OFF                                  \
-      -DARROW_WITH_BROTLI=OFF                                \
-      -DARROW_WITH_ZLIB=ON                                   \
-      -DARROW_NO_DEPRECATED_API=ON                           \
-      ${BOOST_ROOT:+-DBOOST_ROOT=${BOOST_ROOT}}              \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                    \
-      -DARROW_PYTHON=OFF
+cmake $SOURCEDIR/cpp                                                                                \
+      -DARROW_DEPENDENCY_SOURCE=SYSTEM                                                              \
+      -DCMAKE_BUILD_TYPE=Release                                                                    \
+      -DBUILD_SHARED_LIBS=TRUE                                                                      \
+      -DARROW_BUILD_BENCHMARKS=OFF                                                                  \
+      -DARROW_BUILD_TESTS=OFF                                                                       \
+      -DARROW_USE_GLOG=OFF                                                                          \
+      -DARROW_JEMALLOC=OFF                                                                          \
+      -DARROW_HDFS=OFF                                                                              \
+      -DARROW_IPC=ON                                                                                \
+      ${THRIFT_ROOT:+-DARROW_PARQUET=ON}                                                            \
+      ${THRIFT_ROOT:+-DThrift_ROOT=${THRIFT_ROOT}}                                                  \
+      ${FLATBUFFERS_ROOT:+-DFlatbuffers_ROOT=${FLATBUFFERS_ROOT}}                                   \
+      -DCMAKE_INSTALL_LIBDIR="lib"                                                                  \
+      -DARROW_WITH_LZ4=ON                                                                           \
+      ${RAPIDJSON_ROOT:+-DRapidJSON_ROOT=${RAPIDJSON_ROOT}}                                         \
+      ${PROTOBUF_ROOT:+-DProtobuf_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.$SONAME}                   \
+      ${PROTOBUF_ROOT:+-DProtobuf_LITE_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf-lite.$SONAME}         \
+      ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_LIBRARY=$PROTOBUF_ROOT/lib/libprotoc.$SONAME}              \
+      ${PROTOBUF_ROOT:+-DProtobuf_INCLUDE_DIR=$PROTOBUF_ROOT/include}                               \
+      ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc}                      \
+      ${BOOST_ROOT:+-DBoost_DIR=$BOOST_ROOT}                                                        \
+      ${BOOST_ROOT:+-DBoost_INCLUDE_DIR=$BOOST_ROOT/include}                                        \
+      ${LZ4_ROOT:+-DLZ4_ROOT=${LZ4_ROOT}}                                                           \
+      -DARROW_WITH_SNAPPY=OFF                                                                       \
+      -DARROW_WITH_ZSTD=OFF                                                                         \
+      -DARROW_WITH_BROTLI=OFF                                                                       \
+      -DARROW_WITH_ZLIB=ON                                                                          \
+      -DARROW_NO_DEPRECATED_API=ON                                                                  \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                                           \
+      -DARROW_PYTHON=OFF                                                                            \
+      -DARROW_TENSORFLOW=ON                                                                         \
+      -DARROW_GANDIVA=ON                                                                            \
+      -DCLANG_EXECUTABLE=${LLVM_ROOT}/bin-safe/clang++
 
 make ${JOBS:+-j $JOBS}
 make install
@@ -82,5 +100,4 @@ module load BASE/1.0 ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}
 # Our environment
 setenv ARROW_HOME \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(ARROW_HOME)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ARROW_HOME)/lib")
 EoF

--- a/llvm.sh
+++ b/llvm.sh
@@ -39,7 +39,7 @@ make install
 # Needed to be able to find C++ headers.
 case $ARCHITECTURE in
   osx*)
-    find `xcode-select -p` -type d -path "*usr/include/c++" -exec ln -sf {} $INSTALLROOT/include/c++
+    find `xcode-select -p` -type d -path "*usr/include/c++" -exec ln -sf {} $INSTALLROOT/include/c++ \;
   ;;
 esac
 

--- a/llvm.sh
+++ b/llvm.sh
@@ -22,8 +22,6 @@ case $ARCHITECTURE in
   *) DEFAULT_SYSROOT=/
 esac
 
-# note that BUILD_SHARED_LIBS=ON IS NEEDED FOR ADDING DYNAMIC PLUGINS
-#to clang - tidy(for instance)
 cmake ${SOURCEDIR}/llvm                                             \
   -DCMAKE_BUILD_TYPE=Release                                        \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                        \

--- a/llvm.sh
+++ b/llvm.sh
@@ -1,0 +1,73 @@
+package: LLVM
+version: "v7.1.0"
+tag: "llvmorg-7.1.0"
+source: https://github.com/llvm/llvm-project
+requires:
+ - "GCC-Toolchain:(?!osx)"
+build_requires:
+ - CMake
+---
+#!/bin/sh
+
+# Unsetting default compiler flags in order to make sure that no debug
+# information is compiled into the objects which make the build artifacts very
+# big
+unset CXXFLAGS
+unset CFLAGS
+unset LDFLAGS
+
+case $ARCHITECTURE in 
+  # Needed to have the C headers
+  osx*) DEFAULT_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk ;;
+  *) DEFAULT_SYSROOT=/
+esac
+
+# note that BUILD_SHARED_LIBS=ON IS NEEDED FOR ADDING DYNAMIC PLUGINS
+#to clang - tidy(for instance)
+cmake ${SOURCEDIR}/llvm                                             \
+  -DCMAKE_BUILD_TYPE=Release                                        \
+  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                        \
+  -DLLVM_INSTALL_UTILS=OFF                                          \
+  -DBUILD_SHARED_LIBS=OFF                                           \
+  -DDEFAULT_SYSROOT=OFF                                             \
+  -DLLVM_ENABLE_PROJECTS="clang"                                    \
+  -DLLVM_TARGETS_TO_BUILD="X86"                                     \
+  ${GCC_TOOLCHAIN_ROOT:+-DGCC_INSTALL_PREFIX=${GCC_TOOLCHAIN_ROOT}} \
+  -DDEFAULT_SYSROOT=${DEFAULT_SYSROOT}                              \
+  -DPYTHON_EXECUTABLE=$(which python)
+
+make ${JOBS+-j $JOBS}
+make install
+# Needed to be able to find C++ headers.
+case $ARCHITECTURE in
+  osx*)
+    find `xcode-select -p` -type d -path "*usr/include/c++" -exec ln -sf {} $INSTALLROOT/include/c++
+  ;;
+esac
+
+# We do not want to have the clang executables in path
+# to avoid issues with system clang on macOS.
+mkdir $INSTALLROOT/bin-safe
+mv $INSTALLROOT/bin/clang* $INSTALLROOT/bin-safe/
+sed -i.bak -e "s|bin/clang|bin-safe/clang|g" $INSTALLROOT/lib/cmake/clang/ClangTargets-release.cmake
+rm $INSTALLROOT/lib/cmake/clang/*.bak
+
+# Modulefile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0                                                          \\
+            ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} 
+# Our environment
+set CLANG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$CLANG_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$CLANG_ROOT/lib
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/re2.sh
+++ b/re2.sh
@@ -1,0 +1,29 @@
+package: re2
+version: "2019-09-01"
+source: https://github.com/google/re2
+build_requires:
+ - "GCC-Toolchain:(?!osx)"
+ - CMake
+---
+#!/bin/sh
+cmake $SOURCEDIR                           \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+EoF

--- a/root.sh
+++ b/root.sh
@@ -118,7 +118,8 @@ cmake $SOURCEDIR                                                                
       -Dbuiltin_pcre=ON                                                                \
       -Dsqlite=OFF                                                                     \
       $ROOT_PYTHON_FLAGS                                                               \
-      ${ARROW_VERSION:+-Darrow=ON}                                                     \
+      ${ARROW_ROOT:+-Darrow=ON}                                                        \
+      ${ARROW_ROOT:+-DARROW_HOME=$ARROW_ROOT}                                          \
       ${ENABLE_COCOA:+-Dcocoa=ON}                                                      \
       -DCMAKE_CXX_COMPILER=$COMPILER_CXX                                               \
       -DCMAKE_C_COMPILER=$COMPILER_CC                                                  \
@@ -230,6 +231,5 @@ setenv ROOTSYS \$::env(ROOT_BASEDIR)/\$::env(ROOT_RELEASE)
 prepend-path PYTHONPATH \$::env(ROOTSYS)/lib
 prepend-path PATH \$::env(ROOTSYS)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ROOTSYS)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ROOTSYS)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/thrift.sh
+++ b/thrift.sh
@@ -36,7 +36,7 @@ rsync -a --delete --exclude="**/.git" $SOURCEDIR/ ./
             --disable-plugin            \
             --disable-tutorial          \
             ${OPENSSL_ROOT:+--with-openssl=${OPENSSL_ROOT}}
-make CPPFLAGS="-I${BOOST_ROOT}/include ${CPPFLAGS}" CXXFLAGS="-Wno-macro-redefined -Wno-register ${CXXFLAGS}" ${JOBS:+-j $JOBS}
+make CPPFLAGS="-I${BOOST_ROOT}/include ${CPPFLAGS}" CXXFLAGS="-Wno-error -fPIC -O2" ${JOBS:+-j $JOBS}
 make install
 
 # Modulefile
@@ -56,5 +56,4 @@ module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-
 # Our environment
 prepend-path PATH \$::env(BASEDIR)/$PKGNAME/\$version/bin
 prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
 EoF


### PR DESCRIPTION
* Add new tool LLVM which provides llvm and clang 7.1.0. This
  is a required dependency for Gandiva. In principle, since
  now LLVM provides its own full fledged repository, including
  clang, we should probably drop using our own mirror elsewhere.
* Include re2 compile time dependency, needed by Gandiva.
* Make sure thrift can compile correctly with modern compilers.
* Enable Gandiva and Parquet in Arrow.
* Improve detection of Arrow in ROOT.