### PR TITLE
Change realpath to readlink in xrootd script

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -15,7 +15,7 @@ build_requires:
 ---
 #!/bin/bash -e
 [[ -e $SOURCEDIR/bindings ]] && XROOTD_V4=True && XROOTD_PYTHON=True || XROOTD_PYTHON=False
-PYTHON_EXECUTABLE=$( $(readlink -f $(which python3)) -c 'import sys; print(sys.executable)')
+PYTHON_EXECUTABLE=$( $(readlink $(which python3)) -c 'import sys; print(sys.executable)')
 
 case $ARCHITECTURE in
   osx*)

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -15,7 +15,7 @@ build_requires:
 ---
 #!/bin/bash -e
 [[ -e $SOURCEDIR/bindings ]] && XROOTD_V4=True && XROOTD_PYTHON=True || XROOTD_PYTHON=False
-PYTHON_EXECUTABLE=$( $(realpath $(which python3)) -c 'import sys; print(sys.executable)')
+PYTHON_EXECUTABLE=$( $(readlink -f $(which python3)) -c 'import sys; print(sys.executable)')
 
 case $ARCHITECTURE in
   osx*)


### PR DESCRIPTION
This is needed for some SL6 systems. The same was done for some other packages, so it seems that readlink works for everyone.