### PR TITLE
Test existence of freetype-config, if not use pkg-config

### DIFF
--- a/xdevel.sh
+++ b/xdevel.sh
@@ -6,6 +6,6 @@ system_requirement_missing: |
    * On Ubuntu-compatible systems you probably need: libxpm-dev libxext-dev libx11-dev libxft-dev
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `pkg-config freetype2 --cflags` -c -o /dev/null
+  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `freetype-config --cflags 2> /dev/null || pkg-config freetype2 --cflags` -c -o /dev/null
 ---
 


### PR DESCRIPTION
When checking the requirements, it will first test if `freetype-config` exists (removed from Ubuntu 20.04 LTS). If it does exist, it will get `--cflags` from there.
If it does not exist, it will get `--cflags` from `pkg-config freetype2`.
