### PR TITLE
[WIP] Bump llvm/clang to 10.0.1

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -54,8 +54,6 @@ esac
 mkdir -p ./src_tmp
 rsync -a --exclude='**/.git' --delete --delete-excluded "$SOURCEDIR/" ./src_tmp/
 CLANG_VERSION_SHORT=`echo $CLANG_VERSION | sed "s/\.[0-9]*\$//" | sed "s/^v//"`
-sed -i.deleteme -e "s/set(ARROW_LLVM_VERSION \".*\")/set(ARROW_LLVM_VERSION \"$CLANG_VERSION_SHORT\")/" "./src_tmp/cpp/CMakeLists.txt" || true
-sed -i.deleteme -e "s/set(ARROW_LLVM_VERSIONS \".*\")/set(ARROW_LLVM_VERSIONS \"$CLANG_VERSION_SHORT\")/" "./src_tmp/cpp/CMakeLists.txt" || true
 
 case $ARCHITECTURE in
   osx*) ;;

--- a/clang.sh
+++ b/clang.sh
@@ -1,6 +1,6 @@
 package: Clang
-version: "v9.0.0"
-tag: "llvmorg-9.0.0"
+version: "v10.0.1"
+tag: "llvmorg-10.0.1"
 source: https://github.com/llvm/llvm-project
 requires:
  - "Python:slc.*"


### PR DESCRIPTION
@pzhristov @ktf @aalkin : It turns out arrow 1.0.0 supports also clang10, 0.17.1 doesn't.
But apparently, we have some customization in our arrow. Could this be rebased to arrow 1.0.0, then we can try to bump clang.

For reference, I tried this locally with my system installation of clang 10, and building arrow failed (even though clang 10 should be supported), but this might be due to the way the system installation is built.