### PR TITLE
curl is a dependency of ppconsul

### DIFF
--- a/ppconsul.sh
+++ b/ppconsul.sh
@@ -5,6 +5,7 @@ source: https://github.com/oliora/ppconsul
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"
+  - curl
 build_requires:
   - CMake
 ---


### PR DESCRIPTION
This fixes https://alice.its.cern.ch/jira/browse/O2-1723
for me.
The recipe already used CURL_ROOT but the dependency was
not expressed in the requirements.