### PR TITLE
Bump flatbuffers to  v1.12.0

### DIFF
--- a/flatbuffers.sh
+++ b/flatbuffers.sh
@@ -1,5 +1,5 @@
 package: flatbuffers
-version: v1.11.0
+version: v1.12.0
 source: https://github.com/google/flatbuffers
 requires:
   - zlib


### PR DESCRIPTION
Required to compile with new XCode 12.5.