### PR TITLE
Update JAliEn-ROOT to 0.6.3-rc0 - updates related to logging

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -20,6 +20,8 @@ overrides:
   XRootD:
     version: "%(tag_basename)s_JALIEN"
     tag: v4.12.5
+  JAliEn-ROOT:
+    tag: 0.6.3-rc0
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
This update for the moment affects only the jalien dev builds and it does not affect AliPhysics analysis tags or O2 nightlies.

This version includes minor updates related to logging. The severity level for some messages is reduced and logs should be cleaner and easier to read.