### PR TITLE
Bump FairMQ to v1.4.34

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.33
+tag: v1.4.34
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
This version includes potential fix and/or debugging tools for O2-2161.