### PR TITLE
Fix typo in libwebsockets detection

### DIFF
--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -9,7 +9,7 @@ build_requires:
   - zlib
 prefer_system: "osx"
 prefer_system_check: |
-  printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"#endif\nint main(){}' | c++ -I$(brew --prefix libwebsockets)/include -xc++ -std=c++17 - -o /dev/null
+  printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\nint main(){}' | c++ -I$(brew --prefix libwebsockets)/include -xc++ -std=c++17 - -o /dev/null
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in


### PR DESCRIPTION
As it stands, the check will fail due to an unmatched conditional, even if libwebsockets is installed:

```
WARNING: Package libwebsockets cannot be picked up from the system and will be built by aliBuild.
WARNING: This is due to the fact the following script fails:
WARNING:
WARNING: printf "#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"#endif\nint main(){}" | c++ -I$(brew --prefix libwebsockets)/include -xc++ -std=c++17 - -o /dev/null
WARNING:
WARNING: with the following output:
WARNING:
WARNING: libwebsockets: <stdin>:1:2: error: unterminated conditional directive
WARNING: libwebsockets: #if !__has_include(<lws_config.h>)
WARNING: libwebsockets:  ^
WARNING: libwebsockets: 1 error generated.
WARNING: libwebsockets:
WARNING:
```

Adding the missing "\n" seems to fix the issue, as it then picked up libwebsockets on my system