### PR TITLE
libxml2: move to our own clone

### DIFF
--- a/libxml2.sh
+++ b/libxml2.sh
@@ -5,7 +5,7 @@ build_requires:
   - autotools
   - zlib
   - "GCC-Toolchain:(?!osx)"
-source: https://gitlab.gnome.org/GNOME/libxml2.git
+source: https://github.com/alisw/libxml2.git
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   xml2-config --version;


### PR DESCRIPTION
Relying on Gnome.org is simply too flaky.