### PR TITLE
Fix xjalienfs/xrootd/python-modules

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -12,7 +12,7 @@ requires:
 #!/bin/bash -e
 
 # env PYTHONUSERBASE="$INSTALLROOT" pip3 install --user -r alibuild_requirements.txt
-env PYTHONUSERBASE="$INSTALLROOT" ALIBUILD=1 python3 -m pip install --user file://${SOURCEDIR}
+env PYTHONUSERBASE="$INSTALLROOT" ALIBUILD=1 python3 -m pip install --ignore-installed --user file://${SOURCEDIR}
 
 sed -i".bak" 's/#!.*python.*/#!\/usr\/bin\/env python3/' ${INSTALLROOT}/bin/*
 rm -v ${INSTALLROOT}/bin/*.bak

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -63,7 +63,11 @@ if [[ x"$XROOTD_PYTHON" == x"True" ]];
 then
   pushd $INSTALLROOT
     pushd lib
+    if [ -d ../lib64 ]; then
+      ln -s ../lib64/python* python
+    else
       ln -s python* python
+    fi
     popd
   popd
 fi


### PR DESCRIPTION
@ktf @Atlantic777 This bring fixes for xjalienfs:
1. due to #2537 xjalienfs also needs --ignore-installed (for pyOpenSSL module)
2. xrootd had a problem with symlink generation that would make it's PYTHONPATH invalid
3. python-modules needed some small fixes, biggest being the replacement of shabang that was invalid