### PR TITLE
configuration: bump to 2.4.1

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -1,6 +1,6 @@
 package: Configuration
 version: "%(tag_basename)s"
-tag:  v2.4.0
+tag:  v2.4.1
 requires:
   - curl
   - boost

--- a/configuration.sh
+++ b/configuration.sh
@@ -1,6 +1,6 @@
 package: Configuration
 version: "%(tag_basename)s"
-tag:  v2.2.6
+tag:  v2.4.0
 requires:
   - curl
   - boost


### PR DESCRIPTION
Required to have the string backend available.