### PR TITLE
Set CGAL_ROOT environment variable

### DIFF
--- a/cgal.sh
+++ b/cgal.sh
@@ -83,6 +83,7 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
 # Our environment
 set CGAL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv CGAL_ROOT \$CGAL_ROOT
 prepend-path PATH \$CGAL_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$CGAL_ROOT/lib
 EoF


### PR DESCRIPTION
This PR sets `CGAL_ROOT` enviroment variable. See discussion in 
https://github.com/alisw/rivet/issues/6.
