### PR TITLE
 SYSTEM_VERSION_COMPAT is not needed on Big Sur

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -23,7 +23,6 @@ build_requires:
   - alibuild-recipe-tools
 env:
   ROOTSYS: "$ROOT_ROOT"
-  SYSTEM_VERSION_COMPAT: "1"
 prepend_path:
   PYTHONPATH: "$ROOTSYS/lib"
   ROOT_DYN_PATH: "$ROOT_ROOT/lib"
@@ -39,7 +38,6 @@ incremental_recipe: |
 #!/bin/bash -e
 unset ROOTSYS
 # Get ROOT to work on Big Sur (this will modify the version returned by sw_vers from 11.0 to 10.16)
-export SYSTEM_VERSION_COMPAT=1
 COMPILER_CC=cc
 COMPILER_CXX=c++
 COMPILER_LD=c++
@@ -212,7 +210,6 @@ cat >> etc/modulefiles/$PKGNAME <<EoF
 setenv ROOT_RELEASE \$version
 setenv ROOT_BASEDIR \$::env(BASEDIR)/$PKGNAME
 setenv ROOTSYS \$::env(ROOT_BASEDIR)/\$::env(ROOT_RELEASE)
-setenv SYSTEM_VERSION_COMPAT 1
 prepend-path PYTHONPATH \$PKG_ROOT/lib
 prepend-path ROOT_DYN_PATH \$PKG_ROOT/lib
 EoF

--- a/root.sh
+++ b/root.sh
@@ -37,7 +37,6 @@ incremental_recipe: |
 ---
 #!/bin/bash -e
 unset ROOTSYS
-# Get ROOT to work on Big Sur (this will modify the version returned by sw_vers from 11.0 to 10.16)
 COMPILER_CC=cc
 COMPILER_CXX=c++
 COMPILER_LD=c++


### PR DESCRIPTION
This fixes the compilation on the latest BigSur.