### PR TITLE
Added ENABLE_VMC: "ON" in defaults-o2:

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -6,6 +6,7 @@ env:
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "17"
   GEANT4_BUILD_MULTITHREADED: "ON"
+  ENABLE_VMC: "ON"
 disable:
   - AliEn-Runtime
   - JAliEn-ROOT


### PR DESCRIPTION
The VMC library in ROOT v6-18-04 actually used with O2 is optional and needs to be activated with the extra option