### PR TITLE
fairroot: Do not set VMCWORKDIR

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -103,9 +103,6 @@ module load BASE/1.0                                                            
             ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
 set FAIRROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv VMCWORKDIR \$FAIRROOT_ROOT/share/fairbase/examples
-setenv GEOMPATH \$::env(VMCWORKDIR)/common/geometry
-setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig
 prepend-path PATH \$FAIRROOT_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$FAIRROOT_ROOT/lib
 prepend-path ROOT_INCLUDE_PATH \$FAIRROOT_ROOT/include


### PR DESCRIPTION
The VMCWORKDIR variable from FairRoot sometimes
seems to take precedence over the one from O2 (wrong order of
module loading).

See also https://alice-talk.web.cern.ch/t/o2-simulation-does-not-work-when-qc-environment-is-loaded/810
I last saw the problem when loading O2Physics/latest and O2DPG.

We actually don't need to set the variable here and can avoid the problem.