### PR TITLE
Revert JAliEn xrootd to 4.12.5

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -16,8 +16,7 @@ overrides:
   fastjet:
     tag: v3.4.0_1.045-alice1
   XRootD:
-    source: https://github.com/zensanp/xrootd
-    tag: v5.3.1A
+    tag: v4.12.5
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
Reverts XRootD tag in defaults-jalien.sh to 4.12.5 (from 5.3.1).

Temporary workaround for issue breaking file upload to XRootD 4.x sites, allowing us to push new releases while this is being debugged in the background.