### PR TITLE
[O2-2293] Add python module to access Consul to o2-dataflow

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -38,6 +38,12 @@ overrides:
         responses==0.10.6
         PyYAML==5.1
         python-consul==1.1.0
+      PIP36_REQUIREMENTS: |
+        python-consul==1.1.0
+      PIP38_REQUIREMENTS: |
+        python-consul==1.1.0
+      PIP39_REQUIREMENTS: |
+        python-consul==1.1.0
   O2-customization:
     env:
       ENABLE_UPGRADES: OFF # Disable detector upgrades in O2

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -37,6 +37,7 @@ overrides:
         dryable==1.0.3
         responses==0.10.6
         PyYAML==5.1
+        python-consul==1.1.0
   O2-customization:
     env:
       ENABLE_UPGRADES: OFF # Disable detector upgrades in O2


### PR DESCRIPTION
Get Python module to access consul. Only in o2-dataflow. The other solution we tried was to use ansible. However, it makes us rely on an external repo from within CR1. There are other solutions of course, with mirroring the modules repository but it becomes a complicated, time consuming, activity for just a little python module.  