### PR TITLE
[O2-1158] prefer patched alibuild cmake on macos

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/CMake
 build_requires:
  - "GCC-Toolchain:(?!osx)"
  - make
-prefer_system: .*
+prefer_system: "(?!osx)"
 prefer_system_check: |
   verge() { [[  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]]; }
   type cmake && verge 3.16.3 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3`


### PR DESCRIPTION
We need macOS to pick up out patched version of CMake as long as this [CMake bug](https://gitlab.kitware.com/cmake/cmake/issues/19845#note_689595) is not fixed in a release version.