### PR TITLE
Use libtirpc for compiling ApMon-CPP

### DIFF
--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -38,8 +38,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 \\
        ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
-setenv APMON_CPP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$::env(APMON_CPP_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(APMON_CPP_ROOT)/lib")
+set APMON_CPP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$APMON_CPP_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -2,7 +2,6 @@ package: ApMon-CPP
 version: "%(tag_basename)s"
 tag: v2.2.8-alice2
 source: https://github.com/alisw/apmon-cpp.git
-requires:
 build_requires:
  - libtirpc
  - autotools

--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -2,7 +2,9 @@ package: ApMon-CPP
 version: "%(tag_basename)s"
 tag: v2.2.8-alice2
 source: https://github.com/alisw/apmon-cpp.git
+requires:
 build_requires:
+ - libtirpc
  - autotools
  - "GCC-Toolchain:(?!osx)"
 ---
@@ -10,6 +12,14 @@ build_requires:
 rsync -a --exclude='**/.git' --delete --delete-excluded \
       $SOURCEDIR/ ./
 autoreconf -ivf
+
+# TODO: check if rpc.h really didn't come with glibc
+if [[ -n ${LIBTIRPC_ROOT} ]];
+then
+  export CXXFLAGS="${CXXFLAGS} -I${LIBTIRPC_ROOT}/include/tirpc"
+  export LDFLAGS="${LDFLAGS} -ltirpc -L${LIBTIRPC_ROOT}/lib"
+fi
+
 ./configure --prefix=$INSTALLROOT
 make ${JOBS:+-j$JOBS}
 make install

--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: v2.2.8-alice2
 source: https://github.com/alisw/apmon-cpp.git
 build_requires:
- - libtirpc
+ - libtirpc:(!?osx)
  - autotools
  - "GCC-Toolchain:(?!osx)"
 ---
@@ -12,7 +12,6 @@ rsync -a --exclude='**/.git' --delete --delete-excluded \
       $SOURCEDIR/ ./
 autoreconf -ivf
 
-# TODO: check if rpc.h really didn't come with glibc
 if [[ -n ${LIBTIRPC_ROOT} ]];
 then
   export CXXFLAGS="${CXXFLAGS} -I${LIBTIRPC_ROOT}/include/tirpc"

--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: v2.2.8-alice2
 source: https://github.com/alisw/apmon-cpp.git
 build_requires:
- - libtirpc:(!?osx)
+ - "libtirpc:(?!osx)"
  - autotools
  - "GCC-Toolchain:(?!osx)"
 ---

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -31,8 +31,6 @@ overrides:
     version: "%(tag_basename)s"
     requires:
       - "GCC-Toolchain:(?!osx)"
-    build_requires:
-      - autotools
   AliPhysics:
     version: "%(tag_basename)s_JALIEN"
     tag: v5-09-51-01

--- a/libtirpc.sh
+++ b/libtirpc.sh
@@ -7,9 +7,11 @@ build_requires:
   - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
+# TODO: add a check to pick it up from system
+# if yes, test if rpc.h comes for glibc or libtirpc
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 ./bootstrap
-./configure --enable-shared=no --prefix=${INSTALLROOT}
+./configure --enable-shared=no --disable-gssapi --prefix=${INSTALLROOT}
 make ${JOBS+-j $JOBS} install
 rm -rf ${INSTALLROOT}/share "${INSTALLROOT}"/lib/*.la "${INSTALLROOT}"/lib/pkgconfig
 
@@ -26,8 +28,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
-setenv LIBTIRPC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$::env(LIBTIRPC_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LIBTIRPC_ROOT)/lib")
+set LIBTIRPC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$LIBTIRPC_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/libtirpc.sh
+++ b/libtirpc.sh
@@ -7,8 +7,6 @@ build_requires:
   - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
-# TODO: add a check to pick it up from system
-# if yes, test if rpc.h comes for glibc or libtirpc
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 ./bootstrap
 ./configure --enable-shared=no --disable-gssapi --prefix=${INSTALLROOT}


### PR DESCRIPTION
This should fix the problems with compiling ApMon-CPP on platforms with new glibc.