### PR TITLE
Make path to LZ4 optional

### DIFF
--- a/readout.sh
+++ b/readout.sh
@@ -78,7 +78,7 @@ module load BASE/1.0                                                          \\
             Common-O2/$COMMON_O2_VERSION-$COMMON_O2_REVISION                  \\
             libInfoLogger/$LIBINFOLOGGER_VERSION-$LIBINFOLOGGER_REVISION      \\
             ReadoutCard/$READOUTCARD_VERSION-$READOUTCARD_REVISION            \\
-            lz4/${LZ4_VERSION}-${LZ4_REVISION}                                \\
+            ${LZ4_REVISION:+lz4/$LZ4_VERSION-$LZ4_REVISION}                                \\
             FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION               \\
             FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION                           \\
             Control-OCCPlugin/$CONTROL_OCCPLUGIN_VERSION-$CONTROL_OCCPLUGIN_REVISION


### PR DESCRIPTION
Loadling module complains otherwise
if lz4 is taken from the system.