### PR TITLE
[WIP] Load Python SSL certificates from CVMFS or AliEn-Runtime

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -127,5 +127,12 @@ setenv PYTHONHOME \$PYTHON_ROOT
 prepend-path PYTHONPATH \$PYTHON_ROOT/lib/python/site-packages
 prepend-path PATH \$PYTHON_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$PYTHON_ROOT/lib
-setenv SSL_CERT_FILE  [exec python3 -c "import certifi; print(certifi.where())"]
+
+set CVMFS_CERT_DIR "/cvmfs/alice.cern.ch/etc/grid-security/certificates"
+
+if { [file exists \$CVMFS_CERT_DIR] } {
+  setenv SSL_CERT_DIR \$CVMFS_CERT_DIR
+} else {
+  setenv SSL_CERT_DIR \$::env(X509_CERT_DIR)
+}
 EoF


### PR DESCRIPTION
As discussed with @ktf and @costing, this patch makes Python module file conditionally load certificates either from CVMFS, or AliEn-Runtime/AliEn-CAs.

Btw, for the reference, this is why I believe we can switch from `SSL_CERT_FILE` to `SSL_CERT_DIR`:

```
[Python/v3.6.10-14] tmp > which python
/cvmfs/alice.cern.ch/el7-x86_64/Packages/Python/v3.6.10-14/bin/python

[Python/v3.6.10-14] tmp > python -c "import ssl; print(ssl.get_default_verify_paths().openssl_capath_env)"
SSL_CERT_DIR
```

**Open questions:**
  - [ ] What do we do about certifi?
  - [ ] Can we remove package version and revision from AliEn-Runtime to always load the latest certificates?