### PR TITLE
Update link to libxml2 repository for old tags

### DIFF
--- a/libxml2.sh
+++ b/libxml2.sh
@@ -1,6 +1,6 @@
 package: libxml2
 version: v2.9.3
-source: https://git.gnome.org/browse/libxml2
+source: https://gitlab.gnome.org/GNOME/libxml2.git
 tag: v2.9.3
 build_requires:
   - autotools


### PR DESCRIPTION
Ciao @ktf,
the builds of this branch were failing because the libxml2 repo was moved...
Cheers,
Max