### PR TITLE
Drop DDS from O2 on macOS

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -6,7 +6,7 @@ requires:
  - boost
  - FairLogger
  - ZeroMQ
- - DDS
+ - "DDS:(?!osx)"
  - asiofi
  - flatbuffers
 build_requires:

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -8,7 +8,6 @@ requires:
   - ROOT
   - boost
   - protobuf
-  - DDS
   - FairLogger
   - FairMQ
   - yaml-cpp

--- a/o2.sh
+++ b/o2.sh
@@ -4,7 +4,6 @@ tag: "O2-1.0.0"
 requires:
   - arrow
   - FairRoot
-  - DDS
   - Vc
   - hijing
   - HepMC3


### PR DESCRIPTION
It will always come through FairMQ, which we will always depend on.