### PR TITLE
Bump Monitoring to v3.0.6

### DIFF
--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v3.0.4
+tag: v3.0.6
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v2.6.6
+tag: v3.0.3
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v3.0.3
+tag: v3.0.4
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
This fixes compatibility issue with StdOut backend.
