### PR TITLE
Fix tcl command for TEXINPUTS in modulefile

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -106,7 +106,7 @@ prepend-path LD_LIBRARY_PATH \$RIVET_ROOT/lib
 # (TEXMFHOME, HOMETEXMF, TEXMFCNF, TEXINPUTS, LATEXINPUTS)
 # Here trying to keep the env variable changes to their minimum, i.e touch only TEXINPUTS, LATEXINPUTS
 # Manual prepend-path for TEX variables
-set Old_TEXINPUTS [exec which kpsewhich > /dev/null 2>&1 && kpsewhich -var-value TEXINPUTS]
+set Old_TEXINPUTS [exec sh -c "which kpsewhich > /dev/null 2>&1 && kpsewhich -var-value TEXINPUTS"]
 set Extra_RivetTEXINPUTS \$RIVET_ROOT/share/Rivet/texmf/tex//
 setenv TEXINPUTS  \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS
 setenv LATEXINPUTS \$Old_TEXINPUTS:\$Extra_RivetTEXINPUTS


### PR DESCRIPTION
On certain platforms the previous version
of the command leaded to a child error
in the command execution. Specifying that
the command should be executed as bash
command fixed the problem.