### PR TITLE
defaults-o2 :: use latest xrootd 4

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -30,7 +30,7 @@ overrides:
     version: '%(tag_basename)s'
   XRootD:
     source: https://github.com/xrootd/xrootd
-    tag: v4.11.1
+    tag: v4.12.8
   cgal:
     version: 4.12.2
   fastjet:


### PR DESCRIPTION
there is no reason not to use the latest version from 4.X branch. details:
https://github.com/xrootd/xrootd/blob/v4.12.8/docs/ReleaseNotes.txt

