### PR TITLE
Fork bzip2 to alisw, not AliceO2Group

### DIFF
--- a/bz2.sh
+++ b/bz2.sh
@@ -1,7 +1,7 @@
 package: bz2
 version: "1.0.8"
 tag: 8ca1faa31f396d94ab927b257f3a05236c84e330
-source: https://github.com/AliceO2Group/bzip2
+source: https://github.com/alisw/bzip2
 build_requires:
  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"


### PR DESCRIPTION
I've transferred the repo on GitHub. That means that requests for AliceO2Group/bzip2 will be redirected for a while to alisw/bzip2, but the repo lives in alisw now.