### PR TITLE
Generate Modulefile for O2Physics

### DIFF
--- a/o2physics.sh
+++ b/o2physics.sh
@@ -3,6 +3,9 @@ version: "%(tag_basename)s"
 tag: "v0.0.1"
 requires:
   - O2
+build_requires:
+  - CMake
+  - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/O2Physics
 ---
 #!/bin/sh
@@ -11,3 +14,7 @@ cmake "$SOURCEDIR" "-DCMAKE_INSTALL_PREFIX=$INSTALLROOT"          \
       ${CMAKE_BUILD_TYPE:+"-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE"} \
       ${CXXSTD:+"-DCMAKE_CXX_STANDARD=$CXXSTD"}
 cmake --build . -- ${JOBS+-j $JOBS} install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION
For now, O2Physics only has an executable, no libraries.