### PR TITLE
JAliEn-ROOT improvements (O2-1118)

### DIFF
--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -9,7 +9,8 @@ build_requires:
   - zlib
 prefer_system: "osx"
 prefer_system_check: |
-	printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\nint main(){}' | c++ -I$(brew --prefix libwebsockets)/include -xc++ -std=c++17 - -o /dev/null || exit 1; echo -e "#include <lws_config.h>\n#if LWS_LIBRARY_VERSION_NUMBER < 2004000 || LWS_LIBRARY_VERSION_NUMBER >= 3001000\n#error "JAliEn-ROOT requires libwebsockets 3.0.x but other version was detected"\n#endif\nint main() {}" | c++ -x c++ -I$(brew --prefix libwebsockets)/include -std=c++17 - -o /dev/null || exit 1
+  printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\n' | c++ -I$(brew --prefix libwebsockets)/include -c -xc++ -std=c++17 - -o /dev/null
+  printf '#include <lws_config.h>\n#if LWS_LIBRARY_VERSION_NUMBER < 2004000 || LWS_LIBRARY_VERSION_NUMBER >= 3001000\n#error \"JAliEn-ROOT requires libwebsockets 3.0.x but other version was detected\"\n#endif\n' | c++ -c -x c++ -I$(brew --prefix libwebsockets)/include -std=c++17 - -o /dev/null || exit 1
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -9,7 +9,7 @@ build_requires:
   - zlib
 prefer_system: "osx"
 prefer_system_check: |
-  printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\nint main(){}' | c++ -I$(brew --prefix libwebsockets)/include -xc++ -std=c++17 - -o /dev/null
+	printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\nint main(){}' | c++ -I$(brew --prefix libwebsockets)/include -xc++ -std=c++17 - -o /dev/null || exit 1; echo -e "#include <lws_config.h>\n#if LWS_LIBRARY_VERSION_NUMBER < 2004000 || LWS_LIBRARY_VERSION_NUMBER >= 3001000\n#error "JAliEn-ROOT requires libwebsockets 3.0.x but other version was detected"\n#endif\nint main() {}" | c++ -x c++ -I$(brew --prefix libwebsockets)/include -std=c++17 - -o /dev/null || exit 1
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -66,7 +66,7 @@ module load BASE/1.0 XRootD/${XROOTD_VERSION}-${XROOTD_REVISION}             \\
 # Our environment
 set XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 
-set GSHELL_ROOT \$XALIENFS_ROOT
+setenv GSHELL_ROOT \$XALIENFS_ROOT
 setenv GSHELL_NO_GCC 1
 
 prepend-path LD_LIBRARY_PATH \$XALIENFS_ROOT/lib

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.0.3"
+tag: "1.0.4"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -6,10 +6,10 @@ requires:
  - "OpenSSL:(?!osx)"
  - Python-modules
  - AliEn-Runtime
+ - libxml2
 build_requires:
  - CMake
  - "osx-system-openssl:(osx.*)"
- - libxml2
  - "GCC-Toolchain:(?!osx)"
  - UUID:(?!osx)
 ---


### PR DESCRIPTION
- JAliEn-ROOT currently requires libwebsocket version between 2.8 and 3.0, add strict check
- Fix missing GSHELL_ROOT variable in xalienfs (AliEn-ROOT-Legacy)
- Fix XRootD / libxml2 dependency
- bump xjalienfs (JAliEn-ROOT): add alien_mirro and improve alien_cp