### PR TITLE
Bump the ROOT Grid plugins versions

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -1,6 +1,6 @@
 package: AliEn-ROOT-Legacy
 version: "%(tag_basename)s"
-tag: "0.1.1"
+tag: "0.1.2"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
   - CMake

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -1,6 +1,6 @@
 package: AliEn-ROOT-Legacy
 version: "%(tag_basename)s"
-tag: "0.1.2"
+tag: "0.1.3"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
   - CMake
@@ -80,6 +80,5 @@ prepend-path PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/lib
 append-path ROOT_PLUGIN_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/etc/plugins
 prepend-path ROOT_INCLUDE_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/include
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ALIEN_ROOT_LEGACY_ROOT)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -50,6 +50,5 @@ prepend-path PATH \$::env(JALIEN_ROOT_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(JALIEN_ROOT_ROOT)/lib
 append-path ROOT_PLUGIN_PATH \$::env(JALIEN_ROOT_ROOT)/etc/plugins
 prepend-path ROOT_INCLUDE_PATH \$::env(JALIEN_ROOT_ROOT)/include
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(JALIEN_ROOT_ROOT)/lib")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.5.1"
+tag: "0.5.2"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Update the ROOT Grid plugins, support for MacOS Catalina and ROOT 6.18.