### PR TITLE
SHERPA : fix the gitHub source to pick up alisw source

### DIFF
--- a/sherpa.sh
+++ b/sherpa.sh
@@ -1,7 +1,7 @@
 package: SHERPA
 version: "%(tag_basename)s"
 tag: "v2.2.8-alice1"
-source: https://github.com/mfasDa/SHERPA
+source: https://github.com/alisw/SHERPA
 requires:
   - "GCC-Toolchain:(?!osx)"
   - Openloops


### PR DESCRIPTION
For the official test, we switch from @mfasDa development repo to our official alisw repo.
. The tag v2.2.8-alice1 has just been done : https://github.com/alisw/SHERPA/tree/v2.2.8-alice1
. See initial PR for details : https://github.com/alisw/alidist/pull/2072