### PR TITLE
Bump JAliEn components and AliEn CA

### DIFF
--- a/alien-cas.sh
+++ b/alien-cas.sh
@@ -1,6 +1,6 @@
 package: AliEn-CAs
 version: v1
-tag: bcb18b10f695dbfe85599b7bbb5452720a91dddd
+tag: 0c91befac1e17b1b9ccf97b94ca4ebd40f7125a0 
 source: https://github.com/alisw/alien-cas.git
 ---
 #!/bin/bash -e

--- a/alien-cas.sh
+++ b/alien-cas.sh
@@ -1,6 +1,6 @@
 package: AliEn-CAs
 version: v1
-tag: 0c91befac1e17b1b9ccf97b94ca4ebd40f7125a0 
+tag: 4a5bccfccd2c32cc32eb53ae44e213d19b536d2d
 source: https://github.com/alisw/alien-cas.git
 ---
 #!/bin/bash -e

--- a/jalien.sh
+++ b/jalien.sh
@@ -1,6 +1,6 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.1.2"
+tag: "1.1.3"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
  - JDK

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -21,7 +21,6 @@ cp -r $SOURCEDIR/bin ${INSTALLROOT}/bin
 cp ${ALIEN_PY} ${INSTALLROOT}/bin/alien.py
 chmod +x ${INSTALLROOT}/bin/*
 
-
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: 1.0.2
+tag: 1.0.3
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: 1.0.3
+tag: "1.0.3"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
- xjalienfs: the readline workaround, enable tab complete
- jalien: minor improvements in jalien shell
- AliEn CA: certificate update for OpenSSL 1.1 requirements (capabilities)