### PR TITLE
Switch to 2.7.2-alice7 - fix in make-plots

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.7.2-alice6"
+tag: "2.7.2-alice7"
 source: https://github.com/alisw/rivet
 requires:
   - GSL


### PR DESCRIPTION
XMajorTickLineColor defaulted to '0.3pt'  since long, now changed to a proper colour expectation : 'black'
Prevent LaTeX compilation to succeed to produce rivet plots.
See backport from official sources committed to our own repo : https://github.com/alisw/rivet/commit/d03c57dfec3410d6f1044e2a0e9c7b57b4a41325