### PR TITLE
Switch from Herwig v7.2.0 to v7.2.2

### DIFF
--- a/herwig.sh
+++ b/herwig.sh
@@ -1,6 +1,6 @@
 package: Herwig
 version: "%(tag_basename)s"
-tag: "v7.2.0"
+tag: "v7.2.2"
 source: https://github.com/alisw/herwig
 requires:
   - GMP


### PR DESCRIPTION
See also the dependency to thePEG v2.2.2, also upgraded from its v2.2.0
Update of ThePEG recipe thepeg.sh : https://github.com/alisw/alidist/pull/3033