### PR TITLE
Bump HepMC3 to 3.2.2

### DIFF
--- a/hepmc3.sh
+++ b/hepmc3.sh
@@ -13,7 +13,8 @@ build_requires:
 cmake  $SOURCEDIR                          \
        -DROOT_DIR=$ROOT_ROOT               \
        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
-       -DCMAKE_INSTALL_LIBDIR=lib
+       -DCMAKE_INSTALL_LIBDIR=lib          \
+       -DHEPMC3_ENABLE_PYTHON=OFF
 
 make ${JOBS+-j $JOBS}
 make install

--- a/hepmc3.sh
+++ b/hepmc3.sh
@@ -1,6 +1,6 @@
 package: HepMC3
-version: "v3.0.0-git_%(short_hash)s"
-tag: d43693ce0e7731e9b787dbd6176cb6245fd770b3
+version: "%(tag_basename)s"
+tag: 3.2.2
 source: https://gitlab.cern.ch/hepmc/HepMC3.git
 requires:
   - GCC-Toolchain:(?!osx.*)


### PR DESCRIPTION
This PR bumps `HepMC3` to tag version 3.2.2.
It comes with an incompatibility with the current `o2` software, so the check will fail.
Please, refer to https://github.com/AliceO2Group/AliceO2/pull/3941 for further details.

For this PR to be successful, merging with the above `o2` PR must be simultaneous.