### PR TITLE
Override XRootD default tag for JAliEn

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -15,6 +15,8 @@ overrides:
     tag: v5-09-57h-01
   fastjet:
     tag: v3.4.0_1.045-alice1
+  XRootD:
+    tag: v4.12.5
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
Temporary fix for JAliEn build fails caused by later versions of XRootD.