### PR TITLE
Use ALICE fork of bzip2

### DIFF
--- a/bz2.sh
+++ b/bz2.sh
@@ -1,7 +1,7 @@
 package: bz2
 version: "1.0.8"
 tag: 8ca1faa31f396d94ab927b257f3a05236c84e330
-source: https://sourceware.org/git/bzip2.git
+source: https://github.com/AliceO2Group/bzip2
 build_requires:
  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"


### PR DESCRIPTION
To solve an intermittent CI error where the upstream repo, <https://sourceware.org/git/bzip2.git>, is unreachable.

I've created [AliceO2Group/bzip2] already.

[AliceO2Group/bzip2]: https://github.com/AliceO2Group/bzip2