### PR TITLE
CMake 3.16 fix for CUDA compilation

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -1,7 +1,7 @@
 package: CMake
 version: "%(tag_basename)s"
-tag: "v3.16.3-alice1"
-source: https://github.com/alisw/CMake
+tag: "v3.16.3-alice2"
+source: https://github.com/davidrohr/CMake
 build_requires:
  - "GCC-Toolchain:(?!osx)"
  - make

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,7 +1,7 @@
 package: CMake
 version: "%(tag_basename)s"
 tag: "v3.16.3-alice2"
-source: https://github.com/davidrohr/CMake
+source: https://github.com/alisw/CMake
 build_requires:
  - "GCC-Toolchain:(?!osx)"
  - make


### PR DESCRIPTION
This fixes the problem in the O2 GPU CI like in AliceO2Group/AliceO2#2876

@ktf : Can you move the tag over to alisw/CMake (or grant me write access) and change the git URL here accordingly. Opening this PR as is in order for the CI to test it.