### PR TITLE
Bump geant4_vmc to v3-6-p6:

### DIFF
--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v3-6-p3"
+tag: "v3-6-p6-inclxx-biasing-p2"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v3-6-p6-inclxx-biasing-p2"
+tag: "v3-6-p6"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT


### PR DESCRIPTION
This version contains the latest fixes and also the development for mixing
physics lists via biasing.