### PR TITLE
Bump O2 to v21.09

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -1,6 +1,6 @@
 package: O2
 version: "%(tag_basename)s"
-tag: v21.07
+tag: v21.09
 requires:
   - arrow
   - FairRoot


### PR DESCRIPTION
We need this to compile O2 with `o2-dataflow` defaults as now it fails due to lack of boost 1.75 fixes.