### PR TITLE
xjalienfs:: emergency fix for JALIEN_TOKEN_ vars usage

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.1"
+tag: "1.3.2"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* fix for the usage of JALIEN_TOKEN_ {CERT,KEY} env vars