### PR TITLE
Update XRootD to 4.12.x

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -42,6 +42,7 @@ cmake "$BUILDDIR"                                                     \
       -DCMAKE_INSTALL_LIBDIR=lib                                      \
       -DENABLE_CRYPTO=ON                                              \
       -DENABLE_PERL=OFF                                               \
+      -DVOMSXRD_SUBMODULE=OFF                                         \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v4.11.1"
+tag: "v4.12.1"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"
@@ -45,7 +45,9 @@ cmake "$BUILDDIR"                                                     \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \
+      ${UUID_ROOT:+-DUUID_LIBRARY=$UUID_ROOT/lib/libuuid.so}          \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIRS=$UUID_ROOT/include}            \
+      ${UUID_ROOT:+-DUUID_INCLUDE_DIR=$UUID_ROOT/include}             \
       -DENABLE_KRB5=OFF                                               \
       -DENABLE_READLINE=OFF                                           \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \


### PR DESCRIPTION
Second try for updating XRootD to 4.12.x series. Fixes xrd metalinks retry.

Fixed:
  - pick up libuuid from alidist on slc6
  - disable VOMS plugin (not available for the Mac)

To be merged after xjalienfs 1.1.0.

CC: @adriansev 