### PR TITLE
Add new asio v1.18.1

### DIFF
--- a/asio.sh
+++ b/asio.sh
@@ -1,0 +1,35 @@
+package: asio
+version: "%(tag_basename)s"
+tag: v1.18.1
+source: https://github.com/FairRootGroup/asio
+build_requires:
+  - CMake
+prepend_path:
+  ROOT_INCLUDE_PATH: "$ASIO_ROOT/include"
+---
+#!/bin/sh
+
+cmake -S $SOURCEDIR -B .                                        \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                       \
+      ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                 \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}
+
+cmake --build . --target install
+
+# Modulefile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0
+# Our environment
+set ASIO_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path ROOT_INCLUDE_PATH \$ASIO_ROOT/include
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
This is in preparation of upcoming *FairMQ* and *asiofi* releases.

Upstream only ships a Makefile based installation, which lacks a CMake package, which would require maintaining a `Findasio.cmake` module somewhere (possibly duplicating to multiple repos -> maintenance hell). So, in the [FairRootGroup/asio](https://github.com/FairRootGroup/asio) fork - that is used here - a CMake-based install routine is added which also installs a CMake package for asio. If - for policy reasons - you want the source repo to be part of the `alisw` github organization, feel free to fork the repo (I do not have permission to create repos there) and I am happy to adapt the recipe.

---

Rationale for standalone asio:

*in short*: It will be required by upcoming *FairMQ* and *asiofi* releases.

*in long*: [asio](https://github.com/chriskohlhoff/asio) is usually distributed in 2 variants AFAIK:
1. Standalone (`#include <asio.hpp>`)
   1.a. no dependencies, relies on std lib facilities only (`<regex>`, `<system_error>`, `<chrono>`, [see full list](https://github.com/chriskohlhoff/asio/blob/77bcfe775ad63178942c9dd95d93edd10442b80f/asio/include/asio/detail/config.hpp#L28-L39) - the point here is, all of those are **public** dependencies because asio is header-only)
   1.b. configured `--with-boost`, meaning it uses the boost facilities for regex, error code, chrono etc
2. as Boost.Asio (`#include <boost/asio.hpp>`), only in variant b (`--with-boost` facilities)

(Just if you are wondering: Variants 1.b (e.g. [debian](https://packages.debian.org/source/sid/asio), [ubuntu](https://packages.ubuntu.com/source/impish/asio), [fedora/centos-epel](https://src.fedoraproject.org/rpms/asio), [arch](https://archlinux.org/packages/extra/any/asio/)) and 2 (just any boost system packages) are found as distro packages since a long time and work alongside each other just fine (different install trees). If you are wondering why variant 1.a is not found as much, it is most likely for historical reasons, asio is a few years old already (and so are the standalone system packages) and std library facilities were just not available. Only in 2019 asio [switched the default to non-boost standalone](https://github.com/chriskohlhoff/asio/commit/265e75cdbba739b1b1e3a46b283eaee3b9c60fe8))

In the FairMQ SDK (`-DBUILD_SDK=ON`) we require variant 1.a and so far have been bundling it as a **public** dependency (it is installed alongside FairMQ headers in `include/fairmq/bundled/asio`). But this bundling of a public dependency is not a good idea and will be dropped in one of the upcoming FairMQ versions and certainly before the FairMQ SDK component becomes a stable (right now it is still experimental).

The core FairMQ library (`-DBUILD_FAIRMQ=ON`, which is the default, but can be switched off if one wanted to only build the SDK) also has a tiny **public** dependency to Boost.Asio (`<fairmq/tools/Network.h>`). In an upcoming release, this will be changed to be a **private** dependency to asio (variant 1.a).

So, FairMQ as a package (in an upcoming release) will continue to bundle standalone asio (1.a) for the following config (`-DBUILD_SDK=OFF -DBUILD_FAIRMQ=ON -DBUILD_OFI_TRANSPORT=OFF`) because in this case it will be a pure **private** dependency. When building the SDK (used by ODC) and/or the ofi transport (used by ? at the moment, but will be used by DD soon) FairMQ as a package will **require** an external installation of asio (1.a). (FYI, `asiofi` the C++ interface to `libfabric` we developed and which is used by the FairMQ ofi transport, also will have a **public** dependency to asio (1.a), right now it has a **public** dependency to Boost.Asio (2) still).

**In general**, the decision to move away from Boost.Asio (2) is to improve maintainability for both the FairMQ and related code bases and also for package management. We use very recent asio features and that was leading to basically requiring a very recent Boost release which has been impacting tons of other libraries and packages in the software stack. (I know, this is not a particular issue for Alice, because Alice has a sophisticated package management system which usually ships very recent Boost versions, but I am making the general argument here).

**In theory**, we could have switches/adapters/aliases/macros in our code base to switch between `::asio` and `::boost::asio` and all through asio exposed facilities `::std` <-> `::boost`, but this will come with a significant cost and overall decrease in maintainability and readability vs the flexibility gains being able to take asio from any distribution form out there IMHO. In the end, asio is a pretty cheap dependency in variant 1.a: no deps except standard library and header-only.