### PR TITLE
[Fix] make kernel-devel receipe play nice with Ubuntu

### DIFF
--- a/kernel-devel.sh
+++ b/kernel-devel.sh
@@ -1,8 +1,11 @@
 package: kernel-devel
 version: "1.0"
 
-system_requirement_missing: "Please install kernel-devel pciutils-devel kmod-devel"
+system_requirement_missing: |
+  Kernel development packages are missing on your system:
+  * RHEL-compatible systems: Please install kernel-devel, pciutils-devel and kmod-devel
+  * Ubuntu-compatible systems: Please install linux-headers-`uname -r` , libpci-dev, and libkmod-dev
 system_requirement: ".*"
-system_requirement_check: "find /usr/src -name kernel.h | grep include/linux/kernel.h  > /dev/null 2>&1 && ls /usr/include/libkmod.h  > /dev/null 2>&1 && ls /usr/include/pci/pci.h > /dev/null 2>&1"
+system_requirement_check: "find /usr/src -name kernel.h | grep include/linux/kernel.h  > /dev/null 2>&1 && ls /usr/include/libkmod.h  > /dev/null 2>&1 && find /usr/include -name pci.h | grep pci/pci.h  > /dev/null 2>&1"
 
 ---


### PR DESCRIPTION
Ubuntu has its `libpci-dev` headers in another location than CC7, change the string and update installation instructions