### PR TITLE
Bump monitoring to v3.8.5

### DIFF
--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v3.8.4
+tag: v3.8.5
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Auto-generated PR for the following release https://github.com/AliceO2Group/Monitoring/releases/tag/v3.8.5