### PR TITLE
Remove duplicate module load

### DIFF
--- a/o2physics.sh
+++ b/o2physics.sh
@@ -22,6 +22,5 @@ cmake --build . -- ${JOBS+-j $JOBS} install
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$INSTALLROOT/etc/modulefiles/$PKGNAME"
 alibuild-generate-module --bin > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
 set ${PKGNAME}_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 EoF

--- a/o2physics.sh
+++ b/o2physics.sh
@@ -23,9 +23,5 @@ mkdir -p "$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$INSTALLROOT/etc/modulefiles/$PKGNAME"
 alibuild-generate-module --bin > "$MODULEFILE"
 cat >> "$MODULEFILE" <<EoF
-
-# Dependencies
-module load ${ONNXRUNTIME_REVISION:+ONNXRuntime/$ONNXRUNTIME_VERSION-$ONNXRUNTIME_REVISION}
-# Our environment
 set ${PKGNAME}_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 EoF

--- a/o2physics.sh
+++ b/o2physics.sh
@@ -22,5 +22,3 @@ cmake --build . -- ${JOBS+-j $JOBS} install
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$INSTALLROOT/etc/modulefiles/$PKGNAME"
 alibuild-generate-module --bin > "$MODULEFILE"
-set ${PKGNAME}_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-EoF


### PR DESCRIPTION
`alibuild-generate-module` already includes a module load command for ONNXRuntime.

It also sets `PKG_ROOT` in the environment, do we need `O2Physics_ROOT` as well?