### PR TITLE
Fix AliPhysics JAliEn dailies

### DIFF
--- a/autotools.sh
+++ b/autotools.sh
@@ -18,7 +18,7 @@ build_requires:
 unset CXXFLAGS
 unset CFLAGS
 export EMACS=no
-USE_AUTORECONF={$USE_AUTORECONF:=true}
+USE_AUTORECONF=${USE_AUTORECONF:="true"}
 
 echo "Building ALICE autotools. To avoid this install autoconf, automake, autopoint, texinfo, pkg-config."
 

--- a/autotools.sh
+++ b/autotools.sh
@@ -42,6 +42,15 @@ if [ -d help2man* ]; then
   popd
 fi
 
+# m4 -- requires: nothing special
+pushd m4*
+  autoreconf -ivf
+  ./configure --disable-dependency-tracking --prefix $INSTALLROOT
+  make ${JOBS+-j $JOBS}
+  make install
+  hash -r
+popd
+
 # autoconf -- requires: m4
 # FIXME: is that really true? on slc7 it fails if I do it the other way around
 # with the latest version of autoconf / m4
@@ -50,15 +59,6 @@ pushd autoconf*
   ./configure --prefix $INSTALLROOT
   make MAKEINFO=true ${JOBS+-j $JOBS}
   make MAKEINFO=true install
-  hash -r
-popd
-
-# m4 -- requires: nothing special
-pushd m4*
-  autoreconf -ivf
-  ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-  make ${JOBS+-j $JOBS}
-  make install
   hash -r
 popd
 

--- a/autotools.sh
+++ b/autotools.sh
@@ -18,6 +18,7 @@ build_requires:
 unset CXXFLAGS
 unset CFLAGS
 export EMACS=no
+USE_AUTORECONF={$USE_AUTORECONF:=true}
 
 echo "Building ALICE autotools. To avoid this install autoconf, automake, autopoint, texinfo, pkg-config."
 
@@ -44,7 +45,7 @@ fi
 
 # m4 -- requires: nothing special
 pushd m4*
-  autoreconf -ivf
+  $USE_AUTORECONF && autoreconf -ivf
   ./configure --disable-dependency-tracking --prefix $INSTALLROOT
   make ${JOBS+-j $JOBS}
   make install
@@ -55,7 +56,7 @@ popd
 # FIXME: is that really true? on slc7 it fails if I do it the other way around
 # with the latest version of autoconf / m4
 pushd autoconf*
-  autoreconf -ivf
+  $USE_AUTORECONF && autoreconf -ivf
   ./configure --prefix $INSTALLROOT
   make MAKEINFO=true ${JOBS+-j $JOBS}
   make MAKEINFO=true install
@@ -64,7 +65,7 @@ popd
 
 # gettext -- requires: nothing special
 pushd gettext*
-  autoreconf -ivf
+  $USE_AUTORECONF && autoreconf -ivf
   ./configure --prefix $INSTALLROOT \
               --without-xz \
               --without-bzip2 \

--- a/autotools.sh
+++ b/autotools.sh
@@ -33,12 +33,14 @@ export PATH=$INSTALLROOT/bin:$PATH
 export LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH
 
 # help2man
-pushd help2man*
-  ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-  make ${JOBS+-j $JOBS}
-  make install
-  hash -r
-popd
+if [ -d help2man* ]; then
+  pushd help2man*
+    ./configure --disable-dependency-tracking --prefix $INSTALLROOT
+    make ${JOBS+-j $JOBS}
+    make install
+    hash -r
+  popd
+fi
 
 # autoconf -- requires: m4
 # FIXME: is that really true? on slc7 it fails if I do it the other way around

--- a/autotools.sh
+++ b/autotools.sh
@@ -85,7 +85,7 @@ popd
 
 # automake -- requires: m4, autoconf, gettext
 pushd automake*
-  sh ./bootstrap
+  [ -e bootstrap ] && sh ./bootstrap
   ./configure --prefix $INSTALLROOT
   make MAKEINFO=true ${JOBS+-j $JOBS}
   make MAKEINFO=true install

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -6,6 +6,7 @@ env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++11"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+  USE_AUTORECONF: "false"
 overrides:
   AliRoot:
     version: "%(tag_basename)s_JALIEN"

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -13,6 +13,8 @@ overrides:
   AliPhysics:
     version: "%(tag_basename)s_JALIEN"
     tag: v5-09-53-01
+  autotools:
+    tag: v1.5.0
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -7,44 +7,12 @@ env:
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 overrides:
-  XRootD:
-    tag: "v4.11.1"
-    source: https://github.com/xrootd/xrootd
-  JDK:
-    version: "12.0.1_JALIEN"
-  libxml2:
-    version: "%(tag_basename)s_JALIEN"
-    overrides:
-    requires:
-      - zlib
-    build_requires:
-      - autotools
-      - "GCC-Toolchain:(?!osx)"
-  OpenSSL:
-    version: "v1.0.2o_JALIEN"
-    overrides:
-    requires:
-      - zlib
-    build_requires:
-      - "GCC-Toolchain:(?!osx)"
-  ApMon-CPP:
-    version: "%(tag_basename)s"
-    requires:
-      - "GCC-Toolchain:(?!osx)"
-  AliPhysics:
-    version: "%(tag_basename)s_JALIEN"
-    tag: v5-09-53-01
   AliRoot:
     version: "%(tag_basename)s_JALIEN"
     tag: v5-09-53
-    requires:
-      - ROOT
-      - DPMJET
-      - fastjet:(?!.*ppc64)
-      - GEANT3
-      - GEANT4_VMC
-      - Vc
-      - JAliEn-ROOT
+  AliPhysics:
+    version: "%(tag_basename)s_JALIEN"
+    tag: v5-09-53-01
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
Sync again defaults-next-root6 and defaults-jalien, and revert autotools version to v1.5.0 as a temporary solution for AliPhysics JAliEn daily builds.