### PR TITLE
Fix O2_SRC computation, for dev packages

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -16,7 +16,7 @@ cp "${O2_ROOT}"/compile_commands.json .
 # We will try to setup a list of files to be checked by using 2 specific Git commits to compare
 
 # Heuristically guess source directory
-O2_SRC=$(python3 -c 'import json, os; print(os.path.commonprefix([x["file"] for x in json.loads(open("compile_commands.json").read()) if "SOURCES" in x["file"] and "G__" not in x["file"] and x["file"].endswith(".cxx")]))')
+O2_SRC=$(python3 -c 'import json, os; print(os.path.commonprefix([x["file"] for x in json.loads(open("compile_commands.json").read()) if "BUILD" not in x["file"] and "G__" not in x["file"] and x["file"].endswith(".cxx")]))')
 [[ -e "$O2_SRC"/CMakeLists.txt && -d "$O2_SRC"/.git ]]
 
 # We have something to compare our working directory to (ALIBUILD_BASE_HASH). We check only the


### PR DESCRIPTION
For example in AliceO2Group/AliceO2#5745, `.cxx` files don't have paths in `SOURCES`, but in the development package, such as `.../o2-fullci/O2/Common/MathUtils/src/Cartesian.cxx`.