### PR TITLE
Bump JAliEn-ROOT - fix IPv6 failover

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.5.3"
+tag: "0.5.4"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
A TJAlien bugfix release, some IPv6 workarounds, makes the connection manager more stable.