### PR TITLE
Fix xjalienfs shebang replacement

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -19,9 +19,19 @@ fi
 env PYTHONUSERBASE="$INSTALLROOT" ALIBUILD=1 python3 -m pip install --ignore-installed $PIPOPTION file://${SOURCEDIR}
 
 # Make sure all the tools use the correct python
-mkdir -p ${INSTALLROOT}/bin 
-find ${INSTALLROOT}/bin -type f -exec sed -i".bak" 's/#!.*python.*/#!\/usr\/bin\/env python3/' '{}' \;
-rm -fv ${INSTALLROOT}/bin/*.bak
+mkdir -p "$INSTALLROOT/bin"
+for binfile in "$INSTALLROOT"/bin/*; do
+  [ -f "$binfile" ] || continue
+  if grep -q "^'''exec' .*python.*" "$binfile"; then
+    # This file uses a hack to get around shebang size limits. As we're
+    # replacing the shebang with the system python, the limit doesn't apply and
+    # we can just use a normal shebang.
+    sed -i.bak '1d; 2d; 3d; 4s,^,#!/usr/bin/env python3\n,' "$binfile"
+  else
+    sed -i.bak '1s,^#!.*python.*,#!/usr/bin/env python3,' "$binfile"
+  fi
+done
+rm -fv "$INSTALLROOT"/bin/*.bak
 
 if [ -d ${INSTALLROOT}/lib ]; then
   pushd ${INSTALLROOT}/lib


### PR DESCRIPTION
If we're building in a deeply-nested subdirectory, the scripts' shebangs will be over 127 bytes, and therefore pip will use a hack to embed the python command line, like:

```bash
#!/bin/sh
'''exec' /some/long/path/to/our/python3 "$0" "$@"
' '''
```

We want to replace this to use the system python3, but as that's a short shebang, we can just use a regular `#!` line. The new command detects the above case, deletes the first 3 lines, and inserts a regular `#!/usr/bin/env python3` shebang instead.

If pip generates scripts with a regular shebang like:

```bash
#!/some/shortish/path/to/our/python3
```

...we just replace the shebang with one pointing to the system python3.