### PR TITLE
Build O2Physics for O2Suite as well

### DIFF
--- a/o2suite.sh
+++ b/o2suite.sh
@@ -6,6 +6,7 @@ requires:
   - Control-Core
   - Control-OCCPlugin
   - O2
+  - O2Physics
   - "ReadoutCard:(slc*)"
   - Readout
   - QualityControl


### PR DESCRIPTION
This makes sure that changes to O2 don't break O2Physics, once it's factored out into a separate repository.