### PR TITLE
datadist: bump 0.10.8

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v0.10.6
+tag: v0.10.8
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
bump for MW5
requires FMQ 1.4.37