### PR TITLE
Bump FairMQ to 1.4.37

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,8 +1,6 @@
 package: FairMQ
-# version: "%(tag_basename)s"
-# tag: v1.4.35 TODO switch back to version tags once 1.4.36 is released
-version: "v1.4.35.2"
-tag: v1.4.35_hotfix_alice2
+version: "%(tag_basename)s"
+tag: v1.4.36
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.36
+tag: v1.4.37
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
@ktf includes proper fixes for the two previous hotfixes for filesystem and the plugin changes.
@ironMann includes the region caching. This also includes a possibility to pass option for UnmanagedRegion creation: https://github.com/FairRootGroup/FairMQ/blob/master/examples/region/Sampler.cxx#L55
The two options will mlock and/or zero the region memory *before the region event callbacks are called*, like we discussed in the GPU meeting. This is non-breaking as it is an optional argument.