### PR TITLE
add fmt to root includes

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -31,6 +31,5 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
 set FMT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FMT_ROOT \$FMT_ROOT
 prepend-path ROOT_INCLUDE_PATH \$FMT_ROOT/include
 EoF

--- a/fmt.sh
+++ b/fmt.sh
@@ -6,6 +6,8 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
+prepend_path:
+  ROOT_INCLUDE_PATH: "$FMT_ROOT/include"
 ---
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT -DFMT_TEST=OFF
@@ -27,4 +29,8 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+set FMT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv FMT_ROOT \$FMT_ROOT
+prepend-path ROOT_INCLUDE_PATH \$FMT_ROOT/include
 EoF


### PR DESCRIPTION
This is to avoid problens with compilation of macros if the header depending on the fmt is included.
@ktf Still, the fmt is not loaded by default by ``alienv enter O2/latest``, I had to add it explicitly. 
Should not this be done automatically since the fmt is in the dependencies list of ``o2.sh`` ?