### PR TITLE
coconut: force build requires to alibuild-generate-module

### DIFF
--- a/coconut.sh
+++ b/coconut.sh
@@ -2,8 +2,10 @@ package: coconut
 version: "%(tag_basename)s"
 tag: "v0.19.80"
 build_requires:
+  - abseil
   - golang
   - protobuf
+  - c-ares
   - grpc
   - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/Control
@@ -26,6 +28,7 @@ pushd $BUILD
 popd
 
 #ModuleFile
+export FULL_BUILD_REQUIRES="$FULL_BUILD_REQUIRES $BUILD_REQUIRES"
 mkdir -p etc/modulefiles
 alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
aliBuild does not consider as a build require something which is marked as
runtime require by one of the packages in the chain. This is because it cannot
know if you will use only the toplevel package (coconut, in this case) or one
it's dependencies (nothing stops you from loading gRPC directly, once you have
built coconut). However this does not play well with the automatic generation
of modulefiles. We use the FULL_BUILD_REQUIRES to correct the behavior of
alibuild-generate-module.