### PR TITLE
xjalienfs.sh:: update tag to 1.2.0

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.1.0"
+tag: "1.2.0"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Quite a long list of changes and internal change of python module location name prompted to update version to 1.2.0
Moreover now the package is also found in pypi under the name of `alienpy`