### PR TITLE
Bump pythia8 version in o2 defaults

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -20,7 +20,7 @@ overrides:
       - ZeroMQ
       - JAliEn-ROOT
   pythia:
-    tag: "v8302"
+    tag: "v8302-p1"
     requires:
       - lhapdf
       - boost


### PR DESCRIPTION
brings in the commit merged recently
https://github.com/alisw/pythia8/commit/3abbf0e074b4a51c2f86b9c4ba14d043532eb9b1