### PR TITLE
Install git-clang-format in bin-safe

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -86,8 +86,8 @@ cat << \EOF > test.cc
 EOF
 $INSTALLROOT/bin-safe/clang++ -v -c test.cc
 
-curl -o $INSTALLROOT/bin/git-clang-format https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format
-chmod u+x $INSTALLROOT/bin/git-clang-format
+curl -o $INSTALLROOT/bin-safe/git-clang-format https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format
+chmod u+x $INSTALLROOT/bin-safe/git-clang-format
 
 # Modulefile
 mkdir -p etc/modulefiles


### PR DESCRIPTION
git-clang-format is not found during runtime as only the 'bin-safe' path is accessible.
Now installing git-clang-format directly in 'bin-safe'.