### PR TITLE
DataDistribution does not link protobuf nor fmt

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -9,11 +9,11 @@ requires:
   - Ppconsul
   - grpc
   - Monitoring
-  - protobuf
   - O2
-  - fmt
 build_requires:
   - CMake
+  - protobuf
+  - fmt
 source: https://github.com/AliceO2Group/DataDistribution
 incremental_recipe: |
   # reduce number of compile slots if invoked  by Jenkins


### PR DESCRIPTION
@ironMann This is just to make it consistent with actual state.
It can be reverted as soon as you need it.