### PR TITLE
Bump fmt

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -1,6 +1,6 @@
 package: fmt
 version: "%(tag_basename)s"
-tag: 6.1.2
+tag: 7.1.0
 source: https://github.com/fmtlib/fmt
 requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
version 6 has a broken assertion which led to code being checked into O2 that will be incompatible with version 7, so I think it is a good idea to just bump.