### PR TITLE
Disable "rivet-hi" from the Aligenerators bundle

### DIFF
--- a/aligenerators.sh
+++ b/aligenerators.sh
@@ -19,7 +19,6 @@ requires:
   - FONLL
   - Therminator2
   - Rivet
-  - Rivet-hi
   - lhapdf-pdfsets
 build_requires:
   - EPOS-test


### PR DESCRIPTION
The development of heavy-ions features in Rivet have been developped by @pkarczma, @qgp et al under that package.
Their dev has been ported to the official Rivet sources  (rivet >2.7.0)
I remove here such a package for the time being, since we are by now sticking to the official rivet sources.

NB : but please keep the "rivet-hi" alisw directory : ALICE may need to revive internally at some point a dedicated development branch for Rivet (rivet-hi) while ALICE users may need to be able to run with the regular version (2.7.2, 3.1.0, etc).
I have in mind HEPmc3, utilities for vn Fourier measurements, jets physics, etc