### PR TITLE
datadist: v1.0.10

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.0.9
+tag: v1.0.10
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
@davidrohr forgot to send this in. It should be on the next install via night-builds.
(it was already running on EPNs in the last round of manually built packages)