### PR TITLE
Fix for compilation with XCode 12

### DIFF
--- a/debuggui.sh
+++ b/debuggui.sh
@@ -19,6 +19,7 @@ case $ARCHITECTURE in
       [[ ! $LIBUV_ROOT ]] && LIBUV_ROOT=`brew --prefix libuv`
       [[ ! $FREETYPE_ROOT ]] && FREETYPE_ROOT=`brew --prefix freetype`
       EXTRA_LIBS="-framework CoreFoundation -framework AppKit"
+      DEFINES="-DNO_PARALLEL_SORT"
     ;;
     *) 
       DEFINES="-DIMGUI_IMPL_OPENGL_LOADER_GL3W -DTRACY_NO_FILESELECTOR"


### PR DESCRIPTION
Don't know what are the exact consequences of the introduction of the NO_PARALLEL_SORT compilation flag (found by simple googling), but at least it got me past the compilation failure under Xcode 12...