### PR TITLE
Disable yaml-cpp in o2-dataflow defaults

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -27,6 +27,7 @@ disable:
   - JAliEn-ROOT
   - KFParticle
   - MCStepLogger
+  - yaml-cpp
 overrides:
   Python-modules-list:
     env:


### PR DESCRIPTION
`yaml-cpp` is optional dependency to `FairRoot` that is required to build `MCConfigurator`.
As `MCConfigurator` requires also `Geant3` and `Geant4` it will never be built with `o2-dataflow` defaults.