### PR TITLE
Bump to patched Pythia8 for floating point exception in Ropewalk.cc (…

### DIFF
--- a/pythia.sh
+++ b/pythia.sh
@@ -1,6 +1,6 @@
 package: pythia
 version: "%(tag_basename)s"
-tag: v8243
+tag: v8243-alice1
 source: https://github.com/alisw/pythia8
 requires:
   - lhapdf


### PR DESCRIPTION
…by C.Bierlich)

This PR bumps Pythia8 to a patched version of v8.243.
The patch was provided by Pythia8 authors.
The discussion of the issue is documented in JIRA
https://alice.its.cern.ch/jira/browse/ALIROOT-8488

