### PR TITLE
Use tags of MCStepLogger

### DIFF
--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,6 +1,6 @@
 package: MCStepLogger
 version: "%(tag_basename)s"
-tag: master
+tag: "v0.1.0"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Change to using tags instead of referring to the master branch