### PR TITLE
Exclude 3rd party files from code checker

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -82,7 +82,7 @@ COPYRIGHT="$(cat <<'EOF'
 EOF
 )"
 COPYRIGHT_LINES=$(echo "$COPYRIGHT" | wc -l)
-COPYRIGHT_EXCLUDE_REGEXP="3rdparty"  # exclude files from the copyright check
+COPYRIGHT_EXCLUDE_REGEXP="/3rdparty/"  # exclude files from the copyright check
 set +x
 while read FILE; do
   [[ ${FILE:0:2} != "./" ]] || FILE=${FILE:2}

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -82,7 +82,7 @@ COPYRIGHT="$(cat <<'EOF'
 EOF
 )"
 COPYRIGHT_LINES=$(echo "$COPYRIGHT" | wc -l)
-COPYRIGHT_EXCLUDE_REGEXP="^Framework/DebugGUI/"  # exclude files from the copyright check
+COPYRIGHT_EXCLUDE_REGEXP="3rdparty"  # exclude files from the copyright check
 set +x
 while read FILE; do
   [[ ${FILE:0:2} != "./" ]] || FILE=${FILE:2}


### PR DESCRIPTION
@ktf @sawenzel : We don't need to exclude the DebugGUI files any more, since they are not in O2.
Can we instead exclude anything that has 3rdparty in its name (For the Standalone build of the GPU visualization, I have to ship some 3rd party files, like @ktf did before for the DebugGUI). I think 3rdparty is generic enough to be excludable. If not, I can also find another way to hide my files from the codechecker, in principle I can just zip them or so.