### PR TITLE
Bump Herwig to v7.2.0, ThePEG to v2.2.0

### DIFF
--- a/herwig.sh
+++ b/herwig.sh
@@ -1,18 +1,18 @@
 package: Herwig
 version: "%(tag_basename)s"
-tag: "v7.1.2-alice1"
+tag: "v7.2.0"
 source: https://github.com/alisw/herwig
 requires:
   - GMP
   - GSL
   - ThePEG
+  - lhapdf
   - lhapdf-pdfsets
 build_requires:
   - autotools
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
-
 
 export LHAPDF_DATA_PATH="$LHAPDF_ROOT/share/LHAPDF:$LHAPDF_PDFSETS_ROOT/share/LHAPDF"
 

--- a/lhapdf-pdfsets.sh
+++ b/lhapdf-pdfsets.sh
@@ -5,7 +5,7 @@ build_requires:
 ---
 #!/bin/bash -ex
 
-PDFSETS="cteq6l1 MMHT2014lo68cl MMHT2014nlo68cl cteq66 CT10nlo"
+PDFSETS="cteq6l1 MMHT2014lo68cl MMHT2014nlo68cl cteq66 CT10nlo CT14lo CT14nlo"
 if [ ! -d $INSTALLROOT/share/LHAPDF ]; then mkdir -p $INSTALLROOT/share/LHAPDF; fi
 pushd $INSTALLROOT/share/LHAPDF
   # REPO=https://lhapdf.hepforge.org/downloads?f=pdfsets/6.2.1

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -1,6 +1,6 @@
 package: ThePEG
 version: "%(tag_basename)s"
-tag: "v2.1.2"
+tag: "v2.2.0"
 source: https://github.com/alisw/thepeg
 requires:
   - Rivet

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -9,6 +9,7 @@ requires:
   - boost
 build_requires:
   - autotools
+  - GMP
 prepend_path:
   LD_LIBRARY_PATH: "$THEPEG_ROOT/lib/ThePEG"
 env:


### PR DESCRIPTION
- Bump Herwig to v7.2.0
- Bump ThePEG to v2.2.0 (dependency of Herwig)
- Add CT14lo and CT14nlo to lhapdf-pdfsets,
  required by Herwig v7.2.0