### PR TITLE
Bump gRPC to v1.27.1

### DIFF
--- a/grpc.sh
+++ b/grpc.sh
@@ -1,6 +1,6 @@
 package: grpc
 version: "%(tag_basename)s"
-tag:  v1.19.1
+tag:  v1.27.1
 requires:
   - protobuf
   - c-ares


### PR DESCRIPTION
Related: https://alice.its.cern.ch/jira/browse/O2-1125