### PR TITLE
Revert "Update simulation.sh (#2683)"

### DIFF
--- a/simulation.sh
+++ b/simulation.sh
@@ -4,7 +4,6 @@ requires:
   - GEANT4_VMC
   - GEANT4
   - GEANT3
-  - FLUKA_VMC
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
This reverts commit b085c454fe5ba3580c57bfa1d7270c6935cb3f1b. Currently the fact that fluka_vmc does not relocate correctly breaks the builds.