### PR TITLE
Fix OpenSSL loading in ROOT recipe

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -193,7 +193,7 @@ mv system.rootrc.0 $INSTALLROOT/etc/system.rootrc
 
 if [[ $ALIEN_RUNTIME_VERSION ]]; then
   # Get them from AliEn-Runtime in the Modulefile
-  unset OPENSSL_VERSION LIBXML2_VERSION
+  unset OPENSSL_REVISION LIBXML2_REVISION
 fi
 
 # Make some CMake files used by other projects relocatable


### PR DESCRIPTION
Minor fix with loading the OpenSSL in the ROOT recipe. in ROOT recipe we get OpenSSL from AliEn-Runtime. To do thet, we unset OpenSSL version variable, but this should be OPENSSL_REVISION, instead of OPENSSL_VERSION.