### PR TITLE
Added O2sim recipe for the O2 simulation meta-package

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -27,6 +27,8 @@ disable:
   - JAliEn-ROOT
   - KFParticle
   - MCStepLogger
+  - O2sim
+  - O2-full-system-test
 overrides:
   Python-modules-list:
     env:

--- a/o2-full-system-test.sh
+++ b/o2-full-system-test.sh
@@ -2,6 +2,7 @@ package: O2-full-system-test
 version: "1.0"
 requires:
   - O2Suite
+  - O2sim
 force_rebuild: 1
 ---
 #!/bin/bash -e

--- a/o2sim.sh
+++ b/o2sim.sh
@@ -1,0 +1,12 @@
+package: O2sim
+version: "v%(year)s%(month)s%(day)s"
+requires:
+  - O2
+  - O2DPG
+  - AEGIS
+---
+#!/bin/bash -ex
+
+#ModuleFile
+mkdir -p $INSTALLROOT/etc/modulefiles
+alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME


### PR DESCRIPTION
@davidrohr @sawenzel @shahor02 
as discussed, here is the recipe for the `O2sim` meta-package.
It currently bundles the following packages together
* O2
* O2DPG
* AEGIS
