### PR TITLE
Bump FairMQ to 1.4.28

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.27
+tag: v1.4.28
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
This contains a bug fix for numa-aware memory allocation that is needed for the full system test