### PR TITLE
Embed own XercesC in the Geant4 installation [O2-1004]

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -4,8 +4,8 @@ tag: "v10.4.2"
 source: https://gitlab.cern.ch/geant4/geant4.git
 requires:
   - "GCC-Toolchain:(?!osx)"
-  - xercesc
 build_requires:
+  - xercesc
   - CMake
   - "Xcode:(osx.*)"
 prepend_path:
@@ -33,6 +33,12 @@ env:
 # if this variable is not defined default it to OFF
 : ${GEANT4_BUILD_MULTITHREADED:=OFF}
 
+# We embed Xerces-C directly into GEANT4 to avoid relocation issues and
+# incompatibility with other possible instances of XercesC
+if [ ! "X$XERCESC_ROOT" = X ]; then
+  rsync -av $XERCESC_ROOT/ $INSTALLROOT/
+fi
+
 cmake $SOURCEDIR                                             \
   -DGEANT4_INSTALL_DATA_TIMEOUT=2000                         \
   -DCMAKE_CXX_FLAGS="-fPIC"                                  \
@@ -50,7 +56,7 @@ cmake $SOURCEDIR                                             \
   -DGEANT4_USE_G3TOG4=ON                                     \
   -DGEANT4_INSTALL_DATA=ON                                   \
   -DGEANT4_USE_SYSTEM_EXPAT=OFF                              \
-  ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}          \
+  ${XERCESC_REVISION:+-DXERCESC_ROOT_DIR=$INSTALLROOT}       \
   -DGEANT4_USE_GDML=ON                                       \
   ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                    \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -85,11 +91,11 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${XERCESC_VERSION:+xercesc/$XERCESC_VERSION-$XERCESC_REVISION}
+module load BASE/1.0
 # Our environment
 set osname [uname sysname]
-setenv GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv G4INSTALL \$::env(GEANT4_ROOT)
+set GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv G4INSTALL \$GEANT4_ROOT
 setenv G4INSTALL_DATA \$::env(G4INSTALL)/share/
 setenv G4SYSTEM \$osname-g++
 setenv G4LEVELGAMMADATA $G4LEVELGAMMADATA
@@ -99,9 +105,9 @@ setenv G4NEUTRONHPDATA $G4NEUTRONHPDATA
 setenv G4NEUTRONXSDATA $G4NEUTRONXSDATA
 setenv G4SAIDXSDATA $G4SAIDXSDATA
 setenv G4ENSDFSTATEDATA $G4ENSDFSTATEDATA
-set G4BASE \$::env(GEANT4_ROOT)
-prepend-path PATH \$G4BASE/bin
-prepend-path ROOT_INCLUDE_PATH \$G4BASE/include/Geant4
-prepend-path ROOT_INCLUDE_PATH \$G4BASE/include
-prepend-path LD_LIBRARY_PATH \$G4BASE/lib
+
+prepend-path PATH \$GEANT4_ROOT/bin
+prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include/Geant4
+prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include
+prepend-path LD_LIBRARY_PATH \$GEANT4_ROOT/lib
 EoF


### PR DESCRIPTION
This is needed because Geant4 will otherwise put an unrelocatable full path in some of the cmake macros / helpers, breaking builds which do not happen in the exact same location as the initial cached binary.