### PR TITLE
Bump Hijing to v1.36.1

### DIFF
--- a/aegis.sh
+++ b/aegis.sh
@@ -6,6 +6,7 @@ requires:
   - pythia6
 build_requires:
   - CMake
+  - hijing
   - "Xcode:(osx.*)"
 source: https://github.com/AliceO2Group/AEGIS.git
 prepend_path:

--- a/hijing.sh
+++ b/hijing.sh
@@ -1,7 +1,7 @@
 # a pythia6 recipe based on the one from FairROOT
 package: hijing
 version: "%(tag_basename)s"
-tag: "v1.36"
+tag: "v1.36.1"
 source: https://github.com/alisw/hijing.git
 requires:
   - GCC-Toolchain:(?!osx)


### PR DESCRIPTION
This PR changes the tag version of the `Hijing` build to point to the `master` branch.
The current tag does not include `hipyset` which make `Hijing` not usable.
A new tag is not requested because there is a chanche the further updates will be needed until `Hijing` will be in a stable condition. On the other hand, as it is now in the `master` is working decently (it is like this since long).

The other piece of this PR include `Hijing` among the build requirements for the `AEGIS` package.
This therefore enables the building of the `THijing` interface to interact with `Hijing` itself.