### PR TITLE
Rivet - Switch to 2.7.2-alice6 (SIunits.sty) + Manage TEX env variables in the modulefiles part

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -95,4 +95,16 @@ prepend-path PYTHONPATH \$RIVET_ROOT/lib/python3.6/site-packages
 prepend-path PYTHONPATH \$RIVET_ROOT/lib64/python3.6/site-packages
 prepend-path PATH \$RIVET_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$RIVET_ROOT/lib
+
+# Producing plots with (/rivet/bin/make-plots, in python) requires dedicated LaTeX packages
+# which are not always there on the system (alidock, lxplus ...)
+# -> need to point to such packages, actually shipped together with Rivet sources
+# Consider the official source info in /rivet/rivetenv.sh to see what is needed
+# (TEXMFHOME, HOMETEXMF, TEXMFCNF, TEXINPUTS, LATEXINPUTS)
+# Here trying to keep the env variable changes to their minimum, i.e touch only TEXINPUTS, LATEXINPUTS
+# Manual prepend-path for TEX variables
+set Old_TEXINPUTS [exec kpsewhich -var-value TEXINPUTS]
+set Extra_RivetTEXINPUTS \$RIVET_ROOT/share/Rivet/texmf/tex//
+setenv TEXINPUTS  \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS
+setenv LATEXINPUTS \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS
 EoF

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.7.2-alice4"
+tag: "2.7.2-alice6"
 source: https://github.com/alisw/rivet
 requires:
   - GSL


### PR DESCRIPTION
1. Update to 2.7.2-alice6 (ship SIunits.sty needed under CentOS7 lxplus and alidock)
https://github.com/alisw/rivet/commit/be6cbc234a96d1fed4521df70b6a774171639590
i.e. compensate a missing LaTeX package

2. Producing plots with (/rivet/bin/make-plots, in python) requires dedicated LaTeX packages
which are not always there on the system (alidock, lxplus ...)
at the moment, it concerns at least relsize.sty and SIunits.sty
-> need to point to such packages, actually shipped together with Rivet sources
It does not prevent the compilation to succeed but just break the execution of python scripts at the end of the rivet processing.

(Memo : Consider in the future the official source info in /rivet/rivetenv.sh to see what is needed
i.e. here TEXMFHOME, HOMETEXMF, TEXMFCNF, TEXINPUTS, LATEXINPUTS

Here trying to keep the env variable changes to their minimum, i.e touch only TEXINPUTS, LATEXINPUTS
Manual **append**-path for TEX variables in the modulefiles part of the recipe

Checked under alidock and Ubuntu 18.04 LTS

set Old_TEXINPUTS [exec kpsewhich -var-value TEXINPUTS]
set Extra_RivetTEXINPUTS \$RIVET_ROOT/share/Rivet/texmf/tex//
setenv TEXINPUTS  \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS
setenv LATEXINPUTS \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS