### PR TITLE
Add ROOT_DYN_PATH to dynamic search path for ROOT

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -88,5 +88,6 @@ setenv ALICE_PHYSICS \$ALICE_PHYSICS
 prepend-path PATH \$ALICE_PHYSICS/bin
 prepend-path LD_LIBRARY_PATH \$ALICE_PHYSICS/lib
 prepend-path ROOT_INCLUDE_PATH \$ALICE_PHYSICS/include
+prepend-path ROOT_DYN_PATH \$ALICE_PHYSICS/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -122,5 +122,6 @@ prepend-path PATH \$ALICE_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$ALICE_ROOT/lib
 prepend-path ROOT_INCLUDE_PATH \$ALICE_ROOT/include
 prepend-path ROOT_INCLUDE_PATH \$ALICE_ROOT/include/Pythia8
+prepend-path ROOT_DYN_PATH \$ALICE_ROOT/lib
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/root.sh
+++ b/root.sh
@@ -187,7 +187,8 @@ cat >> system.rootrc.0 <<EOF
 
 # Specify additional plugin search paths via the environment variable ROOT_PLUGIN_PATH.
 # Plugins in \$ROOT_PLUGIN_PATH have priority.
-Unix.*.Root.PluginPath: \$(ROOT_PLUGIN_PATH):\$(ROOTSYS)/etc/plugins
+Unix.*.Root.PluginPath: \$(ROOT_PLUGIN_PATH):\$(ROOTSYS)/etc/plugins:
+Unix.*.Root.DynamicPath: .:\$(ROOT_DYN_PATH):
 EOF
 mv system.rootrc.0 $INSTALLROOT/etc/system.rootrc
 
@@ -239,5 +240,6 @@ set ROOT_ROOT  \$::env(ROOTSYS)
 prepend-path PYTHONPATH \$ROOT_ROOT/lib
 prepend-path PATH \$ROOT_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$ROOT_ROOT/lib
+prepend-path ROOT_DYN_PATH ""
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
This addition allows other packages (e.g. AliRoot, AliPhysics) to add paths for ROOT auto-loading of dictionaries and libraries without relying on LD_LIBRARY_PATH.

@ktf for discussion