### PR TITLE
O2-1074 Workaround for -Werror cmake bug on macOS

### DIFF
--- a/alf.sh
+++ b/alf.sh
@@ -18,7 +18,13 @@ incremental_recipe: |
 
 # Enforce no warning code in the PR checker
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
 fi
 
 cmake $SOURCEDIR                                                      \

--- a/alf.sh
+++ b/alf.sh
@@ -16,17 +16,6 @@ incremental_recipe: |
 ---
 #!/bin/bash -ex
 
-# Enforce no warning code in the PR checker
-if [[ $ALIBUILD_O2_TESTS ]]; then
-  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
-  # includes that lead to failing builds. skip it for now.
-  # https://alice.its.cern.ch/jira/browse/O2-1074
-  case $ARCHITECTURE in 
-    osx*) ;;
-    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
-  esac
-fi
-
 cmake $SOURCEDIR                                                      \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                             \
       ${COMMON_O2_REVISION:+-DCommon_ROOT=$COMMON_O2_ROOT}             \

--- a/infologger.sh
+++ b/infologger.sh
@@ -22,7 +22,13 @@ esac
 
 # Enforce no warning code in the PR checker
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
 fi
 
 cmake $SOURCEDIR                                              \

--- a/infologger.sh
+++ b/infologger.sh
@@ -20,20 +20,9 @@ case $ARCHITECTURE in
     osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost);;
 esac
 
-# Enforce no warning code in the PR checker
-if [[ $ALIBUILD_O2_TESTS ]]; then
-  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
-  # includes that lead to failing builds. skip it for now.
-  # https://alice.its.cern.ch/jira/browse/O2-1074
-  case $ARCHITECTURE in 
-    osx*) ;;
-    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
-  esac
-fi
-
 cmake $SOURCEDIR                                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                     \
-      ${BOOST_REVISION:+-DBOOST_ROOT=$BOOST_ROOT}              \
+      ${BOOST_REVISION:+-DBOOST_ROOT=$BOOST_ROOT}             \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -26,6 +26,7 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
     osx*) ;;
     *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
   esac
+fi
 
 cmake $SOURCEDIR                                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                     \

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -18,16 +18,6 @@ case $ARCHITECTURE in
     osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost);;
 esac
 
-if [[ $ALIBUILD_O2_TESTS ]]; then
-  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
-  # includes that lead to failing builds. skip it for now.
-  # https://alice.its.cern.ch/jira/browse/O2-1074
-  case $ARCHITECTURE in 
-    osx*) ;;
-    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
-  esac
-fi
-
 cmake $SOURCEDIR                                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                     \
       ${BOOST_REVISION:+-DBOOST_ROOT=$BOOST_ROOT}                 \

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -19,8 +19,13 @@ case $ARCHITECTURE in
 esac
 
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
-fi
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
 
 cmake $SOURCEDIR                                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                     \

--- a/o2.sh
+++ b/o2.sh
@@ -119,14 +119,6 @@ esac
 
 # This affects only PR checkers
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  # Impose extra errors.
-  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
-  # includes that lead to failing builds. skip it for now.
-  # https://alice.its.cern.ch/jira/browse/O2-1074
-  case $ARCHITECTURE in 
-    osx*) ;;
-    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
-  esac
   # On OSX CI, we do not want to run the GUI, even if available.
   case $ARCHITECTURE in
     osx*) DPL_TESTS_BATCH_MODE=ON ;;

--- a/o2.sh
+++ b/o2.sh
@@ -120,7 +120,13 @@ esac
 # This affects only PR checkers
 if [[ $ALIBUILD_O2_TESTS ]]; then
   # Impose extra errors.
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
   # On OSX CI, we do not want to run the GUI, even if available.
   case $ARCHITECTURE in
     osx*) DPL_TESTS_BATCH_MODE=ON ;;

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -37,7 +37,13 @@ esac
 # For the PR checkers (which sets ALIBUILD_O2_TESTS),
 # we impose -Werror as a compiler flag
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
 fi
 
 # Use ninja if in devel mode, ninja is found and DISABLE_NINJA is not 1

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -34,18 +34,6 @@ case $ARCHITECTURE in
   osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost);;
 esac
 
-# For the PR checkers (which sets ALIBUILD_O2_TESTS),
-# we impose -Werror as a compiler flag
-if [[ $ALIBUILD_O2_TESTS ]]; then
-  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
-  # includes that lead to failing builds. skip it for now.
-  # https://alice.its.cern.ch/jira/browse/O2-1074
-  case $ARCHITECTURE in 
-    osx*) ;;
-    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
-  esac
-fi
-
 # Use ninja if in devel mode, ninja is found and DISABLE_NINJA is not 1
 if [[ ! $CMAKE_GENERATOR && $DISABLE_NINJA != 1 && $DEVEL_SOURCES != $SOURCEDIR ]]; then
   NINJA_BIN=ninja-build

--- a/readoutcard.sh
+++ b/readoutcard.sh
@@ -24,17 +24,6 @@ case $ARCHITECTURE in
     osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost);;
 esac
 
-# Enforce no warning code in the PR checker
-if [[ $ALIBUILD_O2_TESTS ]]; then
-  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
-  # includes that lead to failing builds. skip it for now.
-  # https://alice.its.cern.ch/jira/browse/O2-1074
-  case $ARCHITECTURE in 
-    osx*) ;;
-    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
-  esac
-fi
-
 cmake $SOURCEDIR                                                      \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                             \
       ${BOOST_REVISION:+-DBOOST_ROOT=$BOOST_ROOT}                      \

--- a/readoutcard.sh
+++ b/readoutcard.sh
@@ -26,7 +26,13 @@ esac
 
 # Enforce no warning code in the PR checker
 if [[ $ALIBUILD_O2_TESTS ]]; then
-  CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations"
+  # there seems to be a bug in CMake in macOS with -Werror which adds unwanted 
+  # includes that lead to failing builds. skip it for now.
+  # https://alice.its.cern.ch/jira/browse/O2-1074
+  case $ARCHITECTURE in 
+    osx*) ;;
+    *) CXXFLAGS="${CXXFLAGS} -Werror -Wno-error=deprecated-declarations" ;;
+  esac
 fi
 
 cmake $SOURCEDIR                                                      \


### PR DESCRIPTION
Adding `-Werror` to cmake code under certain circumstances adds an additional 
```cmake
-isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include 
```
which causes compilation to fail with the compiler unable to find cmath functions such as `std::isnan()`
A bugreport exists and I have been able to reproduce this bug outside of our build environment. See [Kitware gitlab](https://gitlab.kitware.com/cmake/cmake/issues/19845#note_689595)

As long as this error persists we need to exclude `-Werror` on macOS. 