### PR TITLE
User proper version in RapidJSON recipe

### DIFF
--- a/rapidjson.sh
+++ b/rapidjson.sh
@@ -1,5 +1,5 @@
 package: RapidJSON
-version: "%(tag_basename)s"
+version: v1.1.0-alice2
 tag: 091de040edb3355dcf2f4a18c425aec51b906f08
 source: https://github.com/Tencent/rapidjson.git
 build_requires:


### PR DESCRIPTION
Previously used version was `v1.1.0-alice1`.