### PR TITLE
Bump CMake to 3.19.2

### DIFF
--- a/c-ares.sh
+++ b/c-ares.sh
@@ -1,6 +1,6 @@
 package: c-ares
-version: "v1.15.0"
-tag: cares-1_15_0
+version: "v1.17.1"
+tag: cares-1_17_1
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - CMake

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,6 +1,6 @@
 package: CMake
 version: "%(tag_basename)s"
-tag: "v3.18.2"
+tag: "v3.19.2"
 source: https://github.com/Kitware/CMake
 requires:
  - "OpenSSL:(?!osx)"
@@ -11,7 +11,7 @@ build_requires:
 prefer_system: .*
 prefer_system_check: |
   verge() { [[  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]]; }
-  type cmake && verge 3.18.0 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3` && ! verge 3.19.0 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3` # Block CMake 3.19, currently incompatible with CUDA compilation
+  type cmake && verge 3.19.2 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3`
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
One of the 2 problems with CMake 3.19 has been fixed in 3.19.1, which is out now, and the other one has been fixed in O2. So we should again be able to use the latest version.