### PR TITLE
Bump Configuration to v2.6.2

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -1,6 +1,6 @@
 package: Configuration
 version: "%(tag_basename)s"
-tag:  v2.6.1
+tag:  v2.6.2
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
@ktf Let's see if the new release fixes the boost::filesystem problem on CI checks on Ubuntu. I would probably wait for a green light from @awegrzyn before actually merging it, who should be back next week.