### PR TITLE
Bump to 3.1.1-alice1 patched version, plus other fixes

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,6 +1,6 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "3.1.1"
+tag: "3.1.1-alice1"
 source: https://github.com/alisw/rivet
 requires:
   - GSL
@@ -87,7 +87,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${GSL_REVISION:+GSL/$GSL_VERSION-$GSL_REVISION} YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
+module load BASE/1.0 ${GSL_REVISION:+GSL/$GSL_VERSION-$GSL_REVISION} ${CGAL_REVISION:+cgal/$CGAL_VERSION-$CGAL_REVISION} ${GMP_REVISION:+GMP/$GMP_VERSION-$GMP_REVISION} YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
 # Our environment
 set RIVET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv RIVET_ROOT \$RIVET_ROOT
@@ -103,7 +103,7 @@ prepend-path LD_LIBRARY_PATH \$RIVET_ROOT/lib
 # (TEXMFHOME, HOMETEXMF, TEXMFCNF, TEXINPUTS, LATEXINPUTS)
 # Here trying to keep the env variable changes to their minimum, i.e touch only TEXINPUTS, LATEXINPUTS
 # Manual prepend-path for TEX variables
-set Old_TEXINPUTS [exec kpsewhich -var-value TEXINPUTS]
+set Old_TEXINPUTS [exec which kpsewhich > /dev/null 2>&1 && kpsewhich -var-value TEXINPUTS]
 set Extra_RivetTEXINPUTS \$RIVET_ROOT/share/Rivet/texmf/tex//
 setenv TEXINPUTS  \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS
 setenv LATEXINPUTS \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS


### PR DESCRIPTION
This PR bumps Rivet to the tagger version `3.3.1-alice1`.
This specific version contains a fix for a few relocation issues that are encountered when running `rivet-build`.

Another issue that is fixed by this PR is the missing `$GMP_ROOT` variable, because none of the modules are loading `GMP`.
So, to make sure of their presence, both `CGAL` and `GMP` modules are explicitly loaded.

Another issue that is fixed is due to the potential missing presence of `kpsewhich`, which makes the loading of the module fail.
For instance, in `alidock` it is not there. A check for the presence of it is added.
