### PR TITLE
Disable o2 tests in GPU CI, will fail with GPU CI's system GCC

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -46,7 +46,7 @@ incremental_recipe: |
     perl -p -i -e "s|$SOURCEDIR|$DEVEL_SOURCES|" compile_commands.json
     ln -sf $BUILDDIR/compile_commands.json $DEVEL_SOURCES/compile_commands.json
   fi
-  if [[ $ALIBUILD_O2_TESTS ]]; then
+  if [[ $ALIBUILD_O2_TESTS ]] && [[ ! $ALIBUILD_O2_FORCE_GPU ]]; then
     export O2_ROOT=$INSTALLROOT
     export VMCWORKDIR=$O2_ROOT/share
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$O2_ROOT/lib
@@ -208,7 +208,7 @@ prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 
-if [[ $ALIBUILD_O2_TESTS ]]; then
+if [[ $ALIBUILD_O2_TESTS ]] && [[ ! $ALIBUILD_O2_FORCE_GPU ]]; then
   export O2_ROOT=$INSTALLROOT
   export VMCWORKDIR=$O2_ROOT/share
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$O2_ROOT/lib


### PR DESCRIPTION
@ktf @MichaelLettrich : I have been trying to understand why the tests in the GPU CI fail, but couldn't understand it.

So I rebuilt inside the GPU CI container from scratch with the alidist GCC instead of the system GCC and then everything works.
Thus I assume something is broken when we use the system GCC. Since we don't support that anyway, and since we cannot avoid using the system GCC if we build ROCm for the moment, I suggest we disable the O2 tests in the GPU CI. This way we at least check the compilation.

We can reenable that once we have the GPU compiler with CC8 and GCC 8.