### PR TITLE
build clang for x86 only

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -38,6 +38,7 @@ esac
 # to clang-tidy (for instance)
 cmake $SOURCEDIR/llvm \
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt" \
+  -DLLVM_TARGETS_TO_BUILD="X86" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT" \
   -DLLVM_INSTALL_UTILS=ON \


### PR DESCRIPTION
Currently clang is being built for all available architectures however we only need x86. this small change should bring down the compile time for clang significantly.
Reference: https://llvm.org/docs/CMake.html