### PR TITLE
Compile Geant4 with GDML support

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -4,6 +4,7 @@ tag: "v10.4.2"
 source: https://gitlab.cern.ch/geant4/geant4.git
 requires:
   - "GCC-Toolchain:(?!osx)"
+  - xercesc
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
@@ -49,6 +50,8 @@ cmake $SOURCEDIR                                             \
   -DGEANT4_USE_G3TOG4=ON                                     \
   -DGEANT4_INSTALL_DATA=ON                                   \
   -DGEANT4_USE_SYSTEM_EXPAT=OFF                              \
+  ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}          \
+  -DGEANT4_USE_GDML=ON                                       \
   ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                    \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
@@ -82,7 +85,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0 ${XERCESC_VERSION:+xercesc/$XERCESC_VERSION-$XERCESC_REVISION}
 # Our environment
 set osname [uname sysname]
 setenv GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
@@ -96,9 +99,9 @@ setenv G4NEUTRONHPDATA $G4NEUTRONHPDATA
 setenv G4NEUTRONXSDATA $G4NEUTRONXSDATA
 setenv G4SAIDXSDATA $G4SAIDXSDATA
 setenv G4ENSDFSTATEDATA $G4ENSDFSTATEDATA
-prepend-path PATH \$::env(GEANT4_ROOT)/bin
-prepend-path ROOT_INCLUDE_PATH \$::env(GEANT4_ROOT)/include/Geant4
-prepend-path ROOT_INCLUDE_PATH \$::env(GEANT4_ROOT)/include
-prepend-path LD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib")
+set G4BASE \$::env(GEANT4_ROOT)
+prepend-path PATH \$G4BASE/bin
+prepend-path ROOT_INCLUDE_PATH \$G4BASE/include/Geant4
+prepend-path ROOT_INCLUDE_PATH \$G4BASE/include
+prepend-path LD_LIBRARY_PATH \$G4BASE/lib
 EoF

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -1,0 +1,43 @@
+package: xercesc
+version: Xerces-C_3_2_2
+tag: Xerces-C_3_2_2
+source: https://github.com/apache/xerces-c
+build_requires:
+  - CMake
+prefer_system: ".*"
+prefer_system_check: |
+  pkg-config --atleast-version=3.2.0 xerces-c 2>&1 && printf "#include \"<xercesc/util/PlatformUtils.hpp>\"\nint main(){}" | c++ -xc - -o /dev/null
+prepend_path:
+  ROOT_INCLUDE_PATH: "$XERCESC_ROOT/include"
+  LD_LIBRARY_PATH: "$XERCESC_ROOT/lib"
+---
+
+cmake $SOURCEDIR                                         \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                \
+      -DBUILD_SHARED_LIBS=ON                             \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}             \
+      -DCMAKE_CXX_STANDARD=${CXXSTD}                     \
+      -Dnetwork:BOOL=OFF                                 \
+      -DCMAKE_INSTALL_LIBDIR=lib
+
+make ${JOBS:+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+set XERCESC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$XERCESC_ROOT/lib
+EoF


### PR DESCRIPTION
This enables Geant4 to import/export the standard
GDML file format for detector description.
Needed for geometry related developments and improvements
and in the interest of building a generic Geant4 distribution.