### PR TITLE
Fetch all commits for workflow

### DIFF
--- a/.github/workflows/recipe-checks.yml
+++ b/.github/workflows/recipe-checks.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
     - name: Run check
       # Runs bash -eo pipefail
       shell: bash


### PR DESCRIPTION
We compare with the PR base commit, which might be an arbitrary number of commits back in the history, so just fetch everything.