### PR TITLE
Update uproot

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -10,7 +10,7 @@ env:
     mock==2.0.0
     notebook==5.7.8
     PyYAML==5.1
-    uproot==3.4.18
+    uproot==4.1.0
     psutil==5.8.0
     scons==4.1.0
   PIP36_REQUIREMENTS: |


### PR DESCRIPTION
Hi, 
starting from the 27/08 uproot4 tag (https://github.com/scikit-hep/uproot4/releases/tag/4.1.0) it is no longer necessary to use Uproot 3 for anything: Uproot 4's capabilities exceed Uproot 3's in all ways that are currently known. Can we update our python modules accordingly?