### PR TITLE
llvm: find C SYSROOT on macOS in a more robust (?) way

### DIFF
--- a/llvm.sh
+++ b/llvm.sh
@@ -18,7 +18,10 @@ unset LDFLAGS
 
 case $ARCHITECTURE in 
   # Needed to have the C headers
-  osx*) DEFAULT_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk ;;
+  osx*) 
+    XCODE_PATH=`xcode-select -p`
+    DEFAULT_SYSROOT=$(find $XCODE_PATH -type d -path "*/MacOSX.sdk/usr/include")
+  ;;
   *) DEFAULT_SYSROOT="" ;;
 esac
 

--- a/llvm.sh
+++ b/llvm.sh
@@ -20,7 +20,7 @@ case $ARCHITECTURE in
   # Needed to have the C headers
   osx*) 
     XCODE_PATH=`xcode-select -p`
-    DEFAULT_SYSROOT=$(find $XCODE_PATH -type d -path "*/MacOSX.sdk/usr/include")
+    DEFAULT_SYSROOT=$(find $XCODE_PATH -type d -path "*/MacOSX.sdk/usr/include" | sed -e 's|/usr/include||g')
   ;;
   *) DEFAULT_SYSROOT="" ;;
 esac


### PR DESCRIPTION
The problem is that unless you do `xcode-select --install`, ` /Library/Developer/CommandLineTools/` is not there and one needs to look up headers in the `XCode.app` application folder. This should allow the recipe to work with all the install combinations of `Xcode installed` `DeveloperTools installed`.