### PR TITLE
O2-1074 Workaround for CMake in Readout

### DIFF
--- a/readout.sh
+++ b/readout.sh
@@ -32,7 +32,12 @@ esac
 
 # Enforce no warning code in the PR checker
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  if [[ $ARCHITECTURE != osx ]] ; then
+    # there seems to be a bug in CMake with -Werror which adds unwanted 
+    # includes that lead to failing builds. skip it for now.
+    # https://alice.its.cern.ch/jira/browse/O2-1074
+    CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  fi
 fi
 
 cmake $SOURCEDIR                                                         \

--- a/readout.sh
+++ b/readout.sh
@@ -32,12 +32,13 @@ esac
 
 # Enforce no warning code in the PR checker
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  if [[ $ARCHITECTURE != osx ]] ; then
-    # there seems to be a bug in CMake with -Werror which adds unwanted 
-    # includes that lead to failing builds. skip it for now.
-    # https://alice.its.cern.ch/jira/browse/O2-1074
-    CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
-  fi
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
 fi
 
 cmake $SOURCEDIR                                                         \


### PR DESCRIPTION
It seems that newer versions of CMake (>3.15) cause problems when building Readout on macOS with `-Werror` enabled. Lets drop `-Werror` on the macOS CI for now until it is fixed in CMake.