### PR TITLE
Remove HIJING requirement

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -5,7 +5,6 @@ requires:
   - arrow
   - FairRoot
   - Vc
-  - hijing
   - HepMC3
   - libInfoLogger
   - Common-O2


### PR DESCRIPTION
not sure why HIJING is set as a requirement for the O2.
Removing it, I don't think this will break anything and it should not be there in principle.