### PR TITLE
aligenmc - Upgrade to v0.0.6

### DIFF
--- a/aligenmc.sh
+++ b/aligenmc.sh
@@ -1,6 +1,6 @@
 package: aligenmc
 version: "%(tag_basename)s"
-tag: "v0.0.5"
+tag: "v0.0.6"
 source: https://github.com/alisw/aligenmc
 ---
 #!/bin/bash -e


### PR DESCRIPTION
New tag, needed for ongoing updates on the front (Herwig, with kT hard thresholds, MB and UE params + AliRoot, with HEPmc headers).
Such features are needed for MC Lego trains (standalone Herwig launched via aligenmc -> HEPmc -> AliRoot -> AliAnalysisTask).
See PR https://github.com/alisw/AliRoot/pull/1241 in AliRoot, and https://github.com/alisw/aligenmc/pull/6 in aligenmc