### PR TITLE
Update xjalienfs to 1.1.0

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.0.7"
+tag: "1.1.0"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Improves backwards compatibility, should work with any XRootD v4.x version.

CC: @adriansev 