### PR TITLE
xjalienfs 1.2.4 hotfix

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.2.3"
+tag: "1.2.4"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* 0a93283 getEnvelope_lfn:: protect against access failure
* d1b6d7b intercept user change, and update the recorded homedir
* 6ad82a2 fix cd behaviour
* 259e5a8 disable fallback to system cmds; protect againt printing empty lines; allow empty ps args