### PR TITLE
xjalienfs :: update to 1.2.7

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.2.6"
+tag: "1.2.7"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
- add alien-cert-info command
- fix running of functions that do not need a websocket connection
- makelist_lfn:: protect/print cases when no envelopes were obtained
+ small optimizations/fixes/text