### PR TITLE
Switch from ThePEG v2.2.0 to v2.2.2

### DIFF
--- a/thepeg.sh
+++ b/thepeg.sh
@@ -1,6 +1,6 @@
 package: ThePEG
 version: "%(tag_basename)s"
-tag: "v2.2.0"
+tag: "v2.2.2"
 source: https://github.com/alisw/thepeg
 requires:
   - Rivet


### PR DESCRIPTION
Requestd by @mfasDa, needed along the ongoing update of Herwig v7.2.0 to v7.2.2