### PR TITLE
Fix curl build when OpenSSL libs are installed on the system

### DIFF
--- a/curl.sh
+++ b/curl.sh
@@ -17,6 +17,9 @@ fi
 
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .
 
+sed -i.deleteme 's/CPPFLAGS="$CPPFLAGS $SSL_CPPFLAGS"/CPPFLAGS="$SSL_CPPFLAGS $CPPFLAGS"/' configure.ac
+sed -i.deleteme 's/LDFLAGS="$LDFLAGS $SSL_LDFLAGS"/LDFLAGS="$SSL_LDFLAGS $LDFLAGS"/' configure.ac
+
 ./buildconf
 ./configure --prefix=$INSTALLROOT --disable-ldap ${OPENSSL_ROOT:+--with-ssl=$OPENSSL_ROOT} --disable-static
 make ${JOBS:+-j$JOBS}


### PR DESCRIPTION
This PR fixes a problem when curl fails to build if OpenSSL is installed on the system, for example in alisw/slc6-builder. The build fails with a message that there is a mismatch between SSL header and library version, even though curl was explicitly configured to use OpenSSL from alidist. 

The problem comes from the curl config script which prefers the system SSL if it's detected, but even then the headers and libs can get mixed up. There is a trace of some discussion in the curl git log and I don't expect that this can be changed upstream. here's that commit message:

```
commit 338f427a24f78a717888c7c2b6b91fa831bea28e
Author: Jay Satiro <raysatiro@yahoo.com>
Date:   Mon Apr 24 03:13:28 2017 -0400

    configure: stop prepending to LDFLAGS, CPPFLAGS

    - Change prepends to appends because user's LDFLAGS and CPPFLAGS should
      always come first so they're searched before ours.

    Bug: https://github.com/curl/curl/issues/1420
    Reported-by: Helmut K. C. Tessarek
```