### PR TITLE
[WIP] Switch ROOT Grid plugins to TNetXNGFile 

### DIFF
--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -1,7 +1,7 @@
 package: Alice-GRID-Utils
 version: "%(tag_basename)s"
-tag: "0.0.6"
-source: https://gitlab.cern.ch/nhardi/alice-grid-utils.git
+tag: "0.0.7"
+source: https://gitlab.cern.ch/jalien/alice-grid-utils.git
 ---
 #!/bin/bash -e
 

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -1,6 +1,6 @@
 package: AliEn-ROOT-Legacy
 version: "%(tag_basename)s"
-tag: "0.1.3"
+tag: "0.2.0"
 source: https://gitlab.cern.ch/jalien/alien-root-legacy.git
 requires:
   - ROOT

--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -33,6 +33,7 @@ cmake $BUILDDIR                                          \
       -DROOTSYS="$ROOTSYS"                               \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DALIEN_DIR="$XALIENFS_ROOT"                       \
+      -DXROOTD_ROOT_DIR="$XROOTD_ROOT"                   \
       -DROOT_VERSION="$ROOT_MAJOR"
 
 cmake --build . --target install ${JOBS:+-- -j$JOBS}

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -29,7 +29,7 @@ overrides:
     source: https://github.com/alisw/xrootd.git
   # Use ROOT 5
   ROOT:
-    tag: v5-34-30-alice10
+    tag: v5-34-30-alice11
     source: https://github.com/alisw/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -29,7 +29,7 @@ overrides:
     source: https://github.com/alisw/xrootd.git
   # Use ROOT 5
   ROOT:
-    tag: v5-34-30-alice10
+    tag: v5-34-30-alice11
     source: https://github.com/alisw/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/defaults-user.sh
+++ b/defaults-user.sh
@@ -32,7 +32,7 @@ overrides:
 
   # Use ROOT 5
   ROOT:
-    tag: v5-34-30-alice10
+    tag: v5-34-30-alice11
     source: https://github.com/alisw/root
     requires:
       - AliEn-Runtime:(?!.*ppc64)

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -5,6 +5,7 @@ source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT
   - xjalienfs
+  - XRootD
 build_requires:
   - libwebsockets
   - json-c
@@ -32,6 +33,7 @@ cmake $BUILDDIR                                          \
       -DJSONC="$JSON_C_ROOT"                             \
        ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT} \
       -DZLIB_ROOT="$ZLIB_ROOT"                           \
+      -DXROOTD_ROOT_DIR="$XROOTD_ROOT"                   \
       -DLWS="$LIBWEBSOCKETS_ROOT"
 make ${JOBS:+-j $JOBS} install
 

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -17,6 +17,7 @@ append_path:
   ROOT_PLUGIN_PATH: "$JALIEN_ROOT_ROOT/etc/plugins"
 ---
 #!/bin/bash -e
+
 case $ARCHITECTURE in
   osx*) 
 	[[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl)

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.5.4"
+tag: "0.6.0"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-18-04-alice1"
+tag: "v6-18-04-alice2"
 source: https://github.com/alisw/root
 requires:
   - arrow


### PR DESCRIPTION
This update requires new tags in ROOT 5/6 forks. The update switches ROOT base class for TAliceFile, implemented by both TJAlienFile and TAlienFile.

- ROOT 5 tag: https://github.com/alisw/root/commits/v5-34-30-alice11
- ROOT 6 tag: https://github.com/alisw/root/tree/v6-18-04-alice2