### PR TITLE
Update JAliEn components

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.5.2"
+tag: "0.5.3"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/jalien.sh
+++ b/jalien.sh
@@ -1,6 +1,6 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.1.1"
+tag: "1.1.2"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
  - JDK

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: 1.0.1
+tag: 1.0.2
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
This update upgrades both Java and JAliEn-ROOT components. It will affect AliRoot/ROOT6 builds.

- JAliEn 1.1.2
- xjalienfs 1.0.2
- JAliEn-ROOT 0.5.3