### PR TITLE
O2-1801 [lhapdf] disable python bindings for python3 in lhapdf

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -26,9 +26,15 @@ rsync -a --exclude '**/.git' $SOURCEDIR/ ./
 
 export LIBRARY_PATH="$LD_LIBRARY_PATH"
 
-if python -c 'import sys; exit(0 if sys.version_info.major >=3 else 1)'; then
-        # LHAPDF not yet ready for Python3
-        DISABLE_PYTHON=1
+if type "python" &>/dev/null; then
+  # Python2 or Python3 point to "python"
+  if python -c 'import sys; exit(0 if sys.version_info.major >=3 else 1)'; then
+    # LHAPDF not yet ready for Python3
+    DISABLE_PYTHON=1
+  fi
+else
+  # Python2 not installed and Python3 points to "python3"
+  DISABLE_PYTHON=1
 fi
 
 autoreconf -ivf


### PR DESCRIPTION
While compiling for Ubuntu 20.04 users have reported failures compiling the 'lhapdf package. It can be traced back to the python bindings of `lhapdf` being incompatible with Python3 which is a general issue affecting all OS.
It seems that the current `alidist` recipe is already doing a version check for Python3 however there seems to be an issue in there.  On some systems Python3 is symlinked only to `python3` and not to `python`, thus the test can't be executed properly. See also #2472 

I'm not at all a bash expert. Let me know if there is a more elegant solution to this.