### PR TITLE
Fix AliEn-ROOT-Legacy loading

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -16,7 +16,6 @@ prepend_path:
   ROOT_INCLUDE_PATH: "$ALIEN_ROOT_LEGACY_ROOT/include"
 ---
 #!/bin/bash -e
-
 if [[ $ARCHITECTURE == osx* && ! $OPENSSL_ROOT ]]; then
   OPENSSL_ROOT=$(brew --prefix openssl)
 fi

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -21,7 +21,7 @@ if [[ $ARCHITECTURE == osx* && ! $OPENSSL_ROOT ]]; then
 fi
 
 # Determine whether we are building for ROOT 5 or ROOT 6+
-[[ -x "$ROOTSYS/bin/rootcling" ]] && ROOT_MAJOR="v6-00-00" || ROOT_MAJOR="v5-00-00"
+type $ROOTSYS/bin/rootcling && ROOT_MAJOR="v6-00-00" || ROOT_MAJOR="v5-00-00"
 
 rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR
 rsync -a $ALICE_GRID_UTILS_ROOT/include/ $BUILDDIR/inc

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -44,9 +44,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${OPENSSL_VERSION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}
 # Our environment
-setenv LIBWEBSOCKETS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(LIBWEBSOCKETS_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(LIBWEBSOCKETS_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LIBWEBSOCKETS_ROOT)/lib")
+set LIBWEBSOCKETS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$LIBWEBSOCKETS_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$LIBWEBSOCKETS_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -7,6 +7,10 @@ build_requires:
   - "GCC-Toolchain:(?!osx)"
   - "OpenSSL:(?!osx)"
   - zlib
+prefer_system: "osx"
+prefer_system_check: |
+  printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\n' | c++ -I$(brew --prefix libwebsockets)/include -c -xc++ -std=c++17 - -o /dev/null
+  printf '#include <lws_config.h>\n#if LWS_LIBRARY_VERSION_NUMBER < 2004000 || LWS_LIBRARY_VERSION_NUMBER >= 3001000\n#error \"JAliEn-ROOT requires libwebsockets 3.0.x but other version was detected\"\n#endif\n' | c++ -c -x c++ -I$(brew --prefix libwebsockets)/include -std=c++17 - -o /dev/null || exit 1
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -6,10 +6,10 @@ requires:
  - "OpenSSL:(?!osx)"
  - Python-modules
  - AliEn-Runtime
+ - libxml2
 build_requires:
  - CMake
  - "osx-system-openssl:(osx.*)"
- - libxml2
  - "GCC-Toolchain:(?!osx)"
  - UUID:(?!osx)
 ---


### PR DESCRIPTION
Bumping the recipe to make aliBuild redeploy the reverted AliEn-ROOT-Legacy package (see the revisions 0.1.3-7 and 0.1.3-9, missing $GSHELL_ROOT).

Also backporting XRootD libxml2 runtime dependency. The libxml2 became runtime dependency after extracting XRootD from AliEn-Runtime.