### PR TITLE
FFTW: disabling AVX2

### DIFF
--- a/fftw3.sh
+++ b/fftw3.sh
@@ -13,8 +13,7 @@ cmake $SOURCEDIR                                   \
       -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}" \
       -DCMAKE_INSTALL_LIBDIR:PATH="lib"            \
       -DENABLE_FLOAT=ON                            \
-      -DENABLE_AVX=ON                              \
-      -DENABLE_AVX2=ON
+      -DENABLE_AVX=ON
 make ${JOBS+-j $JOBS}
 make install
 


### PR DESCRIPTION
This might fix the problem `*** Illegal instruction Register dump:….` when using FFTW on alientest* as discussed in the [PR](https://github.com/AliceO2Group/AliceO2/pull/6427).