### PR TITLE
Specify ROOTSYS to current aliBuild ROOT version

### DIFF
--- a/roounfold.sh
+++ b/roounfold.sh
@@ -10,6 +10,7 @@ cmake $SOURCEDIR                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD} \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}    \
+      -DROOT_DIR=$ROOTSYS \
       -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j$JOBS} install
 #make test

--- a/roounfold.sh
+++ b/roounfold.sh
@@ -10,7 +10,7 @@ cmake $SOURCEDIR                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \
       ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD} \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"}    \
-      -DROOT_DIR=$ROOTSYS \
+      -DROOT_DIR=$ROOT_ROOT \
       -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j$JOBS} install
 #make test


### PR DESCRIPTION
Needed in order to force compilation against ROOT from
alidist in case system ROOT versions are present.