### PR TITLE
Request to add Future python package to module list

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -25,6 +25,7 @@ env:
     dryable==1.0.3
     responses==0.10.6
     RootInteractive==0.0.10
+    future==0.18.2
 ---
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
ApMon needs `past.utils` function from the `future` package to run. As this package is not available on the nodes, it is not possible to run python implementation of ApMon on the nodes at the moment. This PR is a request to add this package to the python modules list in CVMFS in order to get ApMon Python implementation get working on the nodes.
@Atlantic777 can you check this please?