### PR TITLE
Add -ltbb to EXTRA_LIBS

### DIFF
--- a/debuggui.sh
+++ b/debuggui.sh
@@ -22,7 +22,7 @@ case $ARCHITECTURE in
     ;;
     *) 
       DEFINES="-DIMGUI_IMPL_OPENGL_LOADER_GL3W -DTRACY_NO_FILESELECTOR"
-      EXTRA_LIBS="-lGL"
+      EXTRA_LIBS="-lGL -ltbb"
       [[ ! $FREETYPE_ROOT ]] && FREETYPE_ROOT="/usr"       
     ;;
 esac


### PR DESCRIPTION
I needed to explicitly add `-ltbb` to `debuggui.sh` receipt to have it successfully compiled on `ubuntu2004_x86-64`.
I am not sure this is the right way to do it, opened the PR anyway.