### PR TITLE
Keep only top packages in O2Suite

### DIFF
--- a/o2suite.sh
+++ b/o2suite.sh
@@ -2,15 +2,10 @@ package: O2Suite
 version: "1.0.0"
 tag: "O2Suite-1.0.0"
 requires:
-  - Common-O2
   - coconut
   - Control-Core
   - Control-OCCPlugin
-  - Monitoring
-  - Configuration
   - O2
-  - "GCC-Toolchain:(?!osx)"
-  - InfoLogger
   - ReadoutCard
   - Readout
   - qcg


### PR DESCRIPTION
@ktf @Barthelemy does it make sense?

This also removes `InfoLogger` but keeps `libInfoLogger`. @sy-c is that okay with you?