### PR TITLE
[O2-1263] Do not remove the lib/cmake from boost installation

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -78,8 +78,7 @@ cmake ./src_tmp/cpp                                                             
       ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_LIBRARY=$PROTOBUF_ROOT/lib/libprotoc.$SONAME}              \
       ${PROTOBUF_ROOT:+-DProtobuf_INCLUDE_DIR=$PROTOBUF_ROOT/include}                               \
       ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc}                      \
-      ${BOOST_ROOT:+-DBoost_DIR=$BOOST_ROOT}                                                        \
-      ${BOOST_ROOT:+-DBoost_INCLUDE_DIR=$BOOST_ROOT/include}                                        \
+      ${BOOST_ROOT:+-DBoost_ROOT=$BOOST_ROOT}                                                       \
       ${LZ4_ROOT:+-DLZ4_ROOT=${LZ4_ROOT}}                                                           \
       -DARROW_WITH_SNAPPY=OFF                                                                       \
       -DARROW_WITH_ZSTD=OFF                                                                         \

--- a/asiofi.sh
+++ b/asiofi.sh
@@ -24,6 +24,7 @@ cmake $SOURCEDIR                                                 \
       -DDISABLE_COLOR=ON                                         \
       ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                    \
       ${OFI_ROOT:+-DOFI_ROOT=$OFI_ROOT}                          \
+      -DBUILD_SHARED_LIBS=ON                                     \
       -DBUILD_TESTING=ON
 
 

--- a/boost.sh
+++ b/boost.sh
@@ -97,11 +97,6 @@ b2 -q                                            \
    ${CXXSTD:+cxxstd=$CXXSTD}                     \
    install
 
-
-# Remove CMake Config files, some of our dependent packages pick them up, but fail to use them
-# So for now we rely on the boost module FindBoost which comes with CMake
-rm -Rf "$INSTALLROOT"/lib/cmake
-
 # If boost_python is enabled, check if it was really compiled
 [[ $BOOST_PYTHON ]] && ls -1 "$INSTALLROOT"/lib/*boost_python* > /dev/null
 

--- a/control-occplugin.sh
+++ b/control-occplugin.sh
@@ -38,7 +38,8 @@ cmake $SOURCEDIR/occ                                                            
       -DGRPCPATH=${GRPC_ROOT}                                                            \
       -DPROTOBUFPATH=${PROTOBUF_ROOT}                                                    \
       -DFAIRMQPATH=${FAIRMQ_ROOT}                                                        \
-      -DFAIRLOGGERPATH=${FAIRLOGGER_ROOT}
+      -DFAIRLOGGERPATH=${FAIRLOGGER_ROOT}                                                \
+      -DBUILD_SHARED_LIBS=ON
 
 make ${JOBS+-j $JOBS} prefix=$INSTALLROOT
 make prefix=$INSTALLROOT install

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -14,6 +14,7 @@ build_requires:
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
           ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \
           -DROOT_DIR=${ROOT_ROOT}                      \
+          -DBUILD_SHARED_LIBS=ON                       \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS}

--- a/readout.sh
+++ b/readout.sh
@@ -55,7 +55,8 @@ cmake $SOURCEDIR                                                         \
       ${PYTHON_REVISION:+-DPython3_ROOT_DIR="$PYTHON_ROOT"}               \
       ${LZ4_ROOT:+-DLZ4_DIR=$LZ4_ROOT}                                   \
       ${CONTROL_OCCPLUGIN_REVISION:+-DOcc_ROOT=$CONTROL_OCCPLUGIN_ROOT}   \
-      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                  \
+      -DBUILD_SHARED_LIBS=ON
 
 make ${JOBS+-j $JOBS} install
 

--- a/readoutcard.sh
+++ b/readoutcard.sh
@@ -38,7 +38,8 @@ cmake $SOURCEDIR                                                      \
       ${LIBINFOLOGGER_REVISION:+-DInfoLogger_ROOT=$LIBINFOLOGGER_ROOT} \
       ${PDA_REVISION:+-DPDA_ROOT=$PDA_ROOT}                            \
       ${PYTHON_REVISION:+-DPython3_ROOT_DIR="$PYTHON_ROOT"}            \
-      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                               \
+      -DBUILD_SHARED_LIBS=ON
 
 cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}
 make ${JOBS+-j $JOBS} install


### PR DESCRIPTION
The net effect of this PR should be to solve a long standing issue : being able to compile our stack with our own boost, even if a system boost is installed (which has not been possible, at least on macOS, for a while now). That issue resurfaced in disguise in [O2-1263].
 
The key change is to "un-cripple" our version by _not_ removing in `boost.sh` the lib/cmake directory. As otherwise a "crippled" version (w/o lib/cmake directory) is never chosen by the CMake internal FindBoost module if a "not crippled" version exists instead ([more details](https://alice.its.cern.ch/jira/browse/O2-1263?focusedCommentId=245338&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-245338)).

The `-DBUILD_SHARED_LIBS=ON` additions in a couple of package is to be sure the boost system component is correctly found when using BoostConfig.cmake (which is now used as a result of the change above). I don't think it can cause problem, but maybe @sawenzel and @dennisklein can confirm ? 
