### PR TITLE
Add Pythia8 include directory to ROOT_INCLUDE_PATH

### DIFF
--- a/pythia.sh
+++ b/pythia.sh
@@ -56,4 +56,5 @@ setenv PYTHIA8DATA \$PYTHIA_ROOT/share/Pythia8/xmldoc
 setenv PYTHIA8 \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$PYTHIA_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$PYTHIA_ROOT/lib
+prepend-path ROOT_INCLUDE_PATH \$PYTHIA_ROOT/include
 EoF


### PR DESCRIPTION
This PR might solve issues recently observed running `o2-sim`.
Perhaps linked to a new ROOT behaviour.

```
G__O2Generators dictionary payload:1025:10: fatal error: 'Pythia8/Pythia.h' file not found
#include "Pythia8/Pythia.h"
```

Hopefully adding Pythia8 include dirs to the ROOT_INCLUDE_PATH solves the problem.