### PR TITLE
Add -LGMP_ROOT/lib to LD_LIBRARY_PATH

### DIFF
--- a/herwig.sh
+++ b/herwig.sh
@@ -18,7 +18,7 @@ export LHAPDF_DATA_PATH="$LHAPDF_ROOT/share/LHAPDF:$LHAPDF_PDFSETS_ROOT/share/LH
 
 [[ -e .missing_timestamps ]] && ./missing-timestamps.sh --apply || autoreconf -ivf
 [[ $ALIEN_RUNTIME_VERSION ]] && LDZLIB="-L$ALIEN_RUNTIME_ROOT/lib" || { [[ $ZLIB_VERSION ]] && LDZLIB="-L$ZLIB_ROOT/lib" || LDZLIB= ; }
-export LDFLAGS="-L$LHAPDF_ROOT/lib -L$CGAL_ROOT/lib $LDZLIB"
+export LDFLAGS="-L$LHAPDF_ROOT/lib -L$CGAL_ROOT/lib -L$GMP_ROOT/lib $LDZLIB"
 ./configure                        \
     --prefix="$INSTALLROOT"        \
     --with-thepeg="${THEPEG_ROOT}" \


### PR DESCRIPTION
Should fix error concerning missing -lgmp with current herwig builds