### PR TITLE
Update o2sim.sh

### DIFF
--- a/o2sim.sh
+++ b/o2sim.sh
@@ -1,9 +1,10 @@
 package: O2sim
 version: "v%(year)s%(month)s%(day)s"
 requires:
-  - O2
+  - O2Physics
   - O2DPG
   - AEGIS
+  - EVTGEN
 ---
 #!/bin/bash -ex
 


### PR DESCRIPTION
Analysis has been factored into O2Physics so we should also depend on it (since we need it during some stages of MC workflows).
Also adding EVTGEN because it is used by some PWGs.