### PR TITLE
Revert "Disable yaml-cpp in o2-dataflow defaults"

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -27,7 +27,6 @@ disable:
   - JAliEn-ROOT
   - KFParticle
   - MCStepLogger
-  - yaml-cpp
 overrides:
   Python-modules-list:
     env:


### PR DESCRIPTION
Reverts alisw/alidist#2792

Apparently there are some issue with FairRoot on the build machines:

```
Make Error in DataFormats/common/CMakeLists.txt:
  Imported target "FairRoot::Base" includes non-existent path
...
```