### PR TITLE
Bump xjalienfs to 1.0.1

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: 1.0.0
+tag: 1.0.1
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
More bugfixes before the break... Affects JAliEn builds only.