### PR TITLE
Remove libRivet.la as it creates relocation problems in ThePEG

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -62,6 +62,9 @@ make -j$JOBS
 make install
 )
 
+# Remove libRivet.la
+rm $INSTALLROOT/lib/libRivet.la
+
 # Dependencies relocation: rely on runtime environment
 SED_EXPR="s!x!x!"  # noop
 for P in $REQUIRES $BUILD_REQUIRES; do


### PR DESCRIPTION
This PR should fix a issue observed in `ThePEG` which derives from `Rivet`.
By removing the `libRivet.la` file from the `Rivet` installation dir we avoid that.