### PR TITLE
Update GEANT4_VMC: v3-6-p6-inclxx-biasing-p3

### DIFF
--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -16,8 +16,8 @@ overrides:
     version: "v2-7-p2"
     tag: "v2-7-p2"
   GEANT4_VMC:
-    version: "v3-6-p6-inclxx-biasing-p2"
-    tag: "v3-6-p6-inclxx-biasing-p2"
+    version: "v3-6-p6-inclxx-biasing-p3"
+    tag: "v3-6-p6-inclxx-biasing-p3"
   GEANT4:
     source: https://github.com/alisw/geant4.git
     version: "v10.4.2-alice3"

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -17,8 +17,8 @@ overrides:
     version: "v2-7-p2"
     tag: "v2-7-p2"
   GEANT4_VMC:
-    version: "v3-6-p6-inclxx-biasing-p2"
-    tag: "v3-6-p6-inclxx-biasing-p2"
+    version: "v3-6-p6-inclxx-biasing-p3"
+    tag: "v3-6-p6-inclxx-biasing-p3"
   GEANT4:
     source: https://github.com/alisw/geant4.git
     version: "v10.4.2-alice3"


### PR DESCRIPTION
This version includes a fix in FindROOT.cmake which should hopefully fix the build problem in AliPhysics v5-09-02h.