### PR TITLE
replace pip3 calls with "python3 -m pip"

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -30,15 +30,16 @@ fi
 PYTHON_MODULES_INSTALLROOT=$INSTALLROOT/share/python-modules
 mkdir -p $PYTHON_MODULES_INSTALLROOT
 # Install setuptools upfront, since this seems to create issues now...
-env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" pip3 install --user -IU setuptools
+env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" python3 -m pip install --user -IU setuptools
+env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" python3 -m pip install --user -IU wheel
 # FIXME: required because of the newly introduced dependency on scikit-garden requires
 # a numpy to be installed separately
 # See also:
 #   https://github.com/scikit-garden/scikit-garden/issues/23
-grep RootInteractive requirements.txt && env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" pip3 install --user -IU numpy
+grep RootInteractive requirements.txt && env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" python3 -m pip install --user -IU numpy
 # Do not move cython from 0.29.06 for now since 3.0.0rc1 breaks on GPU
-grep RootInteractive requirements.txt && env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" pip3 install --user -IU cython==0.29.16
-env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" pip3 install --user -IU -r requirements.txt
+grep RootInteractive requirements.txt && env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" python3 -m pip install --user -IU cython==0.29.16
+env PYTHONUSERBASE="$PYTHON_MODULES_INSTALLROOT" python3 -m pip install --user -IU -r requirements.txt
 
 # Find the proper Python lib library and export it
 pushd "$PYTHON_MODULES_INSTALLROOT"
@@ -61,7 +62,7 @@ popd
 MATPLOTLIB_TAG="3.0.3"
 if [[ $ARCHITECTURE != slc* ]]; then
   # Simply get it via pip in most cases
-  env PYTHONUSERBASE=$PYTHON_MODULES_INSTALLROOT pip3 install --user "matplotlib==$MATPLOTLIB_TAG"
+  env PYTHONUSERBASE=$PYTHON_MODULES_INSTALLROOT python3 -m pip install --user "matplotlib==$MATPLOTLIB_TAG"
 else
 
   # We are on a RHEL-compatible OS. We compile it ourselves, and link it to our dependencies

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -12,7 +12,7 @@ requires:
 #!/bin/bash -e
 
 # env PYTHONUSERBASE="$INSTALLROOT" pip3 install --user -r alibuild_requirements.txt
-env PYTHONUSERBASE="$INSTALLROOT" ALIBUILD=1 pip3 install --user file://${SOURCEDIR}
+env PYTHONUSERBASE="$INSTALLROOT" ALIBUILD=1 python3 -m pip install --user file://${SOURCEDIR}
 
 sed -i".bak" 's/#!.*python.*/#!\/usr\/bin\/env python3/' ${INSTALLROOT}/bin/*
 rm -v ${INSTALLROOT}/bin/*.bak


### PR DESCRIPTION
Replaces pip3 calls in python-modules.sh and xjalienfs.sh with "python3 -m pip", to avoid possible errors with local pip installation ("No module named 'pip._internal'")