### PR TITLE
Bump QC to v0.21.1

### DIFF
--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -1,6 +1,6 @@
 package: QualityControl
 version: "%(tag_basename)s"
-tag: v0.20.1
+tag: v0.21.1
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Needed by https://github.com/AliceO2Group/QualityControl/pull/304
The compilation on Mac should be fixed.
@matthiasrichter 