### PR TITLE
Bump Delphes to v20200823

### DIFF
--- a/delphes.sh
+++ b/delphes.sh
@@ -1,6 +1,6 @@
 package: Delphes
 version: "%(tag_basename)s"
-tag: master
+tag: v20200823
 requires:
   - ROOT
   - HepMC


### PR DESCRIPTION
This PR bumps `Delphes` to the tag of today `v20200823`