### PR TITLE
Bump to v0.0.7-1

### DIFF
--- a/aligenmc.sh
+++ b/aligenmc.sh
@@ -1,6 +1,6 @@
 package: aligenmc
 version: "%(tag_basename)s"
-tag: "v0.0.7"
+tag: "v0.0.7-1"
 source: https://github.com/alisw/aligenmc
 ---
 #!/bin/bash -e


### PR DESCRIPTION
Version including fixes for
- max kt-hard
- Stable particles in Herwig
- Running with aligenerator package already loaded