### PR TITLE
Bump geant3 v3-5, v2-7-p2

### DIFF
--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -46,8 +46,8 @@ overrides:
 
   # Use VMC packages compatible with ROOT 5
   GEANT3:
-    version: "v2-7-p1"
-    tag: "v2-7-p1"
+    version: "v2-7-p2"
+    tag: "v2-7-p2"
   GEANT4_VMC:
     version: "v3-6-p6-inclxx-biasing-p2"
     tag: "v3-6-p6-inclxx-biasing-p2"

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -46,8 +46,8 @@ overrides:
 
   # Use VMC packages compatible with ROOT 5
   GEANT3:
-    version: "v2-7-p1"
-    tag: "v2-7-p1"
+    version: "v2-7-p2"
+    tag: "v2-7-p2"
   GEANT4_VMC:
     version: "v3-6-p6-inclxx-biasing-p2"
     tag: "v3-6-p6-inclxx-biasing-p2"

--- a/geant3.sh
+++ b/geant3.sh
@@ -1,6 +1,6 @@
 package: GEANT3
 version: "%(tag_basename)s"
-tag: v3-4
+tag: v3-5
 requires:
   - ROOT
 build_requires:


### PR DESCRIPTION
These versions include:
  - Update masses of long lived particles possibly decayed by G3
    (thanks to Ch. Zampolli, CERN)
  - Fix floating point roundoff error in addressing the zebra array
    (thanks to Jason Webb, BNL, STAR Experiment)
