### PR TITLE
Workaround for MacOSX 10.15.4: use curl from brew

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -107,6 +107,7 @@ unset SIMPATH
 case $ARCHITECTURE in
   osx*)
     # If we preferred system tools, we need to make sure we can pick them up.
+    [[ ! $CURL_ROOT ]] && CURL_ROOT=`brew --prefix curl`
     [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
     [[ ! $ZEROMQ_ROOT ]] && ZEROMQ_ROOT=`brew --prefix zeromq`
     [[ ! $GSL_ROOT ]] && GSL_ROOT=`brew --prefix gsl`
@@ -147,7 +148,8 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                                  \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                                             \
       ${ALIBUILD_O2_FORCE_GPU:+-DENABLE_CUDA=ON -DENABLE_HIP=ON -DENABLE_OPENCL1=ON -DENABLE_OPENCL2=ON}  \
-      ${ALIBUILD_O2_FORCE_GPU:+-DOCL2_GPUTARGET=gfx906 -DHIP_AMDGPUTARGET=gfx906 -DCUDA_COMPUTETARGET=75}
+      ${ALIBUILD_O2_FORCE_GPU:+-DOCL2_GPUTARGET=gfx906 -DHIP_AMDGPUTARGET=gfx906 -DCUDA_COMPUTETARGET=75} \
+      ${CURL_ROOT:+-DCURL_ROOT=$CURL_ROOT}
 
 cmake --build . -- ${JOBS+-j $JOBS} install
 

--- a/ppconsul.sh
+++ b/ppconsul.sh
@@ -11,7 +11,8 @@ build_requires:
 #!/bin/bash -e
 
 case $ARCHITECTURE in
-  osx*)
+    osx*)
+    [[ ! $CURL_ROOT ]] && CURL_ROOT=`brew --prefix curl`
     [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost` ;;
 esac
 
@@ -20,7 +21,8 @@ cmake $SOURCEDIR                                 \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT        \
       -DCMAKE_INSTALL_LIBDIR=lib                 \
       -DBUILD_SHARED_LIBS=ON                     \
-      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}
+      ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}    \
+      ${CURL_ROOT:+-DCURL_ROOT=$CURL_ROOT}
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
Workaround the incompatibility between the system curl include directory and the compiler on MacOSX 10.15.4.