### PR TITLE
Fix: temporarily disable libjalienws for JAliEn-ROOT

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -5,7 +5,6 @@ source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT
   - xjalienfs
-  - libjalienws
   - XRootD
 build_requires:
   - libwebsockets


### PR DESCRIPTION
Disabling libjalienws for the moment until the issue with linking to OpenSSL is resolved. JAliEn-ROOT can still work without it.

cc @costing @ktf @odatskov