### PR TITLE
arrow: add Clang to dependencies

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -108,7 +108,8 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
+module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION} \\
+                     ${CLANG_REVISION:+Clang/$CLANG_VERSION-$CLANG_REVISION}
 # Our environment
 set ARROW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$ARROW_ROOT/lib


### PR DESCRIPTION
Fixes linking when building from devel directory:

```
/.../bin/ld: warning: libLLVMCore.so.9, needed by /home/.../arrow/v0.14.1-1/lib/libgandiva.so.14, not found (try using -rpath or -rpath-link)
/.../bin/ld: warning: libLLVMMCJIT.so.9, needed by /home/.../arrow/v0.14.1-1/lib/libgandiva.so.14, not found (try using -rpath or -rpath-link)
/.../bin/ld: warning: libLLVMipo.so.9, needed by /home/.../arrow/v0.14.1-1/lib/libgandiva.so.14, not found (try using -rpath or -rpath-link)
```