### PR TITLE
Fix typo in jalien-root finding libwebsockets

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -19,7 +19,7 @@ append_path:
 case $ARCHITECTURE in
   osx*) 
 	[[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl)
-	[[ ! $LIBWEBSOCKETS_ROOT ]] && LIBWEBSOCKETS_ROOT=$(brew --prefix libwebsocket)
+	[[ ! $LIBWEBSOCKETS_ROOT ]] && LIBWEBSOCKETS_ROOT=$(brew --prefix libwebsockets)
   ;;
 esac
 


### PR DESCRIPTION
The brew package name is `libwebsockets` (was missing the "s").

Note that this seems to then show an additional issue which hasn't shown up until now because it hasn't be possible to take this from brew:

```
In file included from /Users/re239/alice/sw/BUILD/77319b21e45ce6835c0b8e705d5179abbe5f0b1d/JAliEn-ROOT/src/TJAlien.cxx:12:
In file included from /Users/re239/alice/sw/BUILD/77319b21e45ce6835c0b8e705d5179abbe5f0b1d/JAliEn-ROOT/inc/TJAlien.h:53:
In file included from /Users/re239/alice/sw/BUILD/77319b21e45ce6835c0b8e705d5179abbe5f0b1d/JAliEn-ROOT/inc/TJAlienConnectionManager.h:14:
/usr/local/opt/libwebsockets/include/libwebsockets.h:180:10: fatal error: 'uv.h' file not found
#include <uv.h>
         ^~~~~~
```

I think how I see how I could hack around this, but I'm wondering if there is an easier or better solution