### PR TITLE
bump readout v.1.5.2

### DIFF
--- a/readout.sh
+++ b/readout.sh
@@ -1,6 +1,6 @@
 package: Readout
 version: "%(tag_basename)s"
-tag: v1.4.7.2
+tag: v1.5.0
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"

--- a/readout.sh
+++ b/readout.sh
@@ -1,6 +1,6 @@
 package: Readout
 version: "%(tag_basename)s"
-tag: v1.5.1
+tag: v1.5.2
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"

--- a/readout.sh
+++ b/readout.sh
@@ -1,6 +1,6 @@
 package: Readout
 version: "%(tag_basename)s"
-tag: v1.5.0
+tag: v1.5.1
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
This version of readout uses the new STFB interface and does not work with previous STFB versions. Pending STFB bump.