### PR TITLE
Bump JAliEn-ROOT to v0.5.5

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.5.4"
+tag: "0.5.5"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Bump JAliEn-ROOT version to v0.5.5. Two bugfixes:

- improve loading job tokens from environment variables
- improve reconnect mechanism