### PR TITLE
Use alibuild-generate-module for as many recipes as possible

### DIFF
--- a/abseil.sh
+++ b/abseil.sh
@@ -23,11 +23,8 @@ make ${JOBS:+-j$JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
-
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<EoF
 # Our environment
 set ABSEIL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$ABSEIL_ROOT/bin

--- a/aegis.sh
+++ b/aegis.sh
@@ -8,6 +8,7 @@ build_requires:
   - CMake
   - hijing
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/AEGIS.git
 prepend_path:
   LD_LIBRARY_PATH: "$AEGIS_ROOT/lib"
@@ -29,21 +30,7 @@ cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION 
-# Our environment
-set AEGIS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv AEGIS_ROOT \$AEGIS_ROOT
-prepend-path LD_LIBRARY_PATH \$AEGIS_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$AEGIS_ROOT/include
+alibuild-generate-module --lib --root-env > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF

--- a/agile.sh
+++ b/agile.sh
@@ -11,6 +11,7 @@ requires:
 build_requires:
   - "autotools:(slc6|slc7)"
   - SWIG
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 
@@ -36,22 +37,7 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 HepMC/$HEPMC_VERSION-$HEPMC_REVISION lhapdf5/${LHAPDF5_VERSION}-${LHAPDF5_REVISION} ${BOOST_ROOT:+boost/$BOOST_VERSION-$BOOST_REVISION} ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}
-# Our environment
-set AGILE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv AGILE_ROOT \$AGILE_ROOT
-prepend-path PYTHONPATH \$AGILE_ROOT/lib/python2.7/site-packages
-prepend-path PATH \$AGILE_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$AGILE_ROOT/lib
+alibuild-generate-module --bin --lib --root-env --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path PYTHONPATH $PKG_ROOT/lib/python2.7/site-packages
 EoF

--- a/alibuild-recipe-tools.sh
+++ b/alibuild-recipe-tools.sh
@@ -3,24 +3,8 @@ version: "0.2.2"
 tag: "v0.2.2"
 source: https://github.com/alisw/alibuild-recipe-tools
 ---
-mkdir -p $INSTALLROOT/bin
-install $SOURCEDIR/alibuild-generate-module $INSTALLROOT/bin
+install -D "$SOURCEDIR/alibuild-generate-module" "$INSTALLROOT/bin"
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set ALIBUILD_RECIPE_TOOLS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$ALIBUILD_RECIPE_TOOLS_ROOT/lib
-prepend-path PATH \$ALIBUILD_RECIPE_TOOLS_ROOT/bin
-EoF
+"$INSTALLROOT/bin/alibuild-generate-module" --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/alien-cas.sh
+++ b/alien-cas.sh
@@ -14,9 +14,7 @@ find $SOURCEDIR -type d -maxdepth 1 -mindepth 1 -exec rsync -av {}/ $DEST \;
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module > $MODULEFILE
-cat >> "$MODULEFILE" <<EOF
-setenv X509_CERT_DIR \$::env(BASEDIR)/AliEn-CAs/\$version/globus/share/certificates
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<\EOF
+setenv X509_CERT_DIR $::env(BASEDIR)/AliEn-CAs/$version/globus/share/certificates
 EOF

--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -11,6 +11,7 @@ build_requires:
  - AliEn-CAs
  - ApMon-CPP
  - UUID
+ - alibuild-recipe-tools
 env:
   X509_CERT_DIR: "$ALIEN_RUNTIME_ROOT/globus/share/certificates"
 ---
@@ -29,21 +30,7 @@ rm -f $INSTALLROOT/lib/pkgconfig/zlib.pc
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set ALIEN_RUNTIME_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$ALIEN_RUNTIME_ROOT/lib
-prepend-path PATH \$ALIEN_RUNTIME_ROOT/bin
-setenv X509_CERT_DIR \$ALIEN_RUNTIME_ROOT/globus/share/certificates
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+setenv X509_CERT_DIR $PKG_ROOT/globus/share/certificates
 EoF

--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -8,6 +8,7 @@ requires:
   - KFParticle
 build_requires:
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 source: https://github.com/alisw/AliPhysics
 env:
   ALICE_PHYSICS: "$ALIPHYSICS_ROOT"
@@ -88,16 +89,7 @@ fi
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION ${ROOUNFOLD_REVISION:+RooUnfold/$ROOUNFOLD_VERSION-$ROOUNFOLD_REVISION} ${TREELITE_REVISION:+treelite/$TREELITE_VERSION-$TREELITE_REVISION} ${KFPARTICLE_REVISION:+KFParticle/$KFPARTICLE_VERSION-$KFPARTICLE_REVISION}
+alibuild-generate-module --extra > "etc/modulefiles/$PKGNAME" <<EoF
 # Our environment
 setenv ALIPHYSICS_VERSION \$version
 setenv ALIPHYSICS_RELEASE \$::env(ALIPHYSICS_VERSION)

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -12,6 +12,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 env:
   ALICE_ROOT: "$ALIROOT_ROOT"
 prepend_path:
@@ -118,24 +119,7 @@ rsync -av $SOURCEDIR/test/ $INSTALLROOT/test
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                                                                \\
-            ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION}                                                     \\
-            ${DPMJET_REVISION:+DPMJET/$DPMJET_VERSION-$DPMJET_REVISION}                                             \\
-            ${FASTJET_REVISION:+fastjet/$FASTJET_VERSION-$FASTJET_REVISION}                                         \\
-            ${GEANT3_REVISION:+GEANT3/$GEANT3_VERSION-$GEANT3_REVISION}                                             \\
-            ${GEANT4_VMC_REVISION:+GEANT4_VMC/$GEANT4_VMC_VERSION-$GEANT4_VMC_REVISION}                             \\
-            ${VC_REVISION:+Vc/$VC_VERSION-$VC_REVISION}                                                             \\
-            ${JALIEN_ROOT_REVISION:+JAliEn-ROOT/$JALIEN_ROOT_VERSION-$JALIEN_ROOT_REVISION}                         \\
-            ${ALIEN_ROOT_LEGACY_REVISION:+AliEn-ROOT-Legacy/$ALIEN_ROOT_LEGACY_VERSION-$ALIEN_ROOT_LEGACY_REVISION}
+alibuild-generate-module --extra > "etc/modulefiles/$PKGNAME" <<EoF
 # Our environment
 set ALIROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv ALIROOT_VERSION \$version

--- a/arrow.sh
+++ b/arrow.sh
@@ -109,11 +109,8 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
-
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<EoF
 # Our environment
 set ARROW_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$ARROW_ROOT/lib

--- a/bz2.sh
+++ b/bz2.sh
@@ -4,6 +4,7 @@ tag: 8ca1faa31f396d94ab927b257f3a05236c84e330
 source: https://github.com/alisw/bzip2
 build_requires:
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <bzlib.h>\n" | c++ -xc++ - -c -o /dev/null
@@ -16,19 +17,5 @@ make ${JOBS:+-j $JOBS} CFLAGS="-O2 -fPIC -D_FILE_OFFSET_BITS=64" PREFIX=$INSTALL
 # Not really needed. Just in case someone decides to build shared libraries
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set BASEDIR \$::env(BASEDIR)
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-EoF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"

--- a/c-ares.sh
+++ b/c-ares.sh
@@ -4,6 +4,7 @@ tag: cares-1_17_1
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - CMake
+  - alibuild-recipe-tools
 source: https://github.com/c-ares/c-ares
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
@@ -17,20 +18,5 @@ make ${JOBS:+-j$JOBS} install
 
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set C_ARES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$C_ARES_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$C_ARES_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/cgal.sh
+++ b/cgal.sh
@@ -7,6 +7,7 @@ build_requires:
   - MPFR
   - CMake
   - system-curl
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in
@@ -72,21 +73,5 @@ make install VERBOSE=1
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
-# Our environment
-set CGAL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv CGAL_ROOT \$CGAL_ROOT
-prepend-path PATH \$CGAL_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$CGAL_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/clang.sh
+++ b/clang.sh
@@ -10,6 +10,7 @@ build_requires:
  - CMake
  - system-curl
  - ninja
+ - alibuild-recipe-tools
 ---
 #!/bin/sh
 
@@ -93,20 +94,7 @@ chmod u+x $INSTALLROOT/bin-safe/git-clang-format
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                          \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set CLANG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$CLANG_ROOT/bin-safe
-prepend-path LD_LIBRARY_PATH \$CLANG_ROOT/lib
+alibuild-generate-module --lib --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+prepend-path PATH $PKG_ROOT/bin-safe
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/coconut.sh
+++ b/coconut.sh
@@ -5,6 +5,7 @@ build_requires:
   - golang
   - protobuf
   - grpc
+  - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/Control
 ---
 #!/bin/bash -e
@@ -26,21 +27,5 @@ popd
 
 #ModuleFile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-
-# Our environment
-set COCONUT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$COCONUT_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$COCONUT_ROOT/lib
-EoF
-
+alibuild-generate-module --bin --lib > "etc/modulefiles/$PKGNAME"
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/control-core.sh
+++ b/control-core.sh
@@ -27,22 +27,6 @@ pushd $BUILD
 popd
 
 #ModuleFile
-mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-
-# Our environment
-set CONTROL_CORE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$CONTROL_CORE_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$CONTROL_CORE_ROOT/lib
-EoF
-
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+mkdir -p etc/modulefiles "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "etc/modulefiles/$PKGNAME"
+rsync -a --delete etc/modulefiles/ "$INSTALLROOT/etc/modulefiles"

--- a/delphes.sh
+++ b/delphes.sh
@@ -8,6 +8,7 @@ requires:
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 source: https://github.com/alisw/delphes.git
 #prepend_path:
 #  LD_LIBRARY_PATH: "$O2_ROOT/lib"
@@ -22,29 +23,8 @@ cmake --build . -- ${JOBS:+-j$JOBS} install
 
 #ModuleFile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                                                \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
-            ${PYTHIA_REVISION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION}                             \\
-            ${HEPMC_REVISION:+HepMC/$HEPMC_VERSION-$HEPMC_REVISION}                                 \\
-            ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION}                                     \\
-
-# Delphes environment:
-set DELPHES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv DELPHES_ROOT \$DELPHES_ROOT
-
-prepend-path PATH \$DELPHES_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$DELPHES_ROOT/lib
-prepend-path LD_LIBRARY_PATH \$DELPHES_ROOT/lib64
-prepend-path ROOT_INCLUDE_PATH \$DELPHES_ROOT/include
-
+alibuild-generate-module --bin --lib --root-env --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+prepend-path LD_LIBRARY_PATH $PKG_ROOT/lib64
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/double-conversion.sh
+++ b/double-conversion.sh
@@ -3,6 +3,7 @@ version: v3.1.5
 source: https://github.com/google/double-conversion
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 
 mkdir -p $INSTALLROOT
@@ -26,17 +27,5 @@ make ${JOBS:+-j $JOBS} install
 # Trivial module file to keep the linter happy.
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-EoF
+alibuild-generate-module > "$MODULEDIR/$PKGNAME"

--- a/dpmjet.sh
+++ b/dpmjet.sh
@@ -7,6 +7,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 FVERSION=`gfortran --version | grep -i fortran | sed -e 's/.* //' | cut -d. -f1`
@@ -24,21 +25,5 @@ make ${JOBS+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set DPMJET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv DPMJET_ROOT \$DPMJET_ROOT
-prepend-path PATH \$DPMJET_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$DPMJET_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -7,6 +7,7 @@ requires:
 build_requires:
  - CMake
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
@@ -40,21 +41,8 @@ cmake --build . --target install ${JOBS:+-- -j$JOBS}
 
 # ModuleFile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                        \
-       ${FMT_REVISION:+fmt/${FMT_VERSION}-${FMT_REVISION}}
-# Our environment
-set FAIRLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$FAIRLOGGER_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$FAIRLOGGER_ROOT/include
+alibuild-generate-module --lib --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 mkdir -p $MODULEDIR && rsync -a --delete etc/modulefiles/ $MODULEDIR

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -12,6 +12,8 @@ requires:
   - FairMQ
   - yaml-cpp
   - "GCC-Toolchain:(?!osx)"
+build_requires:
+  - alibuild-recipe-tools
 env:
   VMCWORKDIR: "$FAIRROOT_ROOT/share/fairbase/examples"
   GEOMPATH:   "$FAIRROOT_ROOT/share/fairbase/examples/common/geometry"
@@ -75,38 +77,10 @@ done
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                                            \\
-            ${FAIRLOGGER_REVISION:+FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION}         \\
-            ${FAIRMQ_REVISION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION}                         \\
-            ${GEANT3_REVISION:+GEANT3/$GEANT3_VERSION-$GEANT3_REVISION}                         \\
-            ${GEANT4_VMC_REVISION:+GEANT4_VMC/$GEANT4_VMC_VERSION-$GEANT4_VMC_REVISION}         \\
-            ${PROTOBUF_REVISION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}                 \\
-            ${PYTHIA6_REVISION:+pythia6/$PYTHIA6_VERSION-$PYTHIA6_REVISION}                     \\
-            ${PYTHIA_REVISION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION}                         \\
-            ${VGM_REVISION:+vgm/$VGM_VERSION-$VGM_REVISION}                                     \\
-            ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}                             \\
-            ROOT/$ROOT_VERSION-$ROOT_REVISION                                                   \\
-            ${ZEROMQ_REVISION:+ZeroMQ/$ZEROMQ_VERSION-$ZEROMQ_REVISION}                         \\
-            ${DDS_REVISION:+DDS/$DDS_VERSION-$DDS_REVISION}                                     \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set FAIRROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv VMCWORKDIR \$FAIRROOT_ROOT/share/fairbase/examples
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME" <<EoF
+setenv VMCWORKDIR \$PKG_ROOT/share/fairbase/examples
 setenv GEOMPATH \$::env(VMCWORKDIR)/common/geometry
 setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig
-prepend-path PATH \$FAIRROOT_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$FAIRROOT_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$FAIRROOT_ROOT/include
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/flatbuffers.sh
+++ b/flatbuffers.sh
@@ -6,6 +6,7 @@ requires:
 build_requires:
  - CMake
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   which flatc && printf "#include \"flatbuffers/flatbuffers.h\"\nint main(){}" | c++ -I$(brew --prefix flatbuffers)/include -xc++ -std=c++11 - -o /dev/null
@@ -25,21 +26,5 @@ done
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${ZLIB_REVISION:+zlib/${ZLIB_VERSION}-${ZLIB_REVISION}}
-# Our environment
-set FLATBUFFERS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$FLATBUFFERS_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$FLATBUFFERS_ROOT/lib
-prepend-path PATH \$FLATBUFFERS_ROOT/bin
-EoF
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/fluka.sh
+++ b/fluka.sh
@@ -31,10 +31,6 @@ cp -rf $BUILDDIR/bin $BUILDDIR/lib $BUILDDIR/include $BUILDDIR/data $INSTALLROOT
 
 #ModuleFile
 mkdir -p $INSTALLROOT/etc/modulefiles
-alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME
-cat >> $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-# Our environment
-set FLUKA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FLUPRO \$::env(BASEDIR)/$PKGNAME/\$version/lib
-prepend-path PATH \$FLUKA_ROOT/bin
+alibuild-generate-module --bin --extra > "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv FLUPRO $PKG_ROOT/lib
 EoF

--- a/fluka_vmc.sh
+++ b/fluka_vmc.sh
@@ -8,6 +8,7 @@ requires:
 build_requires:
   - CMake
   - FLUKA
+  - alibuild-recipe-tools
 env:
   FLUVMC: "$FLUKA_VMC_ROOT"
   FLUPRO: "$FLUKA_VMC_ROOT"
@@ -30,24 +31,10 @@ rsync -av "$FLUKA_ROOT"/data "$INSTALLROOT/"
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set FLUKA_VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FLUKA_VMC_ROOT \$FLUKA_VMC_ROOT
-setenv FLUVMC \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FLUPRO \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FLUKADATA \$::env(BASEDIR)/$PKGNAME/\$version/data
-prepend-path LD_LIBRARY_PATH \$FLUKA_VMC_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$FLUKA_VMC_ROOT/include/TFluka
+alibuild-generate-module --lib --root-env --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+setenv FLUVMC $PKG_ROOT
+setenv FLUPRO $PKG_ROOT
+setenv FLUKADATA $PKG_ROOT/data
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include/TFluka
 EoF

--- a/fmt.sh
+++ b/fmt.sh
@@ -6,6 +6,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$FMT_ROOT/include"
 ---
@@ -17,20 +18,7 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set FMT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FMT_ROOT \$FMT_ROOT
-prepend-path ROOT_INCLUDE_PATH \$FMT_ROOT/include
+alibuild-generate-module --root-env > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF

--- a/focal.sh
+++ b/focal.sh
@@ -5,6 +5,7 @@ requires:
   - AliRoot
 build_requires:
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 source: https://gitlab.cern.ch/mvl/FOCAL
 env:
   FOCAL: "$FOCAL_ROOT"
@@ -76,16 +77,7 @@ fi
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 AliRoot/$ALIROOT_VERSION-$ALIROOT_REVISION ${ROOUNFOLD_REVISION:+RooUnfold/$ROOUNFOLD_VERSION-$ROOUNFOLD_REVISION} ${TREELITE_REVISION:+treelite/$TREELITE_VERSION-$TREELITE_REVISION} ${KFPARTICLE_REVISION:+KFParticle/$KFPARTICLE_VERSION-$KFPARTICLE_REVISION}
+alibuild-generate-module --extra > "etc/modulefiles/$PKGNAME" <<EoF
 # Our environment
 setenv FOCAL_VERSION \$version
 setenv FOCAL_RELEASE \$::env(FOCAL_VERSION)

--- a/freetype.sh
+++ b/freetype.sh
@@ -5,6 +5,7 @@ requires:
 build_requires:
   - "autotools:(slc6|slc7)"
   - system-curl
+  - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include <ft2build.h>\n" | c++ -xc++ - `freetype-config --cflags` -c -M 2>&1;
@@ -25,21 +26,5 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 $([[ "$ALIEN_RUNTIME_VERSION" ]] && echo AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION || echo ${ZLIB_REVISION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION})
-# Our environment
-set FREETYPE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FREETYPE_ROOT \$FREETYPE_ROOT
-prepend-path PATH \$FREETYPE_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$FREETYPE_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -8,6 +8,7 @@ build_requires:
  - "autotools:(slc6|slc7)"
  - yacc-like
  - make
+ - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
   set -e
@@ -146,18 +147,8 @@ popd
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<EoF
 # Load Toolchain module for the current platform. Fallback on this one
 regexp -- "^(.*)/.*\$" [module-info name] dummy mod_name
 if { "\$mod_name" == "GCC-Toolchain" } {

--- a/geant4.sh
+++ b/geant4.sh
@@ -7,6 +7,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$GEANT4_ROOT/include:$GEANT4_ROOT/include/Geant4"
 incremental_recipe: |
@@ -54,24 +55,8 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${XERCESC_REVISION:+xercesc/$XERCESC_REVISION-$XERCESC_REVISION}
-# Our environment
-set GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GEANT4_ROOT \$GEANT4_ROOT
-prepend-path PATH \$GEANT4_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$GEANT4_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"
 
 # Data sets environment
 $INSTALLROOT/bin/geant4-config --datasets |  sed 's/[^ ]* //' | sed 's/G4/setenv G4/' >> "$MODULEFILE"

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -9,6 +9,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc:$GEANT4_VMC_ROOT/include/mtroot"
 env:
@@ -29,25 +30,10 @@ ln -nfs "$G4VMC_SHARE/examples" "$INSTALLROOT/share/examples"
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GEANT4_REVISION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION} ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} vgm/$VGM_VERSION-$VGM_REVISION
-# Our environment
-set GEANT4_VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GEANT4_VMC_ROOT \$GEANT4_VMC_ROOT
-setenv G4VMCINSTALL \$GEANT4_VMC_ROOT
-prepend-path PATH \$GEANT4_VMC_ROOT/bin
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/mtroot
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/geant4vmc
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/g4root
-prepend-path LD_LIBRARY_PATH \$GEANT4_VMC_ROOT/lib
+alibuild-generate-module --bin --lib --root-env --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+setenv G4VMCINSTALL $PKG_ROOT
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include/mtroot
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include/geant4vmc
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include/g4root
 EoF

--- a/gmp.sh
+++ b/gmp.sh
@@ -4,6 +4,7 @@ tag: v6.2.1
 source: https://github.com/alisw/GMP.git
 requires:
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 ---
 #!/bin/sh
 case $ARCHITECTURE in
@@ -26,20 +27,5 @@ rm -f $INSTALLROOT/lib/*.la
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set GMP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GMP_ROOT \$GMP_ROOT
-prepend-path LD_LIBRARY_PATH \$GMP_ROOT/lib
-EoF
+alibuild-generate-module --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/grpc.sh
+++ b/grpc.sh
@@ -10,6 +10,7 @@ requires:
 build_requires:
   - CMake
   - abseil
+  - alibuild-recipe-tools
 source: https://github.com/alisw/grpc
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
@@ -51,24 +52,5 @@ make ${JOBS:+-j$JOBS} install
 
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                          \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
-            ${C_ARES_REVISION:+c-ares/$C_ARES_VERSION-$C_ARES_REVISION}        \\
-            ${OPENSSL_REVISION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION} \\
-            ${PROTOBUF_REVISION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}
-# Our environment
-set GRPC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$GRPC_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$GRPC_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/gsl.sh
+++ b/gsl.sh
@@ -24,6 +24,5 @@ make ${JOBS:+-j$JOBS} install
 rm -fv $INSTALLROOT/lib/*.la
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --bin --lib > $MODULEFILE
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/infologger.sh
+++ b/infologger.sh
@@ -9,6 +9,7 @@ build_requires:
   - CMake
   - golang
   - SWIG
+  - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/InfoLogger
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
@@ -35,23 +36,5 @@ make ${JOBS+-j $JOBS} install
 
 #ModuleFile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                          \\
-            ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}            \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-
-# Our environment
-set INFOLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv INFOLOGGER_ROOT \$INFOLOGGER_ROOT
-prepend-path PATH \$INFOLOGGER_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$INFOLOGGER_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "etc/modulefiles/$PKGNAME"
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -13,6 +13,7 @@ build_requires:
   - "GCC-Toolchain:(?!osx)"
   - zlib
   - Alice-GRID-Utils
+  - alibuild-recipe-tools
 append_path:
   ROOT_PLUGIN_PATH: "$JALIEN_ROOT_ROOT/etc/plugins"
   ROOT_INCLUDE_PATH: "$JALIEN_ROOT_ROOT/include"
@@ -41,25 +42,8 @@ make ${JOBS:+-j $JOBS} install
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
-                     ROOT/${ROOT_VERSION}-${ROOT_REVISION}                                                   \\
-                     ${XJALIENFS_REVISION:+xjalienfs/$XJALIENFS_VERSION-$XJALIENFS_REVISION}                 \\
-                     ${LIBJALIENWS_REVISION:+libjalienws/$LIBJALIENWS_VERSION-$LIBJALIENWS_REVISION}
-
-# Our environment
-set JALIEN_ROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$JALIEN_ROOT_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$JALIEN_ROOT_ROOT/lib
-append-path ROOT_PLUGIN_PATH \$JALIEN_ROOT_ROOT/etc/plugins
-prepend-path ROOT_INCLUDE_PATH \$JALIEN_ROOT_ROOT/include
+alibuild-generate-module --bin --lib --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+append-path ROOT_PLUGIN_PATH $PKG_ROOT/etc/plugins
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/jalien.sh
+++ b/jalien.sh
@@ -8,6 +8,8 @@ requires:
  - xjalienfs
  - "curl:(?!slc8)"
  - "system-curl:slc8.*"
+build_requires:
+ - alibuild-recipe-tools
 valid_defaults:
  - jalien
 ---
@@ -21,22 +23,7 @@ rsync -av bin/ $INSTALLROOT/bin/
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 JDK/$JDK_VERSION-$JDK_REVISION \\
-            XRootD/$XROOTD_VERSION-$XROOTD_REVISION \\
-            xjalienfs/$XJALIENFS_VERSION-$XJALIENFS_REVISION
-# Our environment
-set JALIEN_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path CLASSPATH \$JALIEN_ROOT/lib/alien-users.jar
-prepend-path PATH \$JALIEN_ROOT/bin
+alibuild-generate-module --bin --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path CLASSPATH $PKG_ROOT/lib/alien-users.jar
 EoF

--- a/jdk.sh
+++ b/jdk.sh
@@ -2,6 +2,7 @@ package: JDK
 version: "12.0.1"
 build_requires:
   - system-curl
+  - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
   [[ $(uname) == Darwin ]] && /usr/libexec/java_home || exit 1; X=$(mktemp -d); cd $X && printf "public class verAliBuild { public static void main(String[] args) { if (Integer.parseInt((System.getProperty(\"java.version\")+\".\").split(\"\\\\\.\")[0]) < 10) System.exit(42); } }" > verAliBuild.java && javac verAliBuild.java && java verAliBuild && rm -rf $X
@@ -32,19 +33,8 @@ fi
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<EoF
 set JAVA_HOME \$::env(BASEDIR)/$PKGNAME/\$version${JAVA_HOME_SUBDIR}
 setenv JAVA_HOME \$JAVA_HOME
 prepend-path PATH \$JAVA_HOME/bin

--- a/json-c.sh
+++ b/json-c.sh
@@ -5,6 +5,7 @@ source: https://github.com/json-c/json-c
 build_requires:
   - "autotools:(slc6|slc7)"
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
@@ -14,20 +15,5 @@ make ${JOBS+-j $JOBS} install
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set JSON_C_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv JSON_C_ROOT \$JSON_C_ROOT
-prepend-path PATH \$JSON_C_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$JSON_C_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "etc/modulefiles/$PKGNAME"
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/libpng.sh
+++ b/libpng.sh
@@ -4,6 +4,7 @@ requires:
  - zlib
 build_requires:
  - CMake
+ - alibuild-recipe-tools
 source: https://github.com/alisw/libpng
 prefer_system: (?!slc5)
 prefer_system_check: |
@@ -24,20 +25,5 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 $([[ $ALIEN_RUNTIME_VERSION ]] && echo "AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION" || echo "${ZLIB_REVISION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}")
-# Our environment
-set LIBPNG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$LIBPNG_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$LIBPNG_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -5,6 +5,7 @@ build_requires:
   - "autotools:(slc6|slc7)"
   - zlib
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 source: https://github.com/alisw/libxml2.git
 prefer_system: "(?!slc5)"
 prefer_system_check: |
@@ -23,21 +24,7 @@ make ${JOBS+-j $JOBS}
 make install
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${ZLIB_REVISION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
-# Our environment
-setenv LIBXML2_VERSION \$version
-set LIBXML2_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(LIBXML2_VERSION)
-setenv LIBXML2_ROOT \$LIBXML2_ROOT
-prepend-path PATH \$LIBXML2_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$LIBXML2_ROOT/lib
+alibuild-generate-module --bin --lib --root-env --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+setenv LIBXML2_VERSION $version
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/lz4.sh
+++ b/lz4.sh
@@ -18,6 +18,5 @@ make -j ${JOBS+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
 alibuild-generate-module --lib --bin > "$MODULEDIR/$PKGNAME"

--- a/lzma.sh
+++ b/lzma.sh
@@ -6,6 +6,7 @@ build_requires:
   - "autotools:(slc6|slc7)"
   - "GCC-Toolchain:(?!osx)"
   - rsync
+  - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <lzma.h>\n" | c++ -xc++ - -c -M 2>&1
@@ -25,22 +26,5 @@ rm -f "$INSTALLROOT"/lib/*.la
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set LZMA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv LZMA_ROOT \$LZMA_ROOT
-set BASEDIR \$::env(BASEDIR)
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-prepend-path PATH \$BASEDIR/$PKGNAME/\$version/bin
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -23,10 +23,8 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --bin --lib > $MODULEFILE
-cat >> "$MODULEFILE" <<EoF
-setenv MCSTEPLOGGER_ROOT \$PKG_ROOT
-prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+setenv MCSTEPLOGGER_ROOT $PKG_ROOT
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF

--- a/mesos.sh
+++ b/mesos.sh
@@ -18,6 +18,7 @@ build_requires:
 - protobuf
 - glog
 - Python-modules
+- alibuild-recipe-tools
 prepend_path:
   PATH: "$MESOS_ROOT/sbin"
   PYTHONPATH: $MESOS_ROOT/lib/python2.7/site-packages

--- a/mpfr.sh
+++ b/mpfr.sh
@@ -25,11 +25,8 @@ rm -f $INSTALLROOT/lib/*.la
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
-
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<EoF
 # Our environment
 set MPFR_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv MPFR_ROOT \$MPFR_ROOT

--- a/ms_gsl.sh
+++ b/ms_gsl.sh
@@ -6,6 +6,7 @@ prepend_path:
   ROOT_INCLUDE_PATH: "$MS_GSL_ROOT/include"
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 
@@ -20,21 +21,7 @@ cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set osname [uname sysname]
-set MS_GSL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv MS_GSL_ROOT \$MS_GSL_ROOT
-prepend-path ROOT_INCLUDE_PATH \$MS_GSL_ROOT/include
+alibuild-generate-module --root-env --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF

--- a/ninja.sh
+++ b/ninja.sh
@@ -4,6 +4,7 @@ tag: "v1.8.2.g3bbbe.kitware.dyndep-1.jobserver-1"
 source: https://github.com/Kitware/ninja
 build_requires:
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 
@@ -13,20 +14,5 @@ cp ./ninja $INSTALLROOT/bin
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set NINJA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv NINJA_ROOT \$NINJA_ROOT
-prepend-path PATH \$NINJA_ROOT/bin
-EoF
-
+alibuild-generate-module --bin --root-env > "etc/modulefiles/$PKGNAME"
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/o2-full-system-test.sh
+++ b/o2-full-system-test.sh
@@ -3,6 +3,8 @@ version: "1.0"
 requires:
   - O2Suite
   - O2sim
+build_requires:
+  - alibuild-recipe-tools
 force_rebuild: 1
 ---
 #!/bin/bash -e
@@ -25,14 +27,4 @@ rm -Rf $BUILDDIR/full-system-test-sim
 
 # Dummy modulefile
 mkdir -p $INSTALLROOT/etc/modulefiles
-cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 O2/$O2_VERSION-$O2_REVISION
-EoF
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/o2.sh
+++ b/o2.sh
@@ -31,6 +31,7 @@ build_requires:
   - RapidJSON
   - googlebenchmark
   - O2-customization
+  - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/AliceO2
 env:
   VMCWORKDIR: "$O2_ROOT/share"
@@ -210,51 +211,14 @@ fi
 
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 \\
-            FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION                                           \\
-            ${DDS_REVISION:+DDS/$DDS_VERSION-$DDS_REVISION}                                         \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
-            ${VC_REVISION:+Vc/$VC_VERSION-$VC_REVISION}                                             \\
-            ${HEPMC3_REVISION:+HepMC3/$HEPMC3_VERSION-$HEPMC3_REVISION}                             \\
-            ${MONITORING_REVISION:+Monitoring/$MONITORING_VERSION-$MONITORING_REVISION}             \\
-            ${CONFIGURATION_REVISION:+Configuration/$CONFIGURATION_VERSION-$CONFIGURATION_REVISION} \\
-            ${LIBINFOLOGGER_REVISION:+libInfoLogger/$LIBINFOLOGGER_VERSION-$LIBINFOLOGGER_REVISION} \\
-            ${COMMON_O2_REVISION:+Common-O2/$COMMON_O2_VERSION-$COMMON_O2_REVISION}                 \\
-            ms_gsl/$MS_GSL_VERSION-$MS_GSL_REVISION                                                 \\
-            ${ARROW_REVISION:+arrow/$ARROW_VERSION-$ARROW_REVISION}                                 \\
-            ${DEBUGGUI_REVISION:+DebugGUI/$DEBUGGUI_VERSION-$DEBUGGUI_REVISION}                     \\
-            ${LIBUV_REVISION:+libuv/$LIBUV_VERSION-$LIBUV_REVISION}                                 \\
-            ${JALIEN_ROOT_REVISION:+JAliEn-ROOT/$JALIEN_ROOT_VERSION-$JALIEN_ROOT_REVISION}         \\
-            ${FASTJET_REVISION:+fastjet/$FASTJET_VERSION-$FASTJET_REVISION}                         \\
-            ${CGAL_REVISION:+cgal/$CGAL_VERSION-$CGAL_REVISION}                                     \\
-            ${GLFW_REVISION:+GLFW/$GLFW_VERSION-$GLFW_REVISION}                                     \\
-            ${FMT_REVISION:+fmt/$FMT_VERSION-$FMT_REVISION}                                         \\
-            ${AEGIS_REVISION:+AEGIS/$AEGIS_VERSION-$AEGIS_REVISION}                                 \\
-            ${LIBJALIENO2_REVISION:+libjalienO2/$LIBJALIENO2_VERSION-$LIBJALIENO2_REVISION}         \\
-            ${KFPARTICLE_REVISION:+KFParticle/$KFPARTICLE_VERSION-$KFPARTICLE_REVISION}             \\
-            ${CURL_REVISION:+curl/$CURL_VERSION-$CURL_REVISION}                                     \\
-            ${FAIRMQ_REVISION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION}
+alibuild-generate-module --bin --lib --root-env --extra > "etc/modulefiles/$PKGNAME" <<EoF
 # Our environment
-set O2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv O2_ROOT \$O2_ROOT
-setenv VMCWORKDIR \$O2_ROOT/share
-
-set O2_ROOT \$O2_ROOT
-prepend-path PATH \$O2_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$O2_ROOT/lib
-prepend-path ROOT_DYN_PATH \$O2_ROOT/lib
-$([[ ${ARCHITECTURE:0:3} == osx && ! $BOOST_VERSION ]] && echo "prepend-path ROOT_INCLUDE_PATH $BOOST_ROOT/include")
-prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include/GPU
-prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include
+setenv VMCWORKDIR \$PKG_ROOT/share
+prepend-path ROOT_DYN_PATH \$PKG_ROOT/lib
+$([[ ${ARCHITECTURE:0:3} == osx && ! $BOOST_VERSION ]] &&
+  echo "prepend-path ROOT_INCLUDE_PATH $BOOST_ROOT/include")
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/GPU
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -5,6 +5,7 @@ requires:
   - o2codechecker
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 force_rebuild: 1
 ---
 #!/bin/bash -e
@@ -114,17 +115,4 @@ grep -v clang-diagnostic-error error-log.txt | grep " error:"   || GRERR=$?
 
 # Dummy modulefile
 mkdir -p $INSTALLROOT/etc/modulefiles
-cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 O2/$O2_VERSION-$O2_REVISION
-# Our environment
-set O2CHECKCODE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv O2CHECKCODE_ROOT \$O2CHECKCODE_ROOT
-EoF
+alibuild-generate-module --root-env > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/o2dpg.sh
+++ b/o2dpg.sh
@@ -11,11 +11,7 @@ rsync -a --exclude='**/.git' --delete --delete-excluded \
 
 # Modulefile
 mkdir -p $INSTALLROOT/etc/modulefiles
-alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME
-
-cat << EOF >> $INSTALLROOT/etc/modulefiles/$PKGNAME
-set O2DPG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv O2DPG_ROOT \$O2DPG_ROOT
+alibuild-generate-module --root-env --extra > "$INSTALLROOT/etc/modulefiles/$PKGNAME" << EOF
 setenv O2DPG_RELEASE \$version
 setenv O2DPG_VERSION $PKGVERSION
 EOF

--- a/o2fullci.sh
+++ b/o2fullci.sh
@@ -5,32 +5,13 @@ requires:
   - O2Suite
   - o2checkcode
   - O2-full-system-test
+build_requires:
+  - alibuild-recipe-tools
 valid_defaults:
   - o2
 ---
 #!/bin/bash -ex
 
-MODULEFILE_DEPS=
-for RPKG in $REQUIRES; do
-  [[ $RPKG != defaults* ]] || continue
-  RPKG_UP=$(echo $RPKG|tr '[:lower:]' '[:upper:]'|tr '-' '_')
-  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
-  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
-  MODULEFILE_DEPS="${MODULEFILE_DEPS} ${RPKG}/${RPKG_VERSION}-${RPKG_REVISION}"
-done
-MODULEFILE_DEPS=$(echo $MODULEFILE_DEPS)
-
 # Modulefile
 mkdir -p $INSTALLROOT/etc/modulefiles
-cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-
-# Dependencies
-module load BASE/1.0 ${MODULEFILE_DEPS}
-EoF
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/o2sim.sh
+++ b/o2sim.sh
@@ -4,6 +4,8 @@ requires:
   - O2
   - O2DPG
   - AEGIS
+build_requires:
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -ex
 

--- a/o2suite.sh
+++ b/o2suite.sh
@@ -13,6 +13,8 @@ requires:
   - "ALF:(?!osx)"
   - "BookkeepingApiCpp:(slc*)"
   - "mesos:(slc8)"
+build_requires:
+  - alibuild-recipe-tools
 valid_defaults:
   - o2
   - o2-dataflow
@@ -22,28 +24,6 @@ valid_defaults:
   - o2-ninja
 ---
 #!/bin/bash -ex
-
-MODULEFILE_DEPS=
-for RPKG in $REQUIRES; do
-  [[ $RPKG != defaults* ]] || continue
-  RPKG_UP=$(echo $RPKG|tr '[:lower:]' '[:upper:]'|tr '-' '_')
-  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
-  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
-  MODULEFILE_DEPS="${MODULEFILE_DEPS} ${RPKG}/${RPKG_VERSION}-${RPKG_REVISION}"
-done
-MODULEFILE_DEPS=$(echo $MODULEFILE_DEPS)
-
 # Modulefile
-mkdir -p $INSTALLROOT/etc/modulefiles
-cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-
-# Dependencies
-module load BASE/1.0 ${MODULEFILE_DEPS}
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/ofi.sh
+++ b/ofi.sh
@@ -4,6 +4,7 @@ tag: "v1.7.1"
 source: https://github.com/ofiwg/libfabric
 build_requires:
   - "autotools:(slc6|slc7)"
+  - alibuild-recipe-tools
 prefer_system: ".*"
 prefer_system_check: |
   pkg-config --atleast-version=1.6.0 libfabric 2>&1 && printf "#include \"rdma/fabric.h\"\nint main(){}" | c++ -xc - -o /dev/null
@@ -15,21 +16,5 @@ make ${JOBS:+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set OFI_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv OFI_ROOT \$OFI_ROOT
-prepend-path PATH \$OFI_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$OFI_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib > "$MODULEDIR/$PKGNAME"

--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -7,6 +7,7 @@ requires:
   - re2
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 
@@ -47,12 +48,5 @@ cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
-
-# Our environment
-set ${PKGNAME}_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$${PKGNAME}_ROOT/lib
-EoF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"

--- a/openssl.sh
+++ b/openssl.sh
@@ -8,6 +8,7 @@ prefer_system_check: |
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 
@@ -40,21 +41,5 @@ rm -rf $INSTALLROOT/lib/pkgconfig \
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${ZLIB_REVISION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION} ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set OPENSSL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv OPENSSL_ROOT \$OPENSSL_ROOT
-prepend-path PATH \$OPENSSL_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$OPENSSL_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/pcre.sh
+++ b/pcre.sh
@@ -2,6 +2,8 @@ package: PCRE
 version: master
 tag: master
 source: https://github.com/ktf/pcre
+build_requires:
+  - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include \"pcre.h\"\n" | c++ -I`brew --prefix pcre`/include -xc++ - -c -o /dev/null
@@ -19,19 +21,5 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set BASEDIR \$::env(BASEDIR)
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-EoF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"

--- a/pda.sh
+++ b/pda.sh
@@ -7,7 +7,7 @@ requires:
 build_requires:
   - kernel-devel
   - "autotools:(slc6|slc7)"
-
+  - alibuild-recipe-tools
 --- 
 #!/bin/sh
 
@@ -17,24 +17,5 @@ make ${JOBS+-j $JOBS} install
 
 #ModuleFile 
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-
-# Dependencies
-module load BASE/1.0                                                                            \\
-            ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}                       
-
-# Our environment
-set PDA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PDA_ROOT \$PDA_ROOT
-set BASEDIR \$::env(BASEDIR)
-prepend-path PATH \$BASEDIR/$PKGNAME/\$version/bin
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "etc/modulefiles/$PKGNAME"
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -4,6 +4,7 @@ source: https://github.com/google/protobuf
 build_requires:
  - CMake
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 ---
 
 cmake $SOURCEDIR/cmake                  \
@@ -17,21 +18,5 @@ make install
 
 #ModuleFile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set PROTOBUF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PROTOBUF_ROOT \$PROTOBUF_ROOT
-prepend-path LD_LIBRARY_PATH \$PROTOBUF_ROOT/lib
-prepend-path PATH \$PROTOBUF_ROOT/bin
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/pythia.sh
+++ b/pythia.sh
@@ -6,6 +6,8 @@ requires:
   - lhapdf
   - HepMC
   - boost
+build_requires:
+  - alibuild-recipe-tools
 env:
   PYTHIA8DATA: "$PYTHIA_ROOT/share/Pythia8/xmldoc"
   PYTHIA8: "$PYTHIA_ROOT"
@@ -37,24 +39,10 @@ chmod a+x $INSTALLROOT/bin/pythia8-config
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${LHAPDF_REVISION:+lhapdf/$LHAPDF_VERSION-$LHAPDF_REVISION} ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION} ${HEPMC_REVISION:+HepMC/$HEPMC_VERSION-$HEPMC_REVISION}
+alibuild-generate-module --bin --lib --root-env --extra > "$MODULEDIR/$PKGNAME" <<EoF
 # Our environment
-set PYTHIA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PYTHIA_ROOT \$PYTHIA_ROOT
-setenv PYTHIA8DATA \$PYTHIA_ROOT/share/Pythia8/xmldoc
+setenv PYTHIA8DATA \$PKG_ROOT/share/Pythia8/xmldoc
 setenv PYTHIA8 \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$PYTHIA_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$PYTHIA_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$PYTHIA_ROOT/include
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/pythia6.sh
+++ b/pythia6.sh
@@ -7,6 +7,7 @@ requires:
   - GCC-Toolchain:(?!osx)
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/sh
 
@@ -19,22 +20,7 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set PYTHIA6_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PYTHIA6_ROOT \$PYTHIA6_ROOT
-prepend-path LD_LIBRARY_PATH \$PYTHIA6_ROOT/lib
-prepend-path AGILE_GEN_PATH \$PYTHIA6_ROOT
+alibuild-generate-module --lib --root-env --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path AGILE_GEN_PATH $PKG_ROOT
 EoF
-

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -1,5 +1,7 @@
 package: Python-modules-list
 version: "1.0"
+build_requires:
+  - alibuild-recipe-tools
 env:
   PIP_REQUIREMENTS: |
     requests==2.21.0
@@ -53,17 +55,5 @@ env:
 ---
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-EoF
+alibuild-generate-module > "$MODULEDIR/$PKGNAME"

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -8,6 +8,7 @@ requires:
 build_requires:
   - system-curl
   - Python-modules-list
+  - alibuild-recipe-tools
 prepend_path:
   PYTHONPATH: $PYTHON_MODULES_ROOT/share/python-modules/lib/python/site-packages
 ---
@@ -89,18 +90,8 @@ find "$PYTHON_MODULES_INSTALLROOT"/lib/python* \
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION} ${ALIEN_RUNTIME_REVISION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION}
+alibuild-generate-module --extra > "$MODULEDIR/$PKGNAME" <<EoF
 # Our environment
 set PYTHON_MODULES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$PYTHON_MODULES_ROOT/share/python-modules/bin

--- a/python.sh
+++ b/python.sh
@@ -109,10 +109,8 @@ find "$INSTALLROOT"/lib/python* \
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --bin --lib > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<EoF
 setenv PYTHONHOME \$PKG_ROOT
 prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
 if { [module-info mode load] } {

--- a/re2.sh
+++ b/re2.sh
@@ -4,6 +4,7 @@ source: https://github.com/google/re2
 build_requires:
  - "GCC-Toolchain:(?!osx)"
  - CMake
+ - alibuild-recipe-tools
 ---
 #!/bin/sh
 cmake $SOURCEDIR                           \
@@ -15,16 +16,5 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-EoF
+alibuild-generate-module > "$MODULEDIR/$PKGNAME"

--- a/readout.sh
+++ b/readout.sh
@@ -67,9 +67,5 @@ make ${JOBS+-j $JOBS} install
 
 #ModuleFile
 mkdir -p etc/modulefiles
-alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
-cat >> etc/modulefiles/$PKGNAME <<EoF
-set READOUT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv READOUT_ROOT \$READOUT_ROOT
-EoF
+alibuild-generate-module --bin --lib --root-env > etc/modulefiles/$PKGNAME
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/roounfold.sh
+++ b/roounfold.sh
@@ -5,6 +5,8 @@ source: https://github.com/alisw/RooUnfold
 requires:
  - ROOT
  - boost
+build_requires:
+ - alibuild-recipe-tools
 ---
 cmake $SOURCEDIR                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \
@@ -18,16 +20,7 @@ make ${JOBS:+-j$JOBS} install
 rsync -av $SOURCEDIR/include/ $INSTALLROOT/include/
 # Modulefile
 mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
+alibuild-generate-module --extra > "etc/modulefiles/$PKGNAME" <<EoF
 # Our environment
 setenv ROOUNFOLD_RELEASE \$version
 setenv ROOUNFOLD_VERSION $PKGVERSION

--- a/sherpa.sh
+++ b/sherpa.sh
@@ -50,15 +50,9 @@ make install
 
 #ModuleFile
 mkdir -p etc/modulefiles
-alibuild-generate-module > etc/modulefiles/$PKGNAME
-cat >> etc/modulefiles/$PKGNAME <<EoF
-# Our environment
-set SHERPA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv SHERPA_ROOT \$SHERPA_ROOT
-setenv SHERPA_INSTALL_PATH \$::env(SHERPA_ROOT)/lib/SHERPA
-setenv SHERPA_SHARE_PATH \$::env(SHERPA_ROOT)/share/SHERPA-MC
-prepend-path PATH \$SHERPA_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$SHERPA_ROOT/lib
-prepend-path LD_LIBRARY_PATH \$SHERPA_ROOT/lib/SHERPA-MC
+alibuild-generate-module --bin --lib --root-env --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+setenv SHERPA_INSTALL_PATH $PKG_ROOT/lib/SHERPA
+setenv SHERPA_SHARE_PATH $PKG_ROOT/share/SHERPA-MC
+prepend-path LD_LIBRARY_PATH $PKG_ROOT/lib/SHERPA-MC
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/sqlite.sh
+++ b/sqlite.sh
@@ -9,6 +9,7 @@ prefer_system_check: |
 build_requires:
   - system-curl
   - "autotools:(slc6|slc7)"
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -ex
 rsync -av $SOURCEDIR/ ./
@@ -21,21 +22,5 @@ rm -rf $INSTALLROOT/share
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set SQLITE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv SQLITE_ROOT \$SQLITE_ROOT
-prepend-path PATH \$SQLITE_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$SQLITE_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/tauola.sh
+++ b/tauola.sh
@@ -6,6 +6,8 @@ requires:
   - HepMC
   - lhapdf
   - pythia
+build_requires:
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
@@ -23,14 +25,7 @@ make install
 
 #ModuleFile
 mkdir -p etc/modulefiles
-alibuild-generate-module > etc/modulefiles/$PKGNAME
-
-cat >> etc/modulefiles/$PKGNAME <<EoF
-# Our environment
-set TAUOLA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv TAUOLA_ROOT \$TAUOLA_ROOT
-setenv TAUOLA_INSTALL_PATH \$::env(TAUOLA_ROOT)/lib/TAUOLA
-prepend-path PATH \$TAUOLA_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$TAUOLA_ROOT/lib
+alibuild-generate-module --bin --lib --root-env --extra > "etc/modulefiles/$PKGNAME" <<\EoF
+setenv TAUOLA_INSTALL_PATH $::env(TAUOLA_ROOT)/lib/TAUOLA
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/tpcfecutils.sh
+++ b/tpcfecutils.sh
@@ -10,6 +10,7 @@ requires:
   - LLA
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 source: https://gitlab+deploy-token-1303:ivjQdcMRX9qpxdv4RCcM@gitlab.cern.ch/alice-tpc-upgrade/alice-tpc-fec-utils.git
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install

--- a/vc.sh
+++ b/vc.sh
@@ -17,9 +17,7 @@ make ${JOBS+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --bin --lib > $MODULEFILE
-cat >> "$MODULEFILE" <<EoF		
-prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include		
+alibuild-generate-module --bin --lib --root-env --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF

--- a/vecgeom.sh
+++ b/vecgeom.sh
@@ -8,6 +8,7 @@ requires:
   - ROOT
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 
 #!/bin/bash -e
@@ -23,22 +24,7 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 Vc/$VC_VERSION-$VC_REVISION ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION}
-# Our environment
-set osname [uname sysname]
-set VC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv VC_ROOT \$VC_ROOT
-prepend-path PATH \$VC_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$VC_ROOT/lib
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+setenv VC_ROOT $PKG_ROOT
 EoF

--- a/vgm.sh
+++ b/vgm.sh
@@ -7,6 +7,7 @@ requires:
   - GEANT4
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 cmake "$SOURCEDIR" \
@@ -25,20 +26,5 @@ find "$INSTALLROOT/lib" -name '*deleteme' -delete || true
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 GEANT4/$GEANT4_VERSION-$GEANT4_REVISION ROOT/$ROOT_VERSION-$ROOT_REVISION
-# Our environment
-set VGM_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv VGM_ROOT \$VGM_ROOT
-prepend-path LD_LIBRARY_PATH \$VGM_ROOT/lib
-EoF
+alibuild-generate-module --lib --root-env > "$MODULEDIR/$PKGNAME"

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -12,6 +12,7 @@ build_requires:
  - SWIG
  - UUID
  - libperl
+ - alibuild-recipe-tools
 prepend_path:
  PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
 env:
@@ -48,27 +49,8 @@ make install INSTALLSITEARCH=$INSTALLROOT/lib/perl \
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 XRootD/${XROOTD_VERSION}-${XROOTD_REVISION}             \\
-            ${OPENSSL_REVISION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}   \\
-            ${ALIEN_RUNTIME_REVISION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION}
-
-# Our environment
-set XALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-
-setenv GSHELL_ROOT \$XALIENFS_ROOT
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<\EOF
+setenv GSHELL_ROOT $PKG_ROOT
 setenv GSHELL_NO_GCC 1
-
-prepend-path LD_LIBRARY_PATH \$XALIENFS_ROOT/lib
-prepend-path PATH \$XALIENFS_ROOT/bin
-EoF
+EOF

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -4,6 +4,7 @@ tag: Xerces-C_3_2_2
 source: https://github.com/apache/xerces-c
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prefer_system: ".*"
 prefer_system_check: |
   pkg-config --atleast-version=3.2.0 xerces-c 2>&1 && printf "#include \"<xercesc/util/PlatformUtils.hpp>\"\nint main(){}" | c++ -xc - -o /dev/null
@@ -25,19 +26,5 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set XERCESC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$XERCESC_ROOT/lib
-EoF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -8,6 +8,8 @@ requires:
  - XRootD
  - AliEn-Runtime
  - Python-modules
+build_requires:
+ - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 
@@ -41,28 +43,7 @@ fi
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
-            ${PYTHON_MODULES_REVISION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION} \\
-            ${ALIEN_RUNTIME_REVISION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION}     \\
-            ${OPENSSL_REVISION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}                             \\
-	    ${XROOTD_REVISION:+XRootD/$XROOTD_VERSION-$XROOTD_REVISION}
-set XJALIENFS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$XJALIENFS_ROOT/bin
-EoF
-
-if [ "X$VIRTUAL_ENV" = X ]; then
-  cat >> "$MODULEFILE" << EoF
-  prepend-path PYTHONPATH \$XJALIENFS_ROOT/lib/python/site-packages
-EoF
-fi
+if [ -z "$VIRTUAL_ENV" ]; then
+  echo 'prepend-path PYTHONPATH $XJALIENFS_ROOT/lib/python/site-packages'
+fi | alibuild-generate-module --bin --extra > "$MODULEDIR/$PKGNAME"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -12,6 +12,7 @@ build_requires:
  - "osx-system-openssl:(osx.*)"
  - "GCC-Toolchain:(?!osx)"
  - UUID:(?!osx)
+ - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 [[ -e $SOURCEDIR/bindings ]] && XROOTD_V4=True && XROOTD_PYTHON=True || XROOTD_PYTHON=False
@@ -84,29 +85,10 @@ fi
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 \
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}     \\
-            ${OPENSSL_REVISION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}                             \\
-            ${LIBXML2_REVISION:+libxml2/$LIBXML2_VERSION-$LIBXML2_REVISION}                             \\
-            ${ALIEN_RUNTIME_REVISION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION}
-
-# Our environment
-set XROOTD_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$XROOTD_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$XROOTD_ROOT/lib
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<EoF
 if { $XROOTD_PYTHON } {
-  prepend-path PYTHONPATH \${XROOTD_ROOT}/lib/python/site-packages
+  prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
   module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
               ${PYTHON_MODULES_REVISION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}
 }

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -6,6 +6,7 @@ requires:
   - boost
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
   pkg-config --atleast-version=0.6.2 yaml-cpp && printf "#include \"yaml-cpp/yaml.h\"\n" | c++ -std=c++17 -I`brew --prefix yaml-cpp`/include -I`brew --prefix boost`/include -xc++ - -c -o /dev/null
@@ -30,19 +31,5 @@ make ${JOBS+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
-# Our environment
-set YAMLCPP \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$YAMLCPP/lib
-EoF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"

--- a/yoda.sh
+++ b/yoda.sh
@@ -8,6 +8,7 @@ requires:
   - "Python-system:(?!slc.*)"
 build_requires:
   - "autotools:(slc6|slc7)"
+  - alibuild-recipe-tools
 prepend_path:
   PYTHONPATH: $YODA_ROOT/lib64/python2.7/site-packages:$YODA_ROOT/lib/python2.7/site-packages
 ---
@@ -24,27 +25,9 @@ make install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                    \\
-            boost/$BOOST_VERSION-$BOOST_REVISION                        \\
-            ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}
-
-# Our environment
-set YODA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-
-prepend-path PATH \$YODA_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib
-prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib64
+alibuild-generate-module --bin --lib --extra > "$MODULEDIR/$PKGNAME" <<\EoF
+prepend-path LD_LIBRARY_PATH $PKG_ROOT/lib64
 set pythonpath [exec yoda-config --pythonpath]
-prepend-path PYTHONPATH \$pythonpath
+prepend-path PYTHONPATH $pythonpath
 EoF

--- a/zeromq.sh
+++ b/zeromq.sh
@@ -23,6 +23,5 @@ make ${JOBS+-j $JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --lib > $MODULEFILE
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"

--- a/zlib.sh
+++ b/zlib.sh
@@ -4,6 +4,7 @@ tag: v1.2.8
 source: https://github.com/star-externals/zlib
 build_requires:
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <zlib.h>\n" | cc -xc++ - -c -M 2>&1
@@ -30,19 +31,5 @@ make ${JOBS+-j $JOBS}
 make install
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set BASEDIR \$::env(BASEDIR)
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-EoF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
Needs `--root-env` and `--extra` extensions for `alibuild-generate-module`.

The following are not converted yet:

    alice-grid-utils.sh     alidpg.sh           alien-root-legacy.sh
    alien-workqueue.sh      aligenerators.sh    aligenmc.sh
    aliroot-guntest.sh      aliroot-ocdb.sh     alo-aliroot.sh
    alo-o2.sh               ampt.sh             apmon-cpp.sh
    asiofi.sh               asio.sh             aurora.sh
    autotools.sh            cctools.sh          codingguidelines.sh
    cpprestsdk.sh           crmc.sh             datadistribution.sh
    dimrpcparallel.sh       epos.sh             fairmq.sh
    fastjet.sh              fonll.sh            geant3.sh
    geant3_vmc-examples.sh  geantv.sh           geekbench.sh
    generators.sh           glog.sh             golang.sh
    googlebenchmark.sh      hdf5.sh             hepmc3.sh
    hepmc.sh                hijing.sh           jemalloc.sh
    jetscape.sh             jewel.sh            jq.sh
    kfparticle.sh           lcov.sh             lhapdf5.sh
    lhapdf-pdfsets.sh       lhapdf.sh           libffi.sh
    libinfologger.sh        libjalieno2.sh      libjalienws.sh
    librdkafka.sh           libtirpc.sh         libwebsockets.sh
    localccdb.sh            mesos-workqueue.sh  msgpack.sh
    o2codechecker.sh        objcmp.sh           odc.sh
    oniguruma.sh            parquet-cpp.sh      rapidjson.sh
    rivet-hi.sh             rivet.sh            rpm-test.sh
    sacrifice.sh            simulation.sh       sodium.sh
    starlight.sh            template-recipe.sh  thepeg.sh
    therminator2.sh         thrift.sh           treelite.sh