### PR TITLE
Allow compiling O2 without a system C++

### DIFF
--- a/openmp.sh
+++ b/openmp.sh
@@ -6,5 +6,5 @@ system_requirement_missing: |
     * On Linux it comes with the compiler
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <omp.h>\n" | c++ -xc++ - -fopenmp -c -o /dev/null
+  printf "#include <omp.h>\n" | cc -xc - -fopenmp -c -o /dev/null
 ---

--- a/termcap.sh
+++ b/termcap.sh
@@ -3,6 +3,6 @@ version: "1.0"
 system_requirement_missing: "Please install the ncurses development package on your system (usually ncurses-devel or libncurses-dev)"
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <termcap.h>\n" | c++ -xc++ - -c -o /dev/null
+  printf "#include <termcap.h>\n" | cc -xc - -c -o /dev/null
 ---
 


### PR DESCRIPTION
This allows building O2 (using precompiled binaries) without having to rely on a system C++ installation.