### PR TITLE
O2-1173 Fix RPATH for LLVM libraries on macOS 

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -38,6 +38,7 @@ esac
 # to clang-tidy (for instance)
 cmake $SOURCEDIR/llvm \
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt" \
+  -DLLVM_TARGETS_TO_BUILD="X86" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT" \
   -DLLVM_INSTALL_UTILS=ON \
@@ -47,6 +48,16 @@ cmake $SOURCEDIR/llvm \
 
 make ${JOBS+-j $JOBS}
 make install
+
+#add correct rpath to dylibs on mac as long as there is no better way to controll rpath in the LLVM CMake.
+case $ARCHITECTURE in
+  osx*)
+  # add rpath to all libraries in lib and change their IDs to be absolute paths
+  find ${INSTALLROOT}/lib -name "*.dylib" ! -name "*ios*.dylib" -exec install_name_tool -add_rpath "${INSTALLROOT}/lib" {} \; -exec install_name_tool -id {} {} \;
+  # in lib/clang/*/lib/darwin, the relative rpath is wrong and needs to be corrected from "@loader_path/../lib" to "@loader_path/../darwin" 
+  find ${INSTALLROOT}/lib/clang/*/lib/darwin \( -name "*.dylib" -a \( ! -name "*ios*.dylib" \) \) -exec install_name_tool -add_rpath "@loader_path/../darwin" {} \;
+  ;;
+esac
 
 # Needed to be able to find C++ headers.
 case $ARCHITECTURE in


### PR DESCRIPTION
LLVM CMake does not seem to care about correct RPATH on macOS. This fix provides the necessary changes in the clang recipe such that RPATH is set correctly for LLVM libs and applications dynamically linking against them will find these libraries.