### PR TITLE
Fix libboost* deletion from INSTALLROOT for DDS

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -40,7 +40,7 @@ esac
 
 make -j$JOBS install
 
-find $INSTALLROOT -path "*/lib/libboost_*" -o -path "*/lib64/libboost_*" -delete
+find $INSTALLROOT -path "*/lib/libboost_*" -delete -o -path "*/lib64/libboost_*" -delete
 rm -f "$INSTALLROOT/LICENSE"
 
 # ModuleFile

--- a/dds.sh
+++ b/dds.sh
@@ -40,7 +40,7 @@ esac
 
 make -j$JOBS install
 
-find $INSTALLROOT -path "*/lib/libboost_*" -delete -o -path "*/lib64/libboost_*" -delete
+find $INSTALLROOT -path "*/lib/libboost_*" -delete
 rm -f "$INSTALLROOT/LICENSE"
 
 # ModuleFile


### PR DESCRIPTION
The `-delete` statement was only tied to the second part of the "OR" expression specified by `-o`, leaving `libboost_*` files under the installed `lib` dir.