### PR TITLE
Recipes for OpenBLAS and Millepede-II

### DIFF
--- a/millepede-ii.sh
+++ b/millepede-ii.sh
@@ -1,0 +1,31 @@
+package: Millepede-II
+version: "%(tag_basename)s"
+tag: "V04-09-00"
+source: https://github.com/alisw/MillepedeII.git
+requires:
+ - zlib
+ - openmp
+ - OpenBLAS
+ - "GCC-Toolchain:(?!osx)"
+build_requires:
+ - alibuild-recipe-tools
+---
+#!/bin/bash -e
+
+rsync -av --delete --exclude="**/.git" ${SOURCEDIR}/ .
+
+case $ARCHITECTURE in
+    osx*)
+    [[ ! $ZLIB_ROOT ]] && ZLIB_ROOT=`brew --prefix zlib` ;;
+esac
+
+make pede\
+     ${ZLIB_ROOT:+ ZLIB_INCLUDES_DIR=${ZLIB_ROOT}/include ZLIB_LIBS_DIR=${ZLIB_ROOT}/lib}\
+     ${OPENBLAS_ROOT:+ SUPPORT_LAPACK64=yes LAPACK64=OPENBLAS LAPACK64_LIBS_DIR=${OPENBLAS_ROOT}/lib LAPACK64_LIB=openblas}
+      
+rsync -a --delete pede ${INSTALLROOT}/bin/
+
+#ModuleFile
+mkdir -p etc/modulefiles
+alibuild-generate-module --bin > etc/modulefiles/$PKGNAME
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/openblas.sh
+++ b/openblas.sh
@@ -1,0 +1,29 @@
+package: OpenBLAS
+version: "%(tag_basename)s"
+tag: "v0.3.13"
+source: https://github.com/xianyi/OpenBLAS.git
+requires:
+ - openmp
+ - "GCC-Toolchain:(?!osx)"
+build_requires:
+ - CMake
+ - alibuild-recipe-tools
+---
+#!/bin/bash -e
+
+cmake $SOURCEDIR                                 \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT        \
+      -DDYNAMIC_ARCH=ON                           \
+      -DBUILD_WITHOUT_LAPACK=OFF                  \
+      -DBUILD_SHARED_LIBS=ON                     
+make ${JOBS:+-j$JOBS}
+make install 
+
+#ModuleFile
+mkdir -p etc/modulefiles
+alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+
+
+
+


### PR DESCRIPTION
Millepede is a separate executable used for detector alignment. It's a bit dated and only available on SVN thus was cloned to a git repo using git-svn.
OpenBLAS is a requirement for Millepede-II