### PR TITLE
Switch to Rivet tag 2.7.2-alice4

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.7.2-alice3"
+tag: "2.7.2-alice4"
 source: https://github.com/alisw/rivet
 requires:
   - GSL


### PR DESCRIPTION
After the fixes of the CMS_2013_I1223519.cc, upgrade Rivet tag version to get rivet complied again hopefully.
See https://github.com/alisw/rivet/pull/4