### PR TITLE
Don't reset XRootD location in ROOT recipe

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -187,7 +187,7 @@ mv system.rootrc.0 $INSTALLROOT/etc/system.rootrc
 
 if [[ $ALIEN_RUNTIME_VERSION ]]; then
   # Get them from AliEn-Runtime in the Modulefile
-  unset OPENSSL_VERSION XROOTD_VERSION LIBXML2_VERSION
+  unset OPENSSL_VERSION LIBXML2_VERSION
 fi
 
 # Make some CMake files used by other projects relocatable


### PR DESCRIPTION
Leftovers from migrating XRootD into a standalone package.