### PR TITLE
Rdev delpheso2 root include

### DIFF
--- a/delphes.sh
+++ b/delphes.sh
@@ -1,6 +1,6 @@
 package: Delphes
 version: "%(tag_basename)s"
-tag: v20200823
+tag: v20201026
 requires:
   - ROOT
   - HepMC

--- a/delpheso2.sh
+++ b/delpheso2.sh
@@ -32,4 +32,5 @@ set DELPHESO2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv DELPHESO2_ROOT \$DELPHESO2_ROOT
 prepend-path PATH \$DELPHESO2_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$DELPHESO2_ROOT/lib
+prepend-path ROOT_INCLUDE_PATH \$DELPHESO2_ROOT/include
 EOF


### PR DESCRIPTION
This PR adds `DELPHESO2_ROOT/include` to `ROOT_INCLUDE_PATH` 