### PR TITLE
Update XRootD to 4.12.5 for _JALIEN builds

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -17,6 +17,9 @@ overrides:
   autotools:
     version: "%(tag_basename)s_JALIEN"
     tag: v1.5.0
+  XRootD:
+    version: "%(tag_basename)s_JALIEN"
+    tag: 4.12.5
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
For testing the latest and greatest XRootD 4.x on AliPhysics _JALIEN builds. This update doesn't affect AliPhysics analysis tags and O2 nightlies.