### PR TITLE
Require Pythia 8.302 version in O2 defaults

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -20,6 +20,7 @@ overrides:
       - ZeroMQ
       - JAliEn-ROOT
   pythia:
+    tag: "v8302"
     requires:
       - lhapdf
       - boost


### PR DESCRIPTION
This PR changes the required Pythia8 version when building with `o2` defaults to `v8302`.
It should not be merged right away, not until https://github.com/AliceO2Group/AliceO2/pull/3536 is merged in the `o2`.

I will notify when this PR is ready to be merged.