### PR TITLE
Run Full System Test with TF of 5 Pb-Pb events as part of Full CI

### DIFF
--- a/o2-full-system-test.sh
+++ b/o2-full-system-test.sh
@@ -1,0 +1,28 @@
+package: O2-full-system-test
+version: "1.0"
+requires:
+  - O2Suite
+force_rebuild: 1
+---
+#!/bin/bash -e
+
+rm -Rf $BUILDDIR/full-system-test-sim
+mkdir $BUILDDIR/full-system-test-sim
+pushd $BUILDDIR/full-system-test-sim
+JOBUTILS_PRINT_ON_ERROR=1 JOBUTILS_JOB_TIMEOUT=500 NEvents=5 NEventsQED=100 SHMSIZE=8000000000 $O2_ROOT/prodtests/full_system_test.sh
+popd
+rm -Rf $BUILDDIR/full-system-test-sim
+
+# Dummy modulefile
+mkdir -p $INSTALLROOT/etc/modulefiles
+cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 O2/$O2_VERSION-$O2_REVISION
+EoF

--- a/o2fullci.sh
+++ b/o2fullci.sh
@@ -4,6 +4,7 @@ tag: "O2FullCI-1.0.0"
 requires:
   - O2Suite
   - o2checkcode
+  - O2-full-system-test
 valid_defaults:
   - o2
 ---


### PR DESCRIPTION
@sawenzel @ktf @TimoWilken : This PR adds a short full system test run to the Full CI. (1 time frame of 5 Pb-Pb events, only CPU, simulattion + raw creation + sync + async reco.)
It will run last, so the other errors would be reported first.
On my laptop it prolongs the full CI by 6.5 minutes, and takes ~10 GB of memory in total, that should be OK for the CI nodes?

I don't see how we can test this before deploying it, since there is no full CI for alidist.
I would thus just deploy it on the weekend, see how it goes, and quickly fix it, if something goes wrong.
Obviously I have tested it locally, where it worked, but the setup of the CI machines could be different than mine.