### PR TITLE
Update GEANT4 to v10.7.2:

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -1,6 +1,6 @@
 package: GEANT4
 version: "%(tag_basename)s"
-tag: "v10.7.1"
+tag: "v10.7.2"
 source: https://gitlab.cern.ch/geant4/geant4.git
 requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
The last patch (p02) includes a fix needed when using the FTFP_BERT physics list with biasing option