### PR TITLE
Fix Xdevel requirements on Ubuntu 20.04

### DIFF
--- a/xdevel.sh
+++ b/xdevel.sh
@@ -6,6 +6,6 @@ system_requirement_missing: |
    * On Ubuntu-compatible systems you probably need: libxpm-dev libxext-dev libx11-dev libxft-dev
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `freetype-config --cflags` -c -o /dev/null
+  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `pkg-config freetype2 --cflags` -c -o /dev/null
 ---
 


### PR DESCRIPTION
In case someone wants to upgrade to Ubuntu 20.04.
This fixes the Xdevel cflags that cannot be obtained via `freetype-config` anymore.