### PR TITLE
curl: disable ldap

### DIFF
--- a/curl.sh
+++ b/curl.sh
@@ -18,7 +18,7 @@ fi
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .
 
 ./buildconf
-./configure --prefix=$INSTALLROOT ${OPENSSL_ROOT:+--with-ssl=$OPENSSL_ROOT} --disable-static
+./configure --prefix=$INSTALLROOT --disable-ldap ${OPENSSL_ROOT:+--with-ssl=$OPENSSL_ROOT} --disable-static
 make ${JOBS:+-j$JOBS}
 make install
 
@@ -26,4 +26,3 @@ make install
 mkdir -p etc/modulefiles
 alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
-


### PR DESCRIPTION
Having ldap might bring in kerberos, which might have its own copy of ssl.