### PR TITLE
Switch defaults jalien to TJAlien 0.6.x branch with TNetXrdNG backend

### DIFF
--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -1,7 +1,7 @@
 package: Alice-GRID-Utils
 version: "%(tag_basename)s"
 tag: "0.0.6"
-source: https://gitlab.cern.ch/nhardi/alice-grid-utils.git
+source: https://gitlab.cern.ch/jalien/alice-grid-utils.git
 ---
 #!/bin/bash -e
 

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -15,7 +15,14 @@ overrides:
     version: "%(tag_basename)s_JALIEN"
     tag: v5-09-54a-01
   autotools:
+    version: "%(tag_basename)s_JALIEN"
     tag: v1.5.0
+  JAliEn-ROOT:
+    version: "%(tag_basename)s"
+    tag: 0.6.1
+  Alice-GRID-Utils:
+    version: "%(tag_basename)s"
+    tag: 0.0.7
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
This change affects only AliPhysics _JALIEN dev daily builds, keeping the ROOT6 builds on TJAlien 0.5.x for the moment.