### PR TITLE
Port installation of compile_commands.json

### DIFF
--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -77,6 +77,17 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
   ctest --output-on-failure -LE manual -E "(testWorkflow|testCheckWorkflow)" ${JOBS+-j $JOBS}
 fi
 
+DEVEL_SOURCES="`readlink $SOURCEDIR || echo $SOURCEDIR`"
+# This really means we are in development mode. We need to make sure we
+# use the real path for sources in this case. We also copy the
+# compile_commands.json file so that IDEs can make use of it directly, this
+# is a departure from our "no changes in sourcecode" policy, but for a good reason
+# and in any case the file is in gitignore.
+if [ "$DEVEL_SOURCES" != "$SOURCEDIR" ]; then
+  perl -p -i -e "s|$SOURCEDIR|$DEVEL_SOURCES|" compile_commands.json
+  ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
+fi
+
 # Modulefile
 mkdir -p etc/modulefiles
 cat > etc/modulefiles/$PKGNAME <<EoF


### PR DESCRIPTION
Port installation of the compile_commands.json in
development mode from o2.sh to qualitycontrol.sh.
Having compile compile_commands.json in the source
dir is helpful as modern IDEs can make use of it.