### PR TITLE
Changes to allow fotran packages to build with gcc 10

### DIFF
--- a/aegis.sh
+++ b/aegis.sh
@@ -17,7 +17,8 @@ prepend_path:
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
-                 -DCMAKE_SKIP_RPATH=TRUE
+                 -DCMAKE_SKIP_RPATH=TRUE                   \
+		 -DCMAKE_Fortran_FLAGS="-std=legacy"
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile

--- a/geant3.sh
+++ b/geant3.sh
@@ -15,7 +15,8 @@ prepend_path:
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT      \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE     \
                  ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}  \
-                 -DCMAKE_SKIP_RPATH=TRUE
+                 -DCMAKE_SKIP_RPATH=TRUE                  \
+		 -DCMAKE_Fortran_FLAGS="-std=legacy -fallow-invalid-boz"
 make ${JOBS:+-j $JOBS} install
 
 [[ ! -d $INSTALLROOT/lib64 ]] && ln -sf lib $INSTALLROOT/lib64

--- a/pythia6.sh
+++ b/pythia6.sh
@@ -10,10 +10,12 @@ build_requires:
 ---
 #!/bin/sh
 
-cmake ${SOURCEDIR}                           \
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-      -DCMAKE_INSTALL_PREFIX=${INSTALLROOT}  \
-      -DCMAKE_INSTALL_LIBDIR=lib
+cmake ${SOURCEDIR}                              \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}    \
+      -DCMAKE_INSTALL_PREFIX=${INSTALLROOT}     \
+      -DCMAKE_INSTALL_LIBDIR=lib                \
+      -DCMAKE_Fortran_FLAGS="-std=legacy"       \
+      -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--allow-multiple-definition"
 make ${JOBS+-j$JOBS}
 make install
 


### PR DESCRIPTION
* Adds `-std=legacy` to gfortran flags
* Adds relevant `allow` flags