### PR TITLE
Upgrade Rivet to 3.1.1

### DIFF
--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -1,7 +1,7 @@
 package: defaults-dev
 version: v1
 env:
-  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CXXFLAGS: "-fPIC -g -O2 -std=c++14"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "2.7.2-alice8"
+tag: "3.1.1"
 source: https://github.com/alisw/rivet
 requires:
   - GSL

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,6 +1,6 @@
 package: YODA
 version: "%(tag_basename)s"
-tag: "v1.7.4"
+tag: "v1.8.2"
 source: https://github.com/alisw/yoda
 requires:
   - boost


### PR DESCRIPTION
This PR upgrades Rivet to v3.1.1.
It comes also with an upgraded YODA.