### PR TITLE
Update JAliEn-ROOT to 0.6.3

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -17,11 +17,6 @@ overrides:
   autotools:
     version: "%(tag_basename)s_JALIEN"
     tag: v1.5.0
-  XRootD:
-    version: "%(tag_basename)s_JALIEN"
-    tag: v4.12.5
-  JAliEn-ROOT:
-    tag: 0.6.3-rc0
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-dev-fairroot.sh
+++ b/defaults-o2-dev-fairroot.sh
@@ -43,9 +43,6 @@ overrides:
   msgpack:
     version: "v3.1.1"
     tag: cpp-3.1.1
-  XRootD:
-    tag: "v4.11.1"
-    source: https://github.com/xrootd/xrootd
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.6.2"
+tag: "0.6.3"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v4.12.1"
+tag: "v4.12.5"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
This PR updates JAliEn-ROOT 0.6.3 (minor logging improvements) and XRootD to v4.12.5. This update affects AliPhysics and O2 and should be included in the next AliRoot tag.