### PR TITLE
Fix common prefix in o2checkcode

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -16,7 +16,7 @@ cp "${O2_ROOT}"/compile_commands.json .
 # We will try to setup a list of files to be checked by using 2 specific Git commits to compare
 
 # Heuristically guess source directory
-O2_SRC=$(python3 -c 'import json,sys,os; sys.stdout.write( os.path.commonprefix([ x["file"] for x in json.loads(open("compile_commands.json").read()) if not "G__" in x["file"] and x["file"].endswith(".cxx") ]) )')
+O2_SRC=$(python3 -c 'import json, os; print(os.path.commonprefix([x["file"] for x in json.loads(open("compile_commands.json").read()) if "SOURCES" in x["file"] and "G__" not in x["file"] and x["file"].endswith(".cxx")]))')
 [[ -e "$O2_SRC"/CMakeLists.txt && -d "$O2_SRC"/.git ]]
 
 # We have something to compare our working directory to (ALIBUILD_BASE_HASH). We check only the


### PR DESCRIPTION
For some reason, O2's `compile_commands.json` in CI has started including the following path, in addition to the usual paths under `sw/SOURCES/`:

    .../sw/BUILD/$hash/O2/version/O2Version.cxx

This breaks the common-prefix heuristic here. This patch includes only files under `sw/SOURCES/` in the calculation, as originally intended, I presume.