### PR TITLE
WIP: use system provided openssl

### DIFF
--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -6,7 +6,7 @@ requires:
 build_requires:
  - zlib
  - libxml2
- - "OpenSSL:(?!osx)"
+ - "system-openssl:(?!osx)"
  - "osx-system-openssl:(osx.*)"
  - AliEn-CAs
  - ApMon-CPP

--- a/cmake.sh
+++ b/cmake.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "v3.19.2"
 source: https://github.com/Kitware/CMake
 requires:
- - "OpenSSL:(?!osx)"
+ - "system-openssl:(?!osx)"
  - "GCC-Toolchain:(?!osx)"
 build_requires:
  - make

--- a/curl.sh
+++ b/curl.sh
@@ -3,7 +3,7 @@ version: "7.70.0"
 tag: curl-7_70_0
 source: https://github.com/curl/curl.git
 build_requires:
- - "OpenSSL:(?!osx)"
+ - "system-openssl:(?!osx)"
  - CMake
  - alibuild-recipe-tools
 ---

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -30,6 +30,10 @@ overrides:
   Alice-GRID-Utils:
     version: "%(tag_basename)s"
     tag: 0.0.6
+  OpenSSL:
+    version: v1.0.2o
+    tag: OpenSSL_1_0_2o
+
   # Use ROOT 5
   ROOT:
     tag: v5-34-30-alice10

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -30,6 +30,10 @@ overrides:
   Alice-GRID-Utils:
     version: "%(tag_basename)s"
     tag: 0.0.6
+  OpenSSL:
+    version: v1.0.2o
+    tag: OpenSSL_1_0_2o
+
   # Use ROOT 5
   ROOT:
     tag: v5-34-30-alice10

--- a/defaults-user.sh
+++ b/defaults-user.sh
@@ -32,6 +32,9 @@ overrides:
   Alice-GRID-Utils:
     version: "%(tag_basename)s"
     tag: 0.0.6
+  OpenSSL:
+    version: v1.0.2o
+    tag: OpenSSL_1_0_2o
 
   # Use ROOT 5
   ROOT:

--- a/libjalieno2.sh
+++ b/libjalieno2.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "0.1.3"
 source: https://gitlab.cern.ch/jalien/libjalieno2.git
 requires:
-  - "OpenSSL:(?!osx)"
+  - "system-openssl:(?!osx)"
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -5,7 +5,7 @@ source: https://github.com/warmcat/libwebsockets
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
-  - "OpenSSL:(?!osx)"
+  - "system-openssl:(?!osx)"
 prefer_system: "osx"
 prefer_system_check: |
   printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\n' | c++ -I$(brew --prefix libwebsockets)/include -c -xc++ -std=c++17 - -o /dev/null

--- a/root.sh
+++ b/root.sh
@@ -14,7 +14,7 @@ requires:
   - libpng
   - lzma
   - libxml2
-  - "OpenSSL:(?!osx)"
+  - "system-openssl:(?!osx)"
   - "osx-system-openssl:(osx.*)"
   - XRootD
 build_requires:

--- a/system-openssl.sh
+++ b/system-openssl.sh
@@ -3,7 +3,7 @@ version: "1.0"
 system_requirement_missing: |
   Please make sure you install openssl:
    * RHEL-compatible systems: you will probably need "openssl" and "openssl-devel" packages.
-system_requirement: "slc8.*"
+# system_requirement: "slc8.*"
 system_requirement_check: |
   echo '#include <openssl/bio.h>' | c++ -x c++ - -c -o /dev/null
 ---

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "1.3.2"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
- - "OpenSSL:(?!osx)"
+ - "system-openssl:(?!osx)"
  - "osx-system-openssl:(osx.*)"
  - XRootD
  - AliEn-Runtime

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -3,13 +3,14 @@ version: "%(tag_basename)s"
 tag: "v5.3.1"
 source: https://github.com/xrootd/xrootd
 requires:
- - "OpenSSL:(?!osx)"
+ - "system-openssl:(?!osx)"
  - Python-modules
  - AliEn-Runtime
  - libxml2
 build_requires:
  - CMake
  - "osx-system-openssl:(osx.*)"
+ - "system-openssl:(?!osx)"
  - "GCC-Toolchain:(?!osx)"
  - UUID:(?!osx)
 ---


### PR DESCRIPTION
Given the usage of modern xrootd and root, we can/should use current system-provided openssl.