### PR TITLE
xjalienfs:: update to 1.3.0

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.2.9"
+tag: "1.3.0"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Sort of emergency release as the websockets upstream module changed signatures and the current usage is no longer compatible with python 3.9.
Short changelog:
* fix python3.9 incompatibility with websocket return type
* significant refactoring of internal XRootD usage framework
* XRootD :: use internal EnvPut for setting client variables
* XRootD :: enable prefix-less usage
* XRootD :: add -timeout and -ratethreshold to set the corresponding capabilities in XRootD 5.2
* re.Pattern does not exists on python 3.6, workaround this
* websockets exceptions can be referenced directly
* XrootdCp:: add skeleton for system xrdcp usage
* websockets.connect :: add User-Agent header
* XrootdCp:: -noxrdzip option for avoidance of xrootd native zip processing