### PR TITLE
Bump treelite to the latest version

### DIFF
--- a/treelite.sh
+++ b/treelite.sh
@@ -1,6 +1,6 @@
 package: treelite
 version: "%(tag_basename)s"
-tag: "a7a0839"
+tag: "8498081"
 source: https://github.com/dmlc/treelite
 requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Hi @ktf,
this is required to support xgboost 1.1 model application in AliPhysics tasks.

Ciao,
Max