### PR TITLE
Update copyright notice in o2checkcode

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -76,11 +76,12 @@ sed -e 's/ warning:/ error:/g' error-log.txt > error-log.txt.0 && mv error-log.t
 
 # Run copyright notice check
 COPYRIGHT="$(cat <<'EOF'
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization


### PR DESCRIPTION
https://github.com/AliceO2Group/AliceO2/pull/6430 updated all files in O2, so now PRs are failing this check. Update the "template" notice to match.