### PR TITLE
xjalienfs :: tag 1.2.9

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.2.8"
+tag: "1.2.9"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Brief user-centric changelog:  
- XrootdCp:: add -strictspec and -http options
- XrootdCp::makelist_xrdjobs:: enforce unix authentication 
- MyCopyProgressHandler::end ::  fix deletion of meta file
- XrootD::cp rework the checks and messages to be clear and informative
- XRootD::cp fix the return/message for the single file copies with destionation already present
- add SEqos command and the internal get_qos
- add certkey-match and tokenkey-match commands
- add {cert,token}-verify commands
- XRootD:: uploads will default to 4 replicas ONLY if absolutly no specs given
- XRootD:: uploads will default to 4 replicas for any .sh, .C, .jdl, .xml smaller than 1MiB
