### PR TITLE
xjalienfs 1.3.1

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.0"
+tag: "1.3.1"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Short changelog:
* fix version command
* XrdCp :: support retry option of xrootd >= 5.2.0  (beside the timeout and ratethreshold)
* XrdCp :: fix upload for python 3.9 and up
* XrdCp :: better treatment of ~ and dot usage in arguments
* fix regex processing for XrdCp and find2 command
* toXml :: client side extension of toXml server command for usage on local files with `-local`
* API plumbing for filtering find/listing output (for any XrdCp and find2 usage) with arguments like {min,max}_{depth,size}, user/group, {min,max}_ctime (unix time in seconds)
* split and factorize code for richer API
* ensure the treatment of double quoted arguments
* API:: improve the mechanics of SendMsg, add capability of bulk command sending with SendMsgMulti
