### PR TITLE
Enable libjalien

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -17,7 +17,6 @@ disable:
   - GEANT4
   - GEANT3
   - GEANT4_VMC
-  - libjalienO2
   - pythia
   - pythia6
   - hijing


### PR DESCRIPTION
Because it is needed by O2 for CCDB.