### PR TITLE
xjalienfs :: hot-fix update to 1.2.8

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.2.7"
+tag: "1.2.8"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* Fix typo in usage of tokens as JALIEN_TOKEN_{CERT,KEY} env vars
* Disable for all user/human communication the return of json keys
* fix global status of process output and with this the return of nowb functions; add showmsg and showkeys SendMsg options