### PR TITLE
utf8proc: use cmake for building

### DIFF
--- a/utf8proc.sh
+++ b/utf8proc.sh
@@ -5,20 +5,15 @@ source: https://github.com/JuliaStrings/utf8proc
 build_requires:
  - "GCC-Toolchain:(?!osx)"
  - alibuild-recipe-tools
+ - CMake
 prefer_system: "(?!osx)"
 prefer_system_check: |
   printf "#include <utf8proc.h>\n" | c++ -c -I$(brew --prefix utf8proc)/include -xc++ - -o /dev/null 2>&1;
   if [ $? -ne 0 ]; then printf "Use brew install utf8proc"; exit 1; fi
 ---
-rsync -a --delete --exclude "**/.git" $SOURCEDIR/ .
-make ${JOBS+-j $JOBS} install prefix=$INSTALLROOT
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+make ${JOBS+-j $JOBS} install
 
 mkdir -p etc/modulefiles
 alibuild-generate-module > etc/modulefiles/$PKGNAME
-
-cat >> etc/modulefiles/$PKGNAME <<EoF
-# Our environment
-set PKGROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$PKGROOT/lib
-EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
By default this will produce an archive library, reducing our
runtime footprint.