### PR TITLE
Backport xjalienfs 1.1.0 and XRootD v4.12.1 to AliRoot 54

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.0.7"
+tag: "1.1.0"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -42,6 +42,7 @@ cmake "$BUILDDIR"                                                     \
       -DCMAKE_INSTALL_LIBDIR=lib                                      \
       -DENABLE_CRYPTO=ON                                              \
       -DENABLE_PERL=OFF                                               \
+      -DVOMSXRD_SUBMODULE=OFF                                         \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v4.11.1"
+tag: "v4.12.1"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"
@@ -45,7 +45,9 @@ cmake "$BUILDDIR"                                                     \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \
+      ${UUID_ROOT:+-DUUID_LIBRARY=$UUID_ROOT/lib/libuuid.so}          \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIRS=$UUID_ROOT/include}            \
+      ${UUID_ROOT:+-DUUID_INCLUDE_DIR=$UUID_ROOT/include}             \
       -DENABLE_KRB5=OFF                                               \
       -DENABLE_READLINE=OFF                                           \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \


### PR DESCRIPTION
Fixes:

 - Backwards compatibility in parsing remote and local file paths in alien.py #2257 
 - Bugfixes in processing XRootD metalinks (retry mechanism) #2256

CC: @adriansev 