### PR TITLE
Add Online Device Control package

### DIFF
--- a/defaults-odc.sh
+++ b/defaults-odc.sh
@@ -1,0 +1,22 @@
+package: defaults-odc
+version: v1
+env:
+  CXXFLAGS: "-fPIC -O2 -std=c++17"
+  CFLAGS: "-fPIC -O2"
+  CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+  CXXSTD: "17"
+  CMAKE_GENERATOR: "Ninja"
+  GEANT4_BUILD_MULTITHREADED: "ON"
+disable:
+  - AliEn-Runtime
+  - AliRoot
+overrides:
+  FairMQ:
+    tag: bump-dds
+    source: https://github.com/rbx/FairMQ/
+  DDS:
+    tag: master
+    source: https://github.com/FairRootGroup/DDS
+  grpc:
+    version: v1.23.0
+---

--- a/defaults-odc.sh
+++ b/defaults-odc.sh
@@ -12,11 +12,13 @@ disable:
   - AliRoot
 overrides:
   FairMQ:
-    tag: bump-dds
-    source: https://github.com/rbx/FairMQ/
+    tag: dev
+    source: https://github.com/FairRootGroup/FairMQ/
   DDS:
     tag: master
     source: https://github.com/FairRootGroup/DDS
   grpc:
-    version: v1.23.0
+    tag: v1.24.3-p1
+    source: https://github.com/FairRootGroup/grpc
+
 ---

--- a/defaults-odc.sh
+++ b/defaults-odc.sh
@@ -11,14 +11,7 @@ disable:
   - AliEn-Runtime
   - AliRoot
 overrides:
-  FairMQ:
-    tag: dev
-    source: https://github.com/FairRootGroup/FairMQ/
-  DDS:
-    tag: master
-    source: https://github.com/FairRootGroup/DDS
   grpc:
     tag: v1.24.3-p1
     source: https://github.com/FairRootGroup/grpc
-
 ---

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -52,6 +52,7 @@ cmake $SOURCEDIR                                                 \
       -DDISABLE_COLOR=ON                                         \
       ${DDS_ROOT:+-DBUILD_DDS_PLUGIN=ON}                         \
       ${DDS_ROOT:+-DBUILD_SDK_COMMANDS=ON}                       \
+      ${DDS_ROOT:+-DBUILD_SDK=ON}                                \
       -DBUILD_NANOMSG_TRANSPORT=OFF                              \
       ${BUILD_OFI:+-DBUILD_OFI_TRANSPORT=ON}                     \
       -DBUILD_EXAMPLES=ON                                        \

--- a/grpc.sh
+++ b/grpc.sh
@@ -58,12 +58,11 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0                                                          \\
-            ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
-            ${C_ARES_VERSION:+c-ares/$C_ARES_VERSION-$C_ARES_REVISION}        \\
-            ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
+            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
+            ${C_ARES_REVISION:+c-ares/$C_ARES_VERSION-$C_ARES_REVISION}        \\
+            ${PROTOBUF_REVISION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
 # Our environment
 set GRPC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$GRPC_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$GRPC_ROOT/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$GRPC_ROOT/lib")
 EoF

--- a/grpc.sh
+++ b/grpc.sh
@@ -21,7 +21,7 @@ git submodule update --init
 popd
 
 case $ARCHITECTURE in
-  osx*) 
+  osx*)
     [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl)
     [[ ! $PROTOBUF_ROOT ]] && PROTOBUF_ROOT=$(brew --prefix protobuf)
   ;;
@@ -37,10 +37,18 @@ cmake $SOURCEDIR                                    \
   -DgRPC_GFLAGS_PROVIDER=packet                     \
   -DgRPC_PROTOBUF_PROVIDER=package                  \
   -DgRPC_BENCHMARK_PROVIDER=packet                  \
+  -DgRPC_BUILD_GRPC_CPP_PLUGIN=ON                   \
   ${OPENSSL_ROOT_DIR:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR} \
   -DgRPC_CARES_PROVIDER=package
 
 make ${JOBS:+-j$JOBS} install
+
+if [[ $ARCHITECTURE == osx* ]]; then
+
+  install_name_tool -change libgrpc_plugin_support.dylib @rpath/libgrpc_plugin_support.dylib $INSTALLROOT/bin/grpc_cpp_plugin
+
+fi
+
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/grpc.sh
+++ b/grpc.sh
@@ -43,11 +43,6 @@ cmake $SOURCEDIR                                    \
 
 make ${JOBS:+-j$JOBS} install
 
-if [[ $ARCHITECTURE == osx* ]]; then
-
-  install_name_tool -change libgrpc_plugin_support.dylib @rpath/libgrpc_plugin_support.dylib $INSTALLROOT/bin/grpc_cpp_plugin
-
-fi
 
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/odc.sh
+++ b/odc.sh
@@ -1,0 +1,69 @@
+#Online Device Control
+package: ODC
+version: "%(tag_basename)s"
+tag: master
+source: https://github.com/FairRootGroup/ODC.git
+requires:
+- boost
+- protobuf
+- DDS
+- FairLogger
+- FairMQ
+- grpc
+build_requires:
+  - CMake
+  - GCC-Toolchain:(?!osx.*)
+---
+
+case $ARCHITECTURE in
+  osx*)
+    # If we preferred system tools, we need to make sure we can pick them up.
+    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
+    [[ ! $PROTOBUF_ROOT ]] && PROTOBUF_ROOT=`brew --prefix protobuf`
+    [[ ! $GSL_ROOT ]] && GSL_ROOT=`brew --prefix gsl`
+    [[ ! $GRPC_ROOT ]] && GRPC_ROOT=`brew --prefix grpc`
+
+    SONAME=dylib
+  ;;
+  *) SONAME=so ;;
+esac
+
+
+
+cmake  $SOURCEDIR                                                                            \
+       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                                   \
+       ${DDS_ROOT:+-DDDS_PATH=$DDS_ROOT}                                                     \
+       ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                                               \
+       -DBoost_NO_SYSTEM_PATHS=${BOOST_NO_SYSTEM_PATHS}                                      \
+       -DProtobuf_ROOT=${PROTOBUF_ROOT}                                                      \
+       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                               \
+       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
+       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                                   \
+       -DgRPC_ROOT=$GRPC_ROOT
+
+
+make ${JOBS+-j $JOBS}
+make install
+
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0                                                                            \\
+            ${FAIRLOGGER_VERSION:+FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION}          \\
+            ${FAIRMQ_VERSION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION}                          \\
+            ${PROTOBUF_VERSION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}                  \\
+            ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION}                              \\
+            ${DDS_ROOT:+DDS/$DDS_VERSION-$DDS_REVISION}                                         \\
+            ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}


### PR DESCRIPTION
Add recipe and default for building the new Online Device Control  (ODC)
works on linux but not on MAC OS (Problems with the GRPC CPP plugin) 