### PR TITLE
Bump geant4_vmc v5-0-p5:

### DIFF
--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v5-0-p4"
+tag: "v5-0-p5"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT


### PR DESCRIPTION
This includes new commands for user control of the parameters for killing looping particles.
Needed for fixing https://alice.its.cern.ch/jira/browse/O2-1515.