### PR TITLE
XRootD sysroot discovery on the Mac

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -8,8 +8,8 @@ env:
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 overrides:
   XRootD:
-    tag: "v4.11.1-rc1-alice"
-    source: https://github.com/atlantic777/xrootd
+    tag: "v4.11.1"
+    source: https://github.com/xrootd/xrootd
   JDK:
     version: "12.0.1_JALIEN"
   libxml2:

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -44,8 +44,8 @@ overrides:
     version: "v3.1.1"
     tag: cpp-3.1.1
   XRootD:
-    tag: "v4.11.1-rc1-alice"
-    source: https://github.com/atlantic777/xrootd
+    tag: "v4.11.1"
+    source: https://github.com/xrootd/xrootd
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -29,8 +29,8 @@ overrides:
   fastjet:
     tag: "v3.3.2_1.041-alice1"
   XRootD:
-    tag: "v4.11.1-rc1-alice"
-    source: https://github.com/atlantic777/xrootd
+    tag: "v4.11.1"
+    source: https://github.com/xrootd/xrootd
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -21,8 +21,6 @@ SONAME="so"
 case $ARCHITECTURE in
   osx*)
     [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
-    MACOS_SYSROOT="$(find `xcode-select -p` -type d -path *usr/include/c++)"
-    PYTHON_EXECUTABLE="CFLAGS=\"${MACOS_SYSROOT}\" ${PYTHON_EXECUTABLE}"
     SONAME="dylib"
     unset UUID_ROOT
   ;;

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -48,9 +48,12 @@ cmake "$SOURCEDIR"                                                    \
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
-pushd $INSTALLROOT
-XRD_PYTHON_PATH="$(find . -path '*site-packages' -type d)"
+if [[ x"$XROOTD_PYTHON" == x"True" ]];
+then
+  pushd $INSTALLROOT
+  XRD_PYTHON_PATH="$(find . -path '*site-packages' -type d)"
 popd
+fi
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
Another take on enabling XRootD Python bindings on the PR checker MacOS machines.