### PR TITLE
lz4: fix library relocation

### DIFF
--- a/lz4.sh
+++ b/lz4.sh
@@ -1,39 +1,22 @@
 package: lz4
 version: "%(tag_basename)s"
-tag: v1.8.3
+tag: v1.9.3
 source: https://github.com/lz4/lz4
 build_requires:
  - "GCC-Toolchain:(?!osx)"
+ - CMake
+ - alibuild-recipe-tools
 prefer_system: ".*"
 prefer_system_check: |
-  printf "#include <lz4.h>\n" | c++ -xc++ -I$(brew --prefix lz4)/include - -c -M 2>&1
+  printf "#include <lz4.h>\n" | cc -xc -I$(brew --prefix lz4)/include - -c -M 2>&1
 ---
 
-rsync -av --delete --exclude="**/.git" $SOURCEDIR/ ./
-make -j ${JOBS+-j $JOBS}
-make PREFIX=$INSTALLROOT INCLUDEDIR=$INSTALLROOT/include install
-case $ARCHITECTURE in
-  osx*)
-    install_name_tool -id liblz4.dylib $INSTALLROOT/lib/liblz4.dylib
-  ;;
-esac
+cmake -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+      $SOURCEDIR/build/cmake
+make -j ${JOBS+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set BASEDIR \$::env(BASEDIR)
-prepend-path PATH \$BASEDIR/$PKGNAME/\$version/bin
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-EoF
+alibuild-generate-module --lib --bin > "$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
Move to new cmake based builds, which should generate the
appropriate RPATH information.