### PR TITLE
Switch all JAliEn-ROOT builds to v0.6.x with TNetXNG backend

### DIFF
--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -1,6 +1,6 @@
 package: Alice-GRID-Utils
 version: "%(tag_basename)s"
-tag: "0.0.6"
+tag: "0.0.7"
 source: https://gitlab.cern.ch/jalien/alice-grid-utils.git
 ---
 #!/bin/bash -e

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -17,12 +17,6 @@ overrides:
   autotools:
     version: "%(tag_basename)s_JALIEN"
     tag: v1.5.0
-  JAliEn-ROOT:
-    version: "%(tag_basename)s"
-    tag: 0.6.1
-  Alice-GRID-Utils:
-    version: "%(tag_basename)s"
-    tag: 0.0.7
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -27,6 +27,9 @@ overrides:
   XRootD:
     tag: v3.3.6-alice2
     source: https://github.com/alisw/xrootd.git
+  Alice-Grid-Utils:
+    version: "%(tag_basename)s"
+    tag: 0.0.6
   # Use ROOT 5
   ROOT:
     tag: v5-34-30-alice10

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -27,7 +27,7 @@ overrides:
   XRootD:
     tag: v3.3.6-alice2
     source: https://github.com/alisw/xrootd.git
-  Alice-Grid-Utils:
+  Alice-GRID-Utils:
     version: "%(tag_basename)s"
     tag: 0.0.6
   # Use ROOT 5

--- a/defaults-user.sh
+++ b/defaults-user.sh
@@ -29,6 +29,9 @@ overrides:
   XRootD:
     tag: v3.3.6-alice2
     source: https://github.com/alisw/xrootd.git
+  Alice-GRID-Utils:
+    version: "%(tag_basename)s"
+    tag: 0.0.6
 
   # Use ROOT 5
   ROOT:

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.6.1"
+tag: "0.6.2"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.5.5"
+tag: "0.6.1"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
This commit enables JAliEn-ROOT 0.6.x branch with TNetXNG backend for all JAliEn based builds including O2, AliPhysics_ROOT6 and AliPhysics_JALIEN. The ROOT5 build stays with the current TXNetFile backend.