### PR TITLE
Fix build issue on slc6 machine

### DIFF
--- a/openloops.sh
+++ b/openloops.sh
@@ -8,6 +8,8 @@ requires:
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ .
 
+unset HTTP_PROXY # unset this to build on slc6 system
+
 ./scons 
 
 JOBS=$((${JOBS:-1}*1/5))


### PR DESCRIPTION
see discussion in #2072 .
This commit unsets `HTTP_PROXY` variable that apparently breaks `pyhon urllib2` causing a download failure in `Openloops` scripts.