### PR TITLE
Print a warning if user's rootrc file could prevent loading the ROOT Grid plugins

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -55,6 +55,9 @@ proc ModulesHelp { } {
   global version
   puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 }
+
+system test -e ~/.rootrc && grep -iq PluginPath ~/.rootrc && echo "WARNING: Your local rootrc config might overwrite ROOT TGrid plugin path"
+
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -43,6 +43,9 @@ proc ModulesHelp { } {
   global version
   puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 }
+
+system test -e ~/.rootrc && grep -iq PluginPath ~/.rootrc && echo "WARNING: Your local rootrc config might overwrite ROOT TGrid plugin path"
+
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies


### PR DESCRIPTION
Alibuild creates system.rootrc file that is required for loading ROOT Grid plugins. If a user has a rootrc file in his home directory that rewrites ROOT PluginPath variable, then the Grid plugins might not be loaded properly. We already had such issues so I'm adding this warning message to detect such situation early.