### PR TITLE
FairMQ: bump to v1.4.35.2

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,8 +1,8 @@
 package: FairMQ
 # version: "%(tag_basename)s"
 # tag: v1.4.35 TODO switch back to version tags once 1.4.36 is released
-version: "v1.4.35.1"
-tag: v1.4.35_hotfix_alice
+version: "v1.4.35.2"
+tag: v1.4.35_hotfix_alice2
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Adds a fix for `O2-2227`.

https://github.com/FairRootGroup/FairMQ/compare/v1.4.35_hotfix_alice...v1.4.35_hotfix_alice2