### PR TITLE
Limit the usage of the Toolchain package only to CVMFS

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -143,8 +143,10 @@ module load BASE/1.0
 # Load Toolchain module for the current platform. Fallback on this one
 regexp -- "^(.*)/.*\$" [module-info name] dummy mod_name
 if { "\$mod_name" == "GCC-Toolchain" } {
-  module load Toolchain/GCC-${PKGVERSION//-*}
-  if { [is-loaded Toolchain] } { continue }
+  if { [regexp {^/cvmfs.*} $ModulesCurrentModulefile dummy1 dummy2] } {
+    module load Toolchain/GCC-${PKGVERSION//-*}
+    if { [is-loaded Toolchain] } { continue }
+  }
   set base_path \$::env(BASEDIR)
 } else {
   # Loading Toolchain: autodetect prefix


### PR DESCRIPTION
Anyone else should just reinstall for a different architecture.