### PR TITLE
Bump xjalienfs to 1.0.7

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.0.6"
+tag: "1.0.7"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Update xjalienfs version to 1.0.7. Updates include:

- improvements in processing copy commands (see -f option)
- timestamped debug messages
- improved JAliEn/Python scripting
- additional help, version and debug info