### PR TITLE
Bump Rivet to 2.7.2-alice8

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.7.2-alice7"
+tag: "2.7.2-alice8"
 source: https://github.com/alisw/rivet
 requires:
   - GSL


### PR DESCRIPTION
fixes plugin compilation by correctly picking up dependencies