### PR TITLE
Bump JAliEn to 1.4.0

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -16,7 +16,8 @@ overrides:
   fastjet:
     tag: v3.4.0_1.045-alice1
   XRootD:
-    tag: v4.12.5
+    source: https://github.com/xrootd/xrootd
+    tag: master
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -16,8 +16,8 @@ overrides:
   fastjet:
     tag: v3.4.0_1.045-alice1
   XRootD:
-    source: https://github.com/xrootd/xrootd
-    tag: master
+    source: https://github.com/zensanp/xrootd
+    tag: 5.3.1A
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/jalien.sh
+++ b/jalien.sh
@@ -1,6 +1,6 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.3.9"
+tag: "1.4.0"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
  - JDK


### PR DESCRIPTION
Update JAliEn (Java components only). Doesn't affect AliPhysics / O2 in any way.

Also removes the previous XRootD 4.12 entry in defaults, in favour of using the latest master.