### PR TITLE
python-modules: drop own build of matplotlib

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -57,46 +57,6 @@ pushd "$PYTHON_MODULES_INSTALLROOT"
   popd
 popd
 
-# Install matplotlib (quite tricky)
-MATPLOTLIB_TAG="3.0.3"
-if [[ $ARCHITECTURE != slc* ]]; then
-  # Simply get it via pip in most cases
-  env PYTHONUSERBASE=$PYTHON_MODULES_INSTALLROOT pip3 install --user "matplotlib==$MATPLOTLIB_TAG"
-else
-
-  # We are on a RHEL-compatible OS. We compile it ourselves, and link it to our dependencies
-
-  # Check if we can enable the Tk interface
-  python3 -c 'import _tkinter' && MATPLOTLIB_TKAGG=True || MATPLOTLIB_TKAGG=False
-  MATPLOTLIB_URL="https://github.com/matplotlib/matplotlib/archive/v${MATPLOTLIB_TAG}.tar.gz"  # note the "v"
-  curl -SsL "$MATPLOTLIB_URL" | tar xzf -
-  cd matplotlib-*
-  cat > setup.cfg <<EOF
-[directories]
-basedirlist  = ${FREETYPE_ROOT:+$PWD/fake_freetype_root,$FREETYPE_ROOT,}${LIBPNG_ROOT:+$LIBPNG_ROOT,}${ZLIB_ROOT:+$ZLIB_ROOT,}/usr/X11R6,$(freetype-config --prefix),$(libpng-config --prefix)
-[gui_support]
-gtk = False
-gtkagg = False
-tkagg = $MATPLOTLIB_TKAGG
-wxagg = False
-macosx = False
-EOF
-
-  # matplotlib wants include files in <PackageRoot>/include, but this is not the case for FreeType
-  if [[ $FREETYPE_ROOT ]]; then
-    mkdir fake_freetype_root
-    ln -nfs $FREETYPE_ROOT/include/freetype2 fake_freetype_root/include
-  fi
-
-  export PYTHONPATH="$PYTHON_MODULES_INSTALLROOT/lib/python/site-packages"
-    python3 setup.py build
-    python3 setup.py install --prefix "$PYTHON_MODULES_INSTALLROOT"
-  unset PYTHONPATH
-fi
-
-# Test if matplotlib can be loaded
-env PYTHONPATH="$PYTHON_MODULES_INSTALLROOT/lib/python/site-packages" python3 -c 'import matplotlib'
-
 # Patch long shebangs (by default max is 128 chars on Linux)
 pushd "$PYTHON_MODULES_INSTALLROOT/bin"
   sed -i.deleteme -e '1 s|^#!.*$|#!/usr/bin/env python3|' * || true


### PR DESCRIPTION
As it is done right now, it simply does not work. What is really happening is that we pick up some matplotlib from the indirect dependencies (and breaks when the implicit dependency is not there, like in the case of the o2-dataflow).