### PR TITLE
test to bump fastjet to 3.3.4 and fjcontrib to 1.045

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -13,6 +13,8 @@ overrides:
   AliPhysics:
     version: "%(tag_basename)s_JALIEN"
     tag: v5-09-56-01
+  fastjet:
+    tag: v3.3.4_1.045-alice1
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
Added a new defaults file for fastjet to get a dedicated build to check for any differences in analysis with the upgraded version. 