### PR TITLE
Bump FairMQ to v1.4.26

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.25
+tag: v1.4.26
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Upon request from @AndreyLebedev, related to the ongoing DDS/ODC developments.

@Barthelemy this also includes the changes discussed in https://github.com/AliceO2Group/InfoLogger/pull/52.