### PR TITLE
Trigger YODA by removing useless line

### DIFF
--- a/yoda.sh
+++ b/yoda.sh
@@ -22,9 +22,6 @@ make -j$JOBS
 make install
 )
 
-### list the content of lib directory
-ls -ld $INSTALLROOT/lib
-
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
This PR is to trigger YODA build on Jenkins.
It is related to a issue that must be solved properly.
Actually the issue is with Rivet, but a YODA rebuild will cause Rivet to be built as well.