### PR TITLE
Set GCC_TOOLCHAIN_ROOT as an environment variable

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -155,6 +155,7 @@ if { "\$mod_name" == "GCC-Toolchain" } {
 }
 # Our environment
 set GCC_TOOLCHAIN_ROOT \$base_path/GCC-Toolchain/\$version
+setenv GCC_TOOLCHAIN_ROOT \$GCC_TOOLCHAIN_ROOT
 prepend-path LD_LIBRARY_PATH \$GCC_TOOLCHAIN_ROOT/lib
 prepend-path LD_LIBRARY_PATH \$GCC_TOOLCHAIN_ROOT/lib64
 prepend-path PATH \$GCC_TOOLCHAIN_ROOT/bin


### PR DESCRIPTION
After this https://github.com/alisw/alidist/pull/1913 having been merged, I couldn't compile O2 and QC inside Clion - it looked like cmake couldn't find the right libstdc++, taking the one from the system:
```
====================[ Build | O2exe-testworkflows-datasampling-benchmark | Debug ]====
/home/pkonopka/alice/sw/slc7_x86-64/CMake/latest/bin/cmake --build /home/pkonopka/alice/O2/cmake-build-debug --target O2exe-testworkflows-datasampling-benchmark -- -j 4
Scanning dependencies of target O2lib-MemoryResources
[  0%] Building CXX object DataFormats/MemoryResources/CMakeFiles/O2lib-MemoryResources.dir/src/MemoryResources.cxx.o
/home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake)
/home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake)
/home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake)
/home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.22' not found (required by /home/pkonopka/alice/sw/slc7_x86-64/CMake/v3.16.3-alice2-3/bin/cmake)
GPU/Common/CMakeFiles/O2lib-GPUCommon.dir/build.make:62: recipe for target 'GPU/Common/G__O2GPUCommon.cxx' failed
gmake[3]: *** [GPU/Common/G__O2GPUCommon.cxx] Error 1
CMakeFiles/Makefile2:10222: recipe for target 'GPU/Common/CMakeFiles/O2lib-GPUCommon.dir/all' failed
gmake[2]: *** [GPU/Common/CMakeFiles/O2lib-GPUCommon.dir/all] Error 2
gmake[2]: *** Waiting for unfinished jobs....
```
This PR fixes my problem.