### PR TITLE
Update STARlight receipt with config script. Install HepMC related files

### DIFF
--- a/starlight.sh
+++ b/starlight.sh
@@ -16,7 +16,15 @@ mkdir -p $INSTALLROOT/bin
 cp ./starlight $INSTALLROOT/bin/.
 mkdir -p $INSTALLROOT/lib
 cp ./libStarlib.a $INSTALLROOT/lib/.
-cp -r $SOURCEDIR/config $INSTALLROOT
+cp -r $SOURCEDIR/config $INSTALLROOT/.
+cp -r $SOURCEDIR/include $INSTALLROOT/.
+cp -r $SOURCEDIR/HepMC $INSTALLROOT/.
+
+#ConfigFile
+cat << EOF > $INSTALLROOT/bin/starlight-config
+echo $INSTALLROOT
+EOF
+chmod +x $INSTALLROOT/bin/starlight-config
 
 #ModuleFile
 mkdir -p etc/modulefiles


### PR DESCRIPTION
This PR updates the `STARlight` receipt adding in the `INSTALL/bin` directory a script that can be sourced to set the `STARLIGHT_ROOT` environment variable, needed for several purposes
```
$ . startlight-config
```

It also installs header files and the scripts needed for conversion of `STARlight` output ASCII file into `HepMC2` format, for injection into the `o2` simulation. 
