### PR TITLE
python-modules: use venv to install environment

### DIFF
--- a/lzma.sh
+++ b/lzma.sh
@@ -9,13 +9,12 @@ prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <lzma.h>\n" | c++ -xc++ - -c -M 2>&1
 ---
-#!/bin/bash -e
-
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 ./autogen.sh
 ./configure CFLAGS="$CFLAGS -fPIC -Ofast" \
             --prefix="$INSTALLROOT"       \
-            --disable-static              \
+            --disable-shared              \
+            --enable-static               \
             --disable-nls                 \
             --disable-rpath               \
             --disable-dependency-tracking \


### PR DESCRIPTION
Now that we can rely on python3, we can simply setup our modules in a
virtualenv environment, with the added advantage that we can pick up whatever
is already available from the system or any previously setup virtualenv,
allowing people to easily customize their Python-modules environment.