### PR TITLE
Bump xjalienfs version

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: 0.0.2-rc0
+tag: 1.0.0
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
This version bump affects only JAliEn builds. The xjalienfs 1.0.0 is a big update, more features, bugfixes and command line utilities.