### PR TITLE
Update apmon-cpp.sh [O2-1211]

### DIFF
--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -1,6 +1,6 @@
 package: ApMon-CPP
 version: "%(tag_basename)s"
-tag: v2.2.8-alice2
+tag: v2.2.8-alice3
 source: https://github.com/alisw/apmon-cpp.git
 build_requires:
  - "libtirpc:(?!osx)"


### PR DESCRIPTION
Switch to the version that doesn't need an external rpc header