### PR TITLE
Modify Geant4 recipe to allow an external directory for data sets, clean-up:

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -28,7 +28,7 @@ env:
   G4SAIDXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4SAIDXSDATA | sed 's/[^ ]* [^ ]* //'`"
 
 ---
-# if this variable is not defined default it to OFF
+# If this variable is not defined default it to OFF
 : ${GEANT4_BUILD_MULTITHREADED:=OFF}
 
 # Data sets directory:

--- a/geant4.sh
+++ b/geant4.sh
@@ -14,64 +14,55 @@ incremental_recipe: |
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 env:
   G4INSTALL : $GEANT4_ROOT
-  G4DATASEARCHOPT : "-mindepth 2 -maxdepth 4 -type d -wholename"
-  G4ABLADATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4ABLA*'`"  ## v10.4.px only
-  G4ENSDFSTATEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4ENSDFSTATE*'`"
-  G4INCLDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4INCL*'`"  ## v10.5.px only
-  G4LEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4EMLOW*'`"
-  G4LEVELGAMMADATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*PhotonEvaporation*'`"
-  G4NEUTRONHPDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4NDL*'`"
-  G4NEUTRONXSDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4NEUTRONXS*'`"   ## v10.4.px only
-  G4PARTICLEXSDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4PARTICLEXS*'`"   ## v10.5.px only
-  G4PIIDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4PII*'`"
-  G4RADIOACTIVEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*RadioactiveDecay*'`"
-  G4REALSURFACEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*RealSurface*'`"
-  G4SAIDXSDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT  '*data*G4SAIDDATA*'`"
+  G4ABLADATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4ABLADATA | sed 's/[^ ]* [^ ]* //'`"
+  G4ENSDFSTATEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4ENSDFSTATEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4INCLDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4INCLDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4LEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4LEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4LEVELGAMMADATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4LEVELGAMMADATA | sed 's/[^ ]* [^ ]* //'`"
+  G4NEUTRONHPDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4NEUTRONHPDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4NEUTRONXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4NEUTRONXSDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4PARTICLEXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4PARTICLEXSDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4PIIDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4PIIDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4RADIOACTIVEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4RADIOACTIVEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4REALSURFACEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4REALSURFACEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4SAIDXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4SAIDXSDATA | sed 's/[^ ]* [^ ]* //'`"
 
 ---
 # if this variable is not defined default it to OFF
 : ${GEANT4_BUILD_MULTITHREADED:=OFF}
 
-cmake $SOURCEDIR                                             \
-  -DGEANT4_INSTALL_DATA_TIMEOUT=2000                         \
-  -DCMAKE_CXX_FLAGS="-fPIC"                                  \
-  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                 \
-  -DCMAKE_INSTALL_LIBDIR="lib"                               \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo                          \
-  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"           \
-  -DGEANT4_ENABLE_TESTING=OFF                                \
-  -DBUILD_SHARED_LIBS=ON                                     \
-  -DGEANT4_INSTALL_EXAMPLES=OFF                              \
-  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT"                        \
-  -DGEANT4_BUILD_MULTITHREADED="$GEANT4_BUILD_MULTITHREADED" \
-  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"                   \
-  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"                     \
-  -DGEANT4_USE_G3TOG4=ON                                     \
-  -DGEANT4_INSTALL_DATA=ON                                   \
-  -DGEANT4_USE_SYSTEM_EXPAT=OFF                              \
-  ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}          \
-  ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                   \
+# Data sets directory:
+# if not set (default), data sets will be installed in CMAKE_INSTALL_DATAROOTDIR
+: ${GEANT4_DATADIR:=""}
+
+cmake $SOURCEDIR                                                \
+  -DGEANT4_INSTALL_DATA_TIMEOUT=2000                            \
+  -DCMAKE_CXX_FLAGS="-fPIC"                                     \
+  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                    \
+  -DCMAKE_INSTALL_LIBDIR="lib"                                  \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo                             \
+  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"              \
+  -DGEANT4_ENABLE_TESTING=OFF                                   \
+  -DBUILD_SHARED_LIBS=ON                                        \
+  -DGEANT4_INSTALL_EXAMPLES=OFF                                 \
+  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT"                           \
+  -DGEANT4_BUILD_MULTITHREADED="$GEANT4_BUILD_MULTITHREADED"    \
+  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"                      \
+  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"                        \
+  -DGEANT4_USE_G3TOG4=ON                                        \
+  -DGEANT4_INSTALL_DATA=ON                                      \
+  ${GEANT4_DATADIR:+-DGEANT4_INSTALL_DATADIR="$GEANT4_DATADIR"} \
+  -DGEANT4_USE_SYSTEM_EXPAT=OFF                                 \
+  ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}             \
+  ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                      \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS}
 make install
 
-# auto discovery of installation paths of G4 DATA
-# in order to avoid putting hard-coded version numbers (which change with every G4 tag)
-# these variables are used to create the modulefile below
-G4DATASEARCHOPT="-mindepth 2 -maxdepth 4 -type d -wholename"
-G4ABLADATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4ABLA*'`
-G4ENSDFSTATEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4ENSDFSTATE*'`
-G4INCLDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4INCL*'`
-G4LEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4EMLOW*'`
-G4LEVELGAMMADATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*PhotonEvaporation*'`
-G4NEUTRONHPDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4NDL*'`
-G4NEUTRONXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4NEUTRONXS*'`
-G4PARTICLEXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4PARTICLEXS*'`
-G4PIIDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4PII*'`
-G4RADIOACTIVEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*RadioactiveDecay*'`
-G4REALSURFACEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*RealSurface*'`
-G4SAIDXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT  '*data*G4SAIDDATA*'`
+# Install data sets
+# Can be done after Geant4 installation, if installed with -DGEANT4_INSTALL_DATA=OFF
+# ./geant4-config --install-datasets
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
@@ -88,28 +79,11 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${XERCESC_REVISION:+xercesc/$XERCESC_REVISION-$XERCESC_REVISION}
 # Our environment
-set osname [uname sysname]
 set GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv GEANT4_ROOT \$GEANT4_ROOT
-setenv G4INSTALL \$GEANT4_ROOT
-setenv G4INSTALL_DATA \$GEANT4_ROOT/share/
-setenv G4SYSTEM \$osname-g++
-
-setenv G4ABLADATA ${G4ABLADATA:-not-defined}
-setenv G4ENSDFSTATEDATA ${G4ENSDFSTATEDATA:-not-defined}
-setenv G4INCLDATA ${G4INCLDATA:-not-defined}
-setenv G4LEDATA ${G4LEDATA:-not-defined}
-setenv G4LEVELGAMMADATA ${G4LEVELGAMMADATA:-not-defined}
-setenv G4NEUTRONHPDATA ${G4NEUTRONHPDATA:-not-defined}
-setenv G4NEUTRONXSDATA ${G4NEUTRONXSDATA:-not-defined}
-setenv G4PARTICLEXSDATA ${G4PARTICLEXSDATA:-not-defined}
-setenv G4PIIDATA ${G4PIIDATA:-not-defined}
-setenv G4RADIOACTIVEDATA  ${G4RADIOACTIVEDATA:-not-defined}
-setenv G4REALSURFACEDATA ${G4REALSURFACEDATA:-not-defined}
-setenv G4SAIDXSDATA ${G4SAIDXSDATA:-not-defined}
-set G4BASE \$GEANT4_ROOT
 prepend-path PATH \$GEANT4_ROOT/bin
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include/Geant4
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include
 prepend-path LD_LIBRARY_PATH \$GEANT4_ROOT/lib
 EoF
+
+# Data sets environment
+$INSTALLROOT/bin/geant4-config --datasets |  sed 's/[^ ]* //' | sed 's/G4/setenv G4/' >> "$MODULEFILE"


### PR DESCRIPTION
- Added GEANT4_DATADIR variable which allows to override the default installation
  path for data sets (CMAKE_INSTALL_DATAROOTDIR)
- Replaced auto discovery of data installation paths (not working when data for more Geant4
  versions are installed in the same directory) with use of geant4-config script
- Removed G4INSTALL, G4INSTALL_DATA, G4SYSTEM env variables (not needed)
- Removed appending ROOT_INCLUDE_PATH with Geant4 includes (not needed)