### PR TITLE
Bump FairMQ to 1.4.27

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -1,6 +1,5 @@
 package: DDS
-version: "3.5.1"
-tag: "3.5.2"
+version: "3.5.3"
 source: https://github.com/FairRootGroup/DDS
 requires:
   - boost

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.25
+tag: v1.4.27
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Supersedes #2554.
Includes fix for [O2-1850](https://alice.its.cern.ch/jira/browse/O2-1850).

Requires DDS 3.5.3 (#2636) because FairMQ 1.4.27 requires that as minimum version (which includes multiple sessions support).