### PR TITLE
root: remove usage of python3-config and simplification

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -91,12 +91,8 @@ if [[ -d $SOURCEDIR/interpreter/llvm ]]; then
   ROOT_PYTHON_FLAGS="-Dpyroot=ON"
   ROOT_PYTHON_FEATURES="pyroot"
   ROOT_HAS_PYTHON=1
-  # One can explicitly pick a Python version with -DPYTHON_EXECUTABLE=... -DPYTHON_INCLUDE_DIR=<path_to_Python.h>
-  PYTHON_EXECUTABLE=$(python3-config --exec-prefix)/bin/python3
-  PYTHON_INCLUDE_DIR=$(python3-config --includes | sed -e's/^[ ]*-I//' | cut -f1 -d' ')
-  PYTHON_LIBRARY_DIR=$(python3-config --ldflags | sed -e's/^[ ]*-L//' | cut -f1 -d' ')
-  PYTHON_LIBNAME=$(python3-config --libs | cut -f1 -d' ' | cut -c3-)
-  PYTHON_LIBRARY=${PYTHON_LIBRARY_DIR}/lib${PYTHON_LIBNAME}.${SONAME}
+  # One can explicitly pick a Python version with -DPYTHON_EXECUTABLE=... 
+  PYTHON_EXECUTABLE=$(python3 -c 'import distutils.sysconfig; print(distutils.sysconfig.get_config_var("exec_prefix"));')/bin/python3
 else
   # Non-ROOT 6 builds: disable Python
   ROOT_PYTHON_FLAGS="-Dpyroot=OFF"
@@ -158,12 +154,6 @@ cmake $SOURCEDIR                                                                
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
       ${ROOT_HAS_PYTHON:+-DPYTHON_PREFER_VERSION=3}                                    \
       ${ROOT_HAS_PYTHON:+-DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}}                     \
-      ${ROOT_HAS_PYTHON:+-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR}}                   \
-      ${ROOT_HAS_PYTHON:+-DPYTHON_LIBRARIES=${PYTHON_LIBRARIES}}                       \
-      ${ROOT_HAS_PYTHON:+-DPython_EXECUTABLE=${PYTHON_EXECUTABLE}}                     \
-      ${ROOT_HAS_PYTHON:+-DPython_INCLUDE_DIR=${PYTHON_INCLUDE_DIR}}                   \
-      ${ROOT_HAS_PYTHON:+-DPython_INCLUDE_DIRS=${PYTHON_INCLUDE_DIR}}                  \
-      ${ROOT_HAS_PYTHON:+-DPYTHON_LIBRARIES=${PYTHON_LIBRARIES}}                       \
 -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT;$LIBPNG_ROOT;$LZMA_ROOT"
 
 FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http


### PR DESCRIPTION
# Use only PYTHON_EXECUTABLE

Among the various `PYTHON_XXX` variables set in the current version of the `root.sh` recipe, I would argue that only one is really needed, namely `PYTHON_EXECUTABLE`.

The other ones are, anyway, as far as I can tell, incorrect in many cases, especially `LIBNAME` (and/or on machines/environments where python3-config command is not available), and thus potentially harmfull. See more details below if needed.

# LIBNAME is incorrect in many cases

Using the script below : 

```console
PYTHON_EXECUTABLE=$(python3-config --exec-prefix)/bin/python3
PYTHON_INCLUDE_DIR=$(python3-config --includes | sed -e's/^[ ]*-I//' | cut -f1 -d’ ')
PYTHON_LIBRARY_DIR=$(python3-config --ldflags | sed -e's/^[ ]*-L//' | cut -f1 -d’ ')
PYTHON_LIBNAME=$(python3-config --libs | cut -f1 -d' ' | cut -c3-)
PYTHON_LIBRARY=${PYTHON_LIBRARY_DIR}/lib${PYTHON_LIBNAME}.${SONAME}

echo PYTHON_EXECUTABLE=$PYTHON_EXECUTABLE
echo PYTHON_LIBRARY_DIR =$PYTHON_LIBRARY_DIR
echo PYTHON_INCLUDE_DIR=$PYTHON_INCLUDE_DIR
echo PYTHON_LIBNAME=$PYTHON_LIBNAME
echo PYTHON_LIBRARY=$PYTHON_LIBRARY
```

(Note the SONAME var is not defined, but that's not relevant)
 
The results are : 

## macOS Catalina with brew (installed globally, i.e. in `/usr/local`) : ok 

```console
PYTHON_EXECUTABLE=/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/bin/python3
PYTHON_LIBRARY_DIR =/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/config-3.7m-darwin
PYTHON_INCLUDE_DIR=/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/include/python3.7m
PYTHON_LIBNAME=python3.7m
PYTHON_LIBRARY=/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/config-3.7m-darwin/libpython3.7m.
```

## macOS BigSur with system python : all incorrect

```console
checkpyroot.sh:1: command not found: python3-config
checkpyroot.sh:2: command not found: python3-config
checkpyroot.sh:3: command not found: python3-config
checkpyroot.sh:4: command not found: python3-config
PYTHON_EXECUTABLE=/bin/python3
PYTHON_LIBRARY_DIR=
PYTHON_INCLUDE_DIR=
PYTHON_LIBNAME=
PYTHON_LIBRARY=/lib.
```

## macOS BigSur with brew (user installation) : LIBNAME incorrect

```console
PYTHON_EXECUTABLE=/Users/laurent/github.com/Homebrew/brew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/bin/python3
PYTHON_LIBRARY_DIR=/Users/laurent/github.com/Homebrew/brew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/config-3.9-darwin
PYTHON_INCLUDE_DIR=/Users/laurent/github.com/Homebrew/brew/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/include/python3.9
PYTHON_LIBNAME=intl
PYTHON_LIBRARY=/Users/laurent/github.com/Homebrew/brew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/config-3.9-darwin/libintl.
```

## centOS 7 with system python (3.6.8) : all incorrect

```console
checkpyroot.sh:1: command not found: python3-config
checkpyroot.sh:2: command not found: python3-config
checkpyroot.sh:3: command not found: python3-config
checkpyroot.sh:4: command not found: python3-config
PYTHON_EXECUTABLE=/bin/python3
PYTHON_INCLUDE_DIR=
PYTHON_LIBRARY_DIR=
PYTHON_LIBNAME=
PYTHON_LIBRARY=/lib.
```

## centOS 7 with a Spack installed python (3.8.6) : LIBNAME incorrect

```console
PYTHON_EXECUTABLE=/home/laurent/opt/spack/linux-centos7-skylake/gcc-7.3.0/python-3.8.6-bhoihmu45x2w457aahtnkvkeaw7t4uzj/bin/python3
PYTHON_LIBRARY_DIR =/home/laurent/opt/spack/linux-centos7-skylake/gcc-7.3.0/python-3.8.6-bhoihmu45x2w457aahtnkvkeaw7t4uzj/lib
PYTHON_INCLUDE_DIR=/home/laurent/opt/spack/linux-centos7-skylake/gcc-7.3.0/python-3.8.6-bhoihmu45x2w457aahtnkvkeaw7t4uzj/include/python3.8
PYTHON_LIBNAME=
PYTHON_LIBRARY=/home/laurent/opt/spack/linux-centos7-skylake/gcc-7.3.0/python-3.8.6-bhoihmu45x2w457aahtnkvkeaw7t4uzj/lib/lib.
```

## ubuntu 20.04 with system python : LIBNAME incorrect

```console
PYTHON_EXECUTABLE=/usr/bin/python3
PYTHON_LIBRARY_DIR=/usr/lib/python3.8/config-3.8-x86_64-linux-gnu
PYTHON_INCLUDE_DIR=/usr/include/python3.8
PYTHON_LIBNAME=
PYTHON_LIBRARY=/usr/lib/python3.8/config-3.8-x86_64-linux-gnu/lib.
```