### PR TITLE
Bump libwebsockets version to v3.0.1

### DIFF
--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -12,6 +12,7 @@ build_requires:
 case $ARCHITECTURE in
   osx*) [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl) ;;
 esac
+
 cmake $SOURCEDIR/                                                   \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                         \
       -DCMAKE_BUILD_TYPE=RELEASE                                    \

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -42,7 +42,6 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${OPENSSL_VERSION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}
 # Our environment
 set LIBWEBSOCKETS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$LIBWEBSOCKETS_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$LIBWEBSOCKETS_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -40,9 +40,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${OPENSSL_VERSION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}
 # Our environment
-setenv LIBWEBSOCKETS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(LIBWEBSOCKETS_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(LIBWEBSOCKETS_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LIBWEBSOCKETS_ROOT)/lib")
+set LIBWEBSOCKETS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$LIBWEBSOCKETS_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$LIBWEBSOCKETS_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -1,6 +1,6 @@
 package: libwebsockets
 version: "%(tag_basename)s"
-tag: "v2.4.2"
+tag: "v3.0.1"
 source: https://github.com/warmcat/libwebsockets
 build_requires:
   - CMake


### PR DESCRIPTION
Users confirmed that upgrading to libwebsockets v3.0.1fixes issues with linking to OpenSSL on some MacOS machines. Affects only JAliEn builds.