### PR TITLE
Move check for .sh files to loop

### DIFF
--- a/.github/workflows/recipe-checks.yml
+++ b/.github/workflows/recipe-checks.yml
@@ -26,9 +26,11 @@ jobs:
         err_fnames=()
 
         git diff --name-only "$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})" |
-          grep '\.sh$' |
           while read -r fname; do
-            [ -e "$fname" ] || continue
+            case "$fname" in
+              *.sh) [ -e "$fname" ] || continue;;
+              *) continue;;
+            esac
             echo "Linting $fname"
             if ! scripts/lint-recipes "$fname" ||
                # This should really be cleaned up, since macOS cleans any


### PR DESCRIPTION
This avoids an error if there are no changed .sh files in a PR. In that case, grep would return 1, which would fail the check due to the `-o pipefail`.