### PR TITLE
O2-738 Don't execute GPUsort(CUDA|HIP) tests on CI

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -217,7 +217,7 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
   # Clean up ROOT files created by tests in build area
   find $PWD -name "*.root" -delete
   TESTERR=
-  ctest -E test_Framework --output-on-failure ${JOBS+-j $JOBS} || TESTERR=$?
+  ctest -E "(test_Framework)|(test_GPUsort(CUDA|HIP))" --output-on-failure ${JOBS+-j $JOBS} || TESTERR=$?
   ctest -R test_Framework --output-on-failure || TESTERR=$?
   # Display additional logs for tests that timed out in a non-fatal way
   set +x


### PR DESCRIPTION
We want to build the tests if CUDA/hip is available on the CI without executing them, since we don't have CI machines with GPU.
This PR has to be merged before [PR 2914 in O2](https://github.com/AliceO2Group/AliceO2/pull/2914) can be merged.