### PR TITLE
Adding POWHEG r3693

### DIFF
--- a/powheg.sh
+++ b/powheg.sh
@@ -1,11 +1,12 @@
 package: POWHEG
 version: "%(tag_basename)s"
-tag: "r3178-alice1"
+tag: "r3693-alice1"
 source: https://github.com/alisw/POWHEG
 requires:
   - fastjet
   - "GCC-Toolchain:(?!osx|slc5)"
-  - lhapdf5
+  - lhapdf
+  - lhapdf-pdfsets
 ---
 #!/bin/bash -e
 
@@ -35,7 +36,11 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 lhapdf5/$LHAPDF5_VERSION-$LHAPDF5_REVISION ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} ${FASTJET_REVISION:+fastjet/$FASTJET_VERSION-$FASTJET_REVISION}
+module load BASE/1.0 \
+            lhapdf/$LHAPDF_VERSION-$LHAPDF_REVISION \
+            lhapdf-pdfsets/$LHAPDF_PDFSETS_VERSION-$LHAPDF_PDFSETS_REVISION \
+            ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \
+            ${FASTJET_VERSION:+fastjet/$FASTJET_VERSION-$FASTJET_REVISION}
 # Our environment
 set POWHEG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv POWHEG_ROOT \$POWHEG_ROOT


### PR DESCRIPTION
In addition move from LHAPDF5 to LHAPDF6 in order to allow usage of more modern PDF sets.