### PR TITLE
[O2-1286] Use a different toolset for macos

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -57,7 +57,7 @@ fi
 
 TMPB2=$BUILDDIR/tmp-boost-build
 case $ARCHITECTURE in
-  osx*) TOOLSET=clang ;;
+  osx*) TOOLSET=clang-darwin ;;
   *) TOOLSET=gcc ;;
 esac
 

--- a/boost.sh
+++ b/boost.sh
@@ -57,7 +57,7 @@ fi
 
 TMPB2=$BUILDDIR/tmp-boost-build
 case $ARCHITECTURE in
-  osx*) TOOLSET=darwin ;;
+  osx*) TOOLSET=clang ;;
   *) TOOLSET=gcc ;;
 esac
 
@@ -99,6 +99,7 @@ b2 -q                                            \
    ${BOOST_CXXFLAGS:+cxxflags="$BOOST_CXXFLAGS"} \
    ${CXXSTD:+cxxstd=$CXXSTD}                     \
    install
+
 
 # Remove CMake Config files, some of our dependent packages pick them up, but fail to use them
 # So for now we rely on the boost module FindBoost which comes with CMake


### PR DESCRIPTION
I'm not an expert in boost building, but this seems to solve the : 

clang: error: unknown argument: '-fcoalesce-templates'

issue first reported in [alice-talk](https://alice-talk.web.cern.ch/t/o2-build-failed-at-boost-due-to-unknown-argument/545) and tracked in [JIRA O2-1286](https://alice.its.cern.ch/jira/browse/O2-1286)

at least on Catalina (10.15.4) with  clang --version
Apple clang version 11.0.3 (clang-1103.0.32.29)
