### PR TITLE
Bump AliEn-CAs

### DIFF
--- a/alien-cas.sh
+++ b/alien-cas.sh
@@ -1,6 +1,6 @@
 package: AliEn-CAs
 version: v1
-tag: 4a5bccfccd2c32cc32eb53ae44e213d19b536d2d
+tag: [[[ TOBEDEFINED ]]]
 source: https://github.com/alisw/alien-cas.git
 ---
 #!/bin/bash -e

--- a/alien-cas.sh
+++ b/alien-cas.sh
@@ -1,6 +1,6 @@
 package: AliEn-CAs
 version: v1
-tag: [[[ TOBEDEFINED ]]]
+tag: 53fbc54de2fc99129eff587ac0dd6dc814b0439e
 source: https://github.com/alisw/alien-cas.git
 ---
 #!/bin/bash -e


### PR DESCRIPTION
Start distributing AliEn 2 CA. Update the hash after https://github.com/alisw/alien-cas/pull/5 is merged.