### PR TITLE
Disable arrow (not needed for AliRoot; does not compile on sl6?)

### DIFF
--- a/defaults-dev.sh
+++ b/defaults-dev.sh
@@ -4,6 +4,10 @@ env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++11"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+
+disable:
+  - arrow
+
 overrides:
   fastjet:
     version: "v3.3.4_1.042"


### PR DESCRIPTION
Hi Guilio,

Another update for the defaults-dev for aligenerator: disable arrow since it does not seem to compile on SL6 and is not needed.

Best regards,

Marco.