### PR TITLE
arrow: do not expose LLVM outside gandiva

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -33,6 +33,12 @@ case $ARCHITECTURE in
     [[ ! -d $PROTOBUF_ROOT ]] && unset PROTOBUF_ROOT
     MACOSX_RPATH=OFF
     SONAME=dylib
+    cat >no-llvm-symbols.txt << EOF
+_LLVM*
+__ZN4llvm*
+__ZNK4llvm*
+EOF
+    CMAKE_SHARED_LINKER_FLAGS="-Wl,-unexported_symbols_list,$PWD/no-llvm-symbols.txt"
   ;;
   *) SONAME=so ;;
 esac
@@ -46,6 +52,7 @@ esac
 # Taken from our stack, linked dynamically (needed at runtime):
 #   boost
 cmake $SOURCEDIR/cpp                                                                                \
+      ${CMAKE_SHARED_LINKER_FLAGS:+-DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}}        \
       -DARROW_DEPENDENCY_SOURCE=SYSTEM                                                              \
       -DCMAKE_BUILD_TYPE=Release                                                                    \
       -DBUILD_SHARED_LIBS=TRUE                                                                      \
@@ -96,7 +103,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}
+module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
 # Our environment
 setenv ARROW_HOME \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(ARROW_HOME)/lib


### PR DESCRIPTION
This is to prevent it conflicting with the LLVM coming from ROOT.