### PR TITLE
Force building of yaml-cpp on Ubuntu 20.04

### DIFF
--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -6,7 +6,7 @@ requires:
   - boost
 build_requires:
   - CMake
-prefer_system: (?!slc5)
+prefer_system: (?!slc5|ubuntu2004)
 prefer_system_check: |
   pkg-config --atleast-version=0.6.2 yaml-cpp && printf "#include \"yaml-cpp/yaml.h\"\n" | c++ -std=c++17 -I`brew --prefix yaml-cpp`/include -I`brew --prefix boost`/include -xc++ - -c -o /dev/null
 ---


### PR DESCRIPTION
To fix the FairRoot build, which fails if yaml-cpp is picked up from the system.

Reported here: https://alice-talk.web.cern.ch/t/o2-build-fails-in-fairrot-v18-4-1-on-ubuntu-20-04/799
and several times before.