### PR TITLE
lzma: build as static library (O2-1127)

### DIFF
--- a/lzma.sh
+++ b/lzma.sh
@@ -9,13 +9,12 @@ prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <lzma.h>\n" | c++ -xc++ - -c -M 2>&1
 ---
-#!/bin/bash -e
-
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 ./autogen.sh
 ./configure CFLAGS="$CFLAGS -fPIC -Ofast" \
             --prefix="$INSTALLROOT"       \
-            --disable-static              \
+            --disable-shared              \
+            --enable-static               \
             --disable-nls                 \
             --disable-rpath               \
             --disable-dependency-tracking \


### PR DESCRIPTION
Centos7 comes with an incompatible version, so we simply
make our own invisible to the system tools.