### PR TITLE
Bump FairMQ to 1.4.42

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.41
+tag: v1.4.42
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.40
+tag: v1.4.41
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Provides support for shallow copy in shared memory.