### PR TITLE
Automatically open a PR from rc/ branches

### DIFF
--- a/.github/workflows/daily-tag-pr.yml
+++ b/.github/workflows/daily-tag-pr.yml
@@ -1,4 +1,4 @@
-name: Check PR with clang-format
+name: Create a PR from pushes to rc/ branches
 
 on:
   push:
@@ -8,27 +8,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.push.deleted }}
+    if: ${{ !github.event.deleted }}
 
     steps:
       - name: Get rc branch
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.push.ref }}
+          ref: ${{ github.event.ref }}
 
-      - name: Compute base branch
-        id: base
-        env: 
-          rc_branch: ${{ github.event.push.ref }}
+      - name: Compute base branch name
+        id: name
         run: |
-          echo "::set-output name=base::${rc_branch#refs/heads/rc/}"
+          echo "::set-output name=base::${GITHUB_REF#refs/heads/rc/}"
 
       - name: Send pull request to regular branch
-        uses: alisw/pull-request@master
+        uses: repo-sync/pull-request@v2.5
         with:
-          source_branch: ${{ github.event.push.ref }}
-          destination_branch: ${{ steps.base.outputs.base }}
+          destination_branch: ${{ steps.name.outputs.base }}
           pr_title: 'daily tags: auto-update dist definitions'
-          github_token: ${{ secrets.ALIBUILD_GITHUB_TOKEN }}
           pr_body: |
-            The `daily-tags.sh` script has created a tag release with these changes.
+            The daily-tags.sh script has created a tag release with these changes.
+          pr_allow_empty: true
+          github_token: ${{ secrets.ALIBUILD_GITHUB_TOKEN }}

--- a/.github/workflows/daily-tag-pr.yml
+++ b/.github/workflows/daily-tag-pr.yml
@@ -1,0 +1,34 @@
+name: Check PR with clang-format
+
+on:
+  push:
+    branches:
+      - 'rc/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.push.deleted }}
+
+    steps:
+      - name: Get rc branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.push.ref }}
+
+      - name: Compute base branch
+        id: base
+        env: 
+          rc_branch: ${{ github.event.push.ref }}
+        run: |
+          echo "::set-output name=base::${rc_branch#refs/heads/rc/}"
+
+      - name: Send pull request to regular branch
+        uses: alisw/pull-request@master
+        with:
+          source_branch: ${{ github.event.push.ref }}
+          destination_branch: ${{ steps.base.outputs.base }}
+          pr_title: 'daily tags: auto-update dist definitions'
+          pr_body: |
+            The `daily-tags.sh` script has created a tag release with these changes.
+        continue-on-error: true # We do not create PRs if the branch is not there.

--- a/.github/workflows/daily-tag-pr.yml
+++ b/.github/workflows/daily-tag-pr.yml
@@ -29,6 +29,6 @@ jobs:
           source_branch: ${{ github.event.push.ref }}
           destination_branch: ${{ steps.base.outputs.base }}
           pr_title: 'daily tags: auto-update dist definitions'
+          github_token: ${{ secrets.ALIBUILD_GITHUB_TOKEN }}
           pr_body: |
             The `daily-tags.sh` script has created a tag release with these changes.
-        continue-on-error: true # We do not create PRs if the branch is not there.


### PR DESCRIPTION
With alisw/ali-bot#910, daily-tags.sh pushes automatic changes to an `rc/*` branch first to avoid overwriting others' changes. This action creates a PR from that branch.

Tested and working in another repo.