### PR TITLE
MW2: bump gsl, libxml2, zlib, clang, libxml2

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -34,7 +34,6 @@ case $ARCHITECTURE in
   unknown*) DEFAULT_SYSROOT="" ;;
   *) DEFAULT_SYSROOT="" ;;
 esac
-
 # note that BUILD_SHARED_LIBS=ON IS NEEDED FOR ADDING DYNAMIC PLUGINS
 # to clang-tidy (for instance)
 cmake $SOURCEDIR/llvm \

--- a/gsl.sh
+++ b/gsl.sh
@@ -22,7 +22,6 @@ autoreconf -f -v -i
 make ${JOBS:+-j$JOBS}
 make ${JOBS:+-j$JOBS} install
 rm -fv $INSTALLROOT/lib/*.la
-
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -21,7 +21,6 @@ autoreconf -i
 
 make ${JOBS+-j $JOBS}
 make install
-
 # Modulefile
 mkdir -p etc/modulefiles
 cat > etc/modulefiles/$PKGNAME <<EoF

--- a/openssl.sh
+++ b/openssl.sh
@@ -37,6 +37,7 @@ make install_sw # no not install man pages
 rm -rf $INSTALLROOT/lib/pkgconfig \
        $INSTALLROOT/lib/*.a
 
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/zlib.sh
+++ b/zlib.sh
@@ -28,7 +28,6 @@ case $ARCHITECTURE in
 esac
 make ${JOBS+-j $JOBS}
 make install
-
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
There was a bad version of aliBuild which was used to kickstart the cc8
distribution which produced rpms. I had to bump revisions of a few packages in
order to get proper builds.