### PR TITLE
Adding scons to python modules

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -12,6 +12,7 @@ env:
     PyYAML==5.1
     uproot==3.4.18
     psutil==5.8.0
+    scons==4.1.0
   PIP36_REQUIREMENTS: |
     numpy==1.16.2
     scipy==1.2.1


### PR DESCRIPTION
scons is used in particular in loop generators
in order to compile process libraries on-the-fly.
Therefore it must be available on grid sites.