### PR TITLE
Use Python-modules rather than python

### DIFF
--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/onnxruntime.git
 requires:
   - protobuf
   - re2
-  - Python
+  - Python-modules
 build_requires:
   - CMake
   - alibuild-recipe-tools


### PR DESCRIPTION
I just remembered we should never depend on python to stay compatible with eventual system installations providing the same modules.