### PR TITLE
Workaround LLVM DEFAULT_SYSROOT issue on ubuntu

### DIFF
--- a/llvm.sh
+++ b/llvm.sh
@@ -25,6 +25,8 @@ case $ARCHITECTURE in
       DEFAULT_SYSROOT=`xcrun --show-sdk-path`
     fi
   ;;
+  # This will most likely fail if we start producing binary packages for Ubuntu, but for the moment we do not.
+  ubuntu*) DEFAULT_SYSROOT="" ;;
   *) DEFAULT_SYSROOT="/usr" ;;
 esac
 


### PR DESCRIPTION
This will most likely fail if we start producing binary packages for Ubuntu, but for the moment we do not.