### PR TITLE
Modify Geant4 recipe to make possible to define an external directory for data sets, plus clean-up: 

### DIFF
--- a/aliroot-guntest.sh
+++ b/aliroot-guntest.sh
@@ -10,7 +10,12 @@ requires:
 # A simple regression test launching a Geant3 + Geant4 gun simulation + reconstruction.
 # Tests if the processing runs through and yields a reasonable ESD.
 # Note that the test is limited to the default OCDB.
-env
+
+# Set Geant4 data sets environment
+[ "$G4INSTALL" != "" ] && \
+`$G4INSTALL/bin/geant4-config --datasets | sed 's/[^ ]* //' | sed 's/G4/export G4/' | sed 's/DATA /DATA=/'`
+
+env | sort
 rsync -a "$ALIROOT_ROOT"/test/vmctest/gun test
 cd test/gun
 

--- a/geant4.sh
+++ b/geant4.sh
@@ -14,64 +14,55 @@ incremental_recipe: |
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 env:
   G4INSTALL : $GEANT4_ROOT
-  G4DATASEARCHOPT : "-mindepth 2 -maxdepth 4 -type d -wholename"
-  G4ABLADATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4ABLA*'`"  ## v10.4.px only
-  G4ENSDFSTATEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4ENSDFSTATE*'`"
-  G4INCLDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4INCL*'`"  ## v10.5.px only
-  G4LEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4EMLOW*'`"
-  G4LEVELGAMMADATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*PhotonEvaporation*'`"
-  G4NEUTRONHPDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4NDL*'`"
-  G4NEUTRONXSDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4NEUTRONXS*'`"   ## v10.4.px only
-  G4PARTICLEXSDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4PARTICLEXS*'`"   ## v10.5.px only
-  G4PIIDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*G4PII*'`"
-  G4RADIOACTIVEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*RadioactiveDecay*'`"
-  G4REALSURFACEDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT '*data*RealSurface*'`"
-  G4SAIDXSDATA : "`find ${G4INSTALL} $G4DATASEARCHOPT  '*data*G4SAIDDATA*'`"
+  G4ABLADATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4ABLADATA | sed 's/[^ ]* [^ ]* //'`"
+  G4ENSDFSTATEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4ENSDFSTATEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4INCLDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4INCLDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4LEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4LEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4LEVELGAMMADATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4LEVELGAMMADATA | sed 's/[^ ]* [^ ]* //'`"
+  G4NEUTRONHPDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4NEUTRONHPDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4NEUTRONXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4NEUTRONXSDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4PARTICLEXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4PARTICLEXSDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4PIIDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4PIIDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4RADIOACTIVEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4RADIOACTIVEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4REALSURFACEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4REALSURFACEDATA | sed 's/[^ ]* [^ ]* //'`"
+  G4SAIDXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4SAIDXSDATA | sed 's/[^ ]* [^ ]* //'`"
 
 ---
-# if this variable is not defined default it to OFF
+# If this variable is not defined default it to OFF
 : ${GEANT4_BUILD_MULTITHREADED:=OFF}
 
-cmake $SOURCEDIR                                             \
-  -DGEANT4_INSTALL_DATA_TIMEOUT=2000                         \
-  -DCMAKE_CXX_FLAGS="-fPIC"                                  \
-  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                 \
-  -DCMAKE_INSTALL_LIBDIR="lib"                               \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo                          \
-  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"           \
-  -DGEANT4_ENABLE_TESTING=OFF                                \
-  -DBUILD_SHARED_LIBS=ON                                     \
-  -DGEANT4_INSTALL_EXAMPLES=OFF                              \
-  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT"                        \
-  -DGEANT4_BUILD_MULTITHREADED="$GEANT4_BUILD_MULTITHREADED" \
-  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"                   \
-  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"                     \
-  -DGEANT4_USE_G3TOG4=ON                                     \
-  -DGEANT4_INSTALL_DATA=ON                                   \
-  -DGEANT4_USE_SYSTEM_EXPAT=OFF                              \
-  ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}          \
-  ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                   \
+# Data sets directory:
+# if not set (default), data sets will be installed in CMAKE_INSTALL_DATAROOTDIR
+: ${GEANT4_DATADIR:=""}
+
+cmake $SOURCEDIR                                                \
+  -DGEANT4_INSTALL_DATA_TIMEOUT=2000                            \
+  -DCMAKE_CXX_FLAGS="-fPIC"                                     \
+  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                    \
+  -DCMAKE_INSTALL_LIBDIR="lib"                                  \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo                             \
+  -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"              \
+  -DGEANT4_ENABLE_TESTING=OFF                                   \
+  -DBUILD_SHARED_LIBS=ON                                        \
+  -DGEANT4_INSTALL_EXAMPLES=OFF                                 \
+  -DCLHEP_ROOT_DIR:PATH="$CLHEP_ROOT"                           \
+  -DGEANT4_BUILD_MULTITHREADED="$GEANT4_BUILD_MULTITHREADED"    \
+  -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"                      \
+  -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"                        \
+  -DGEANT4_USE_G3TOG4=ON                                        \
+  -DGEANT4_INSTALL_DATA=ON                                      \
+  ${GEANT4_DATADIR:+-DGEANT4_INSTALL_DATADIR="$GEANT4_DATADIR"} \
+  -DGEANT4_USE_SYSTEM_EXPAT=OFF                                 \
+  ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}             \
+  ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                      \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS}
 make install
 
-# auto discovery of installation paths of G4 DATA
-# in order to avoid putting hard-coded version numbers (which change with every G4 tag)
-# these variables are used to create the modulefile below
-G4DATASEARCHOPT="-mindepth 2 -maxdepth 4 -type d -wholename"
-G4ABLADATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4ABLA*'`
-G4ENSDFSTATEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4ENSDFSTATE*'`
-G4INCLDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4INCL*'`
-G4LEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4EMLOW*'`
-G4LEVELGAMMADATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*PhotonEvaporation*'`
-G4NEUTRONHPDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4NDL*'`
-G4NEUTRONXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4NEUTRONXS*'`
-G4PARTICLEXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4PARTICLEXS*'`
-G4PIIDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*G4PII*'`
-G4RADIOACTIVEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*RadioactiveDecay*'`
-G4REALSURFACEDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT '*data*RealSurface*'`
-G4SAIDXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT  '*data*G4SAIDDATA*'`
+# Install data sets
+# Can be done after Geant4 installation, if installed with -DGEANT4_INSTALL_DATA=OFF
+# ./geant4-config --install-datasets
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
@@ -88,28 +79,11 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 # Dependencies
 module load BASE/1.0 ${XERCESC_REVISION:+xercesc/$XERCESC_REVISION-$XERCESC_REVISION}
 # Our environment
-set osname [uname sysname]
 set GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv GEANT4_ROOT \$GEANT4_ROOT
-setenv G4INSTALL \$GEANT4_ROOT
-setenv G4INSTALL_DATA \$GEANT4_ROOT/share/
-setenv G4SYSTEM \$osname-g++
-
-setenv G4ABLADATA ${G4ABLADATA:-not-defined}
-setenv G4ENSDFSTATEDATA ${G4ENSDFSTATEDATA:-not-defined}
-setenv G4INCLDATA ${G4INCLDATA:-not-defined}
-setenv G4LEDATA ${G4LEDATA:-not-defined}
-setenv G4LEVELGAMMADATA ${G4LEVELGAMMADATA:-not-defined}
-setenv G4NEUTRONHPDATA ${G4NEUTRONHPDATA:-not-defined}
-setenv G4NEUTRONXSDATA ${G4NEUTRONXSDATA:-not-defined}
-setenv G4PARTICLEXSDATA ${G4PARTICLEXSDATA:-not-defined}
-setenv G4PIIDATA ${G4PIIDATA:-not-defined}
-setenv G4RADIOACTIVEDATA  ${G4RADIOACTIVEDATA:-not-defined}
-setenv G4REALSURFACEDATA ${G4REALSURFACEDATA:-not-defined}
-setenv G4SAIDXSDATA ${G4SAIDXSDATA:-not-defined}
-set G4BASE \$GEANT4_ROOT
 prepend-path PATH \$GEANT4_ROOT/bin
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include/Geant4
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include
 prepend-path LD_LIBRARY_PATH \$GEANT4_ROOT/lib
 EoF
+
+# Data sets environment
+$INSTALLROOT/bin/geant4-config --datasets |  sed 's/[^ ]* //' | sed 's/G4/setenv G4/' >> "$MODULEFILE"

--- a/geant4.sh
+++ b/geant4.sh
@@ -14,18 +14,6 @@ incremental_recipe: |
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 env:
   G4INSTALL : $GEANT4_ROOT
-  G4ABLADATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4ABLADATA | sed 's/[^ ]* [^ ]* //'`"
-  G4ENSDFSTATEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4ENSDFSTATEDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4INCLDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4INCLDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4LEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4LEDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4LEVELGAMMADATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4LEVELGAMMADATA | sed 's/[^ ]* [^ ]* //'`"
-  G4NEUTRONHPDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4NEUTRONHPDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4NEUTRONXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4NEUTRONXSDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4PARTICLEXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4PARTICLEXSDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4PIIDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4PIIDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4RADIOACTIVEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4RADIOACTIVEDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4REALSURFACEDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4REALSURFACEDATA | sed 's/[^ ]* [^ ]* //'`"
-  G4SAIDXSDATA : "`${G4INSTALL}/bin/geant4-config --datasets | grep G4SAIDXSDATA | sed 's/[^ ]* [^ ]* //'`"
 
 ---
 # If this variable is not defined default it to OFF

--- a/o2.sh
+++ b/o2.sh
@@ -81,6 +81,10 @@ incremental_recipe: |
       export ROOT_INCLUDE_PATH=$(brew --prefix boost)/include:$ROOT_INCLUDE_PATH
     fi
     export ROOT_INCLUDE_PATH=$INSTALLROOT/include:$INSTALLROOT/include/GPU:$ROOT_INCLUDE_PATH
+    # Set Geant4 data sets environment
+    if [ "$G4INSTALL" != "" ]]; then
+      `$G4INSTALL/bin/geant4-config --datasets | sed 's/[^ ]* //' | sed 's/G4/export G4/' | sed 's/DATA /DATA=/'`
+    fi
     # Clean up old coverage data and tests logs
     find . -name "*.gcov" -o -name "*.gcda" -delete
     # cleanup ROOT files created by tests in build area


### PR DESCRIPTION
- This PR restores back ca2863573252a2cefd93b52843e13c11932a1774
- Fix setting Geant4 data sets in build environment (failing in the previous version):
   - Removed setting data sets in env: section in geant4.sh
   - Added setting data sets environment via geant4-config in recipes with Geant4 tests
     (aliroot-guntest.sh, o2.sh)
