### PR TITLE
use xrootd 5 as default

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -30,7 +30,7 @@ overrides:
     version: '%(tag_basename)s'
   XRootD:
     source: https://github.com/xrootd/xrootd
-    tag: v4.12.8
+    tag: v5.3.1
   cgal:
     version: 4.12.2
   fastjet:

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v4.12.5"
+tag: "v5.3.1"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Since the root was updated to 6.24 we can use the latest xrootd 5.x