### PR TITLE
fixes the build error of QC on Mac

### DIFF
--- a/grpc.sh
+++ b/grpc.sh
@@ -60,6 +60,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0                                                          \\
             ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
             ${C_ARES_REVISION:+c-ares/$C_ARES_VERSION-$C_ARES_REVISION}        \\
+            ${OPENSSL_REVISION:+OpenSSL/$OPENSSL_VERSION-OPENSSL_REVISION} \\
             ${PROTOBUF_REVISION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
 # Our environment
 set GRPC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -32,7 +32,10 @@ incremental_recipe: |
 #!/bin/bash -ex
 
 case $ARCHITECTURE in
-  osx*) [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost);;
+    osx*) 
+		  [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
+		  [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+    ;;
 esac
 
 # For the PR checkers (which sets ALIBUILD_O2_TESTS),
@@ -64,6 +67,7 @@ cmake $SOURCEDIR                                              \
       -DARROW_HOME=$ARROW_ROOT                                \
       ${CONTROL_OCCPLUGIN_REVISION:+-DOcc_ROOT=$CONTROL_OCCPLUGIN_ROOT}                      \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                 \
+      ${OPENSSL_ROOT_DIR:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR}          \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}


### PR DESCRIPTION
Fixes errors such as 
```
DEBUG:O2Suite:QualityControl:0: CMake Error at Framework/CMakeLists.txt:282 (add_executable):
DEBUG:O2Suite:QualityControl:0:   Target "testTriggerHelpers" links to target "OpenSSL::Crypto" but the
DEBUG:O2Suite:QualityControl:0:   target was not found.  Perhaps a find_package() call is missing for an
DEBUG:O2Suite:QualityControl:0:   IMPORTED target, or an ALIAS target is missing?
DEBUG:O2Suite:QualityControl:0: 
```