### PR TITLE
TEST: First go at making package for AliRivetTask

### DIFF
--- a/rivettask.sh
+++ b/rivettask.sh
@@ -1,0 +1,46 @@
+package: AliRivetTask
+version: "%{year}s%{month}s%{day}s"
+source: https://gitlab.cern.ch/cholm/alice-rivet-task
+requires:
+  - Rivet
+  - AliRoot 
+build_requires:
+  - GCC-Toolchain:(?!osx)
+  - alibuild-recipe-tools
+---
+#!/bin/bash -e
+
+# Echo all commands
+set -x
+
+# Picking up ROOT from the system when ours is disabled
+[[ -z "$ROOT_ROOT" ]] && ROOT_ROOT="$(root-config --prefix)"
+
+# Print environment to see what is going on - debugging
+printenv
+
+# Copy code here 
+cp ${SOURCEDIR}/AliRivetTask.C .
+cp ${SOURCEDIR}/Build.C .
+
+# Use AcLic to build 
+root -l -b -q Build.C
+
+# Install binary, scripts, and code 
+mkdir -p ${INSTALLROOT}/lib
+mkdir -p ${INSTALLROOT}/include
+mkdir -p ${INSTALLROOT}/share
+cp ${SOURCEDIR}/AliRivetTask.C p ${INSTALLROOT}/include
+cp ${SOURCEDIR}/AliRivetTask_C*  ${INSTALLROOT}/lib/
+cp ${SOURCEDIR}/AddTaskRivet.C   ${INSTALLROOT}/share/
+cp ${SOURCEDIR}/RivetConfig.C    ${INSTALLROOT}/share/
+
+#ModuleFile
+mkdir -p modulefiles
+alibuild-generate-module > etc/modulefiles/$PKGNAME
+cat >> modulefiles/${PKGNAME} <<EOF
+
+EOF
+mkdir -p $INSTALLROOT/etc/modulefiles && \
+    rsync -a --delete modulefiles/ $INSTALLROOT/etc/modulefiles
+

--- a/rivettask.sh
+++ b/rivettask.sh
@@ -1,4 +1,4 @@
-package: AliRivetTask
+package: RivetTask
 version: "%{year}s%{month}s%{day}s"
 source: https://gitlab.cern.ch/cholm/alice-rivet-task
 requires:


### PR DESCRIPTION
This is a go at making a package of the project `AliRivetTask` (see https://gitlab.cern.ch/cholm/alice-rivet-task).  The project defines a standard AliRoot task to run Rivet analyses on simulation productions.  More details are available from the project gitlab page and in a presentation given in PWGMM (see https://indico.cern.ch/event/1029448/#7-new-development-aliphysics-a). 

This package depends on AliRoot and Rivet meaning it will hopefully ensure compatible builds of these two packages (the culprit seems to be fastjet which is a common dependency between those two packages).   Other than that, it uses ROOT AcLic to build the binary plugin which is then put in `${INSTALLDIR}/lib/AliRivetTask_C.so`.  Macros, etc. are put in `${INSTALLDIR}/share`.  The source code is put in `${INSTALLDIR}/include/AliRivetTask.C`.   This is mainly so that clients may pick up the relevant code. 