### PR TITLE
Fix lhapdf build scripts

### DIFF
--- a/lhapdf-pdfsets.sh
+++ b/lhapdf-pdfsets.sh
@@ -13,7 +13,7 @@ pushd $INSTALLROOT/share/LHAPDF
   for P in $PDFSETS; do
     PDFPACK=$(printf "%s.tar.gz" $P)
     PDFEXT=$(printf "%s/%s" $REPO $PDFPACK)
-    curl $PDFEXT --output $PDFPACK
+    curl -L $PDFEXT --output $PDFPACK
     tar xzvf $PDFPACK
     rm -rf $PDFPACK
   done

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -24,7 +24,7 @@ pushd $INSTALLROOT/share/lhapdf
   for P in $PDFSETS; do
     PDFFILE=$(printf "%s.LHgrid" $P)
     PDFSOURCE=$(printf "%s/%s" $PDFREPO $PDFFILE)
-    curl $PDFSOURCE --output $PDFFILE
+    curl -L $PDFSOURCE --output $PDFFILE
     ls ${P}*
   done
 popd


### PR DESCRIPTION
The source URL now returns a HTTP redirect, so we need to pass `-L` to `curl` to follow it.