### PR TITLE
Set AGU version to 0.0.6 for ROOT5 build in defaults-release

### DIFF
--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -27,6 +27,9 @@ overrides:
   XRootD:
     tag: v3.3.6-alice2
     source: https://github.com/alisw/xrootd.git
+  Alice-GRID-Utils:
+    version: "%(tag_basename)s"
+    tag: 0.0.6
   # Use ROOT 5
   ROOT:
     tag: v5-34-30-alice10


### PR DESCRIPTION
For ROOT5 and AliEn-ROOT-Legacy we should use AGU 0.0.6. The version override is specified in defaults prod-latest but missing in defaults release. This should fix the failing PR checks in AliRoot repo and other scenarios where ROOT5 builds failed with XRootD errors.

cc @chiarazampolli @marcovanleeuwen 