### PR TITLE
Don't use CMake >= 3.19.0 and leave a message

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -11,7 +11,7 @@ build_requires:
 prefer_system: .*
 prefer_system_check: |
   verge() { [[  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]]; }
-  type cmake && verge 3.18.0 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3`
+  type cmake && verge 3.18.0 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3` && ! verge 3.19.0 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3` # Block CMake 3.19, currently incompatible with CUDA compilation
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
We cannot bump right now because there is some incompatibility with GPU compilation. I'll check if the problem is on our side or a regression in CMake. So long block >= 3.19