### PR TITLE
Update FairRoot to 7701b7e6917ae

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,6 +1,6 @@
 package: FairRoot
 version: "%(short_hash)s"
-tag: "4ab2d2b1f0392ad93b92026d70fe049c38665f7d"
+tag: "7701b7e6917ae3bf86a1756c8d0497a108734aa8"
 source: https://github.com/FairRootGroup/FairRoot
 requires:
   - generators


### PR DESCRIPTION
This version includes fixes needed for our simulation:
- Suppress the warning on usage of deprecated function
- Fix for building with Geant4 10.6.x