### PR TITLE
Use explicit prefix of openssl@1.1

### DIFF
--- a/alien-root-legacy.sh
+++ b/alien-root-legacy.sh
@@ -18,7 +18,7 @@ prepend_path:
 #!/bin/bash -e
 
 if [[ $ARCHITECTURE == osx* && ! $OPENSSL_ROOT ]]; then
-  OPENSSL_ROOT=$(brew --prefix openssl)
+  OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 fi
 
 # Determine whether we are building for ROOT 5 or ROOT 6+

--- a/control-occplugin.sh
+++ b/control-occplugin.sh
@@ -28,7 +28,7 @@ case $ARCHITECTURE in
       [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
       [[ ! $PROTOBUF_ROOT ]] && PROTOBUF_ROOT=$(brew --prefix protobuf)
       [[ ! $GRPC_ROOT ]] && GRPC_ROOT=$(brew --prefix grpc)
-      [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+      [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
       LIBEXT=dylib
     ;;
 esac

--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -13,7 +13,7 @@ build_requires:
 case $ARCHITECTURE in
   osx*) 
     [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-    [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl)
+    [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl@1.1)
   ;;
 esac
 

--- a/curl.sh
+++ b/curl.sh
@@ -10,7 +10,7 @@ build_requires:
 #!/bin/bash -e
 
 if [[ $ARCHITECTURE = osx* ]]; then
-  OPENSSL_ROOT=$(brew --prefix openssl)
+  OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 else
   ${OPENSSL_ROOT:+env LDFLAGS=-Wl,-R$OPENSSL_ROOT/lib}
 fi

--- a/grpc.sh
+++ b/grpc.sh
@@ -24,7 +24,7 @@ popd
 
 case $ARCHITECTURE in
   osx*)
-    [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+    [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
     [[ ! $PROTOBUF_ROOT ]] && PROTOBUF_ROOT=$(brew --prefix protobuf)
   ;;
 esac

--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -20,7 +20,7 @@ append_path:
 #!/bin/bash -e
 case $ARCHITECTURE in
   osx*) 
-	[[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl)
+	[[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 	[[ ! $LIBWEBSOCKETS_ROOT ]] && LIBWEBSOCKETS_ROOT=$(brew --prefix libwebsockets)
   ;;
 esac

--- a/libjalieno2.sh
+++ b/libjalieno2.sh
@@ -12,7 +12,7 @@ build_requires:
 #!/bin/bash -e
 
 if [[ $ARCHITECTURE = osx* ]]; then
-  OPENSSL_ROOT=$(brew --prefix openssl)
+  OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 fi
 
 rsync -a --exclude '**/.git' --delete $SOURCEDIR/ $BUILDDIR

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
 ---
 #!/bin/bash -e
 case $ARCHITECTURE in
-  osx*) [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl) ;;
+  osx*) [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl@1.1) ;;
 esac
 
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ $BUILDDIR

--- a/openssl.sh
+++ b/openssl.sh
@@ -4,7 +4,7 @@ tag: OpenSSL_1_0_2o
 source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER >= 0x10100000L\n#error \"System's GCC cannot be used: we need OpenSSL 1.0.x to build XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
+  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl@1.1 || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl@1.1`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER >= 0x10100000L\n#error \"System's GCC cannot be used: we need OpenSSL 1.0.x to build XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -x c++ - -I`brew --prefix openssl@1.1`/include -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"

--- a/osx-system-openssl.sh
+++ b/osx-system-openssl.sh
@@ -1,9 +1,9 @@
 package: osx-system-openssl
 version: "1.0"
 system_requirement_missing: |
-  Please make sure you install openssl using Homebrew (brew install openssl)
+  Please make sure you install openssl using Homebrew (brew install openssl@1.1)
 system_requirement: "osx.*"
 system_requirement_check: |
-  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null
+  echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl@1.1`/include -c -o /dev/null
 ---
 

--- a/python.sh
+++ b/python.sh
@@ -41,7 +41,7 @@ if [[ $ALIEN_RUNTIME_VERSION ]]; then
   ZLIB_ROOT=${ZLIB_ROOT:+$ALIEN_RUNTIME_ROOT}
 fi
 case $ARCHITECTURE in
-  osx*) [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl) ;;
+  osx*) [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl@1.1) ;;
 esac
 
 # Set own OpenSSL if appropriate

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -43,7 +43,7 @@ incremental_recipe: |
 case $ARCHITECTURE in
   osx*) 
       [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-      [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+      [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
       [[ ! $LIBUV_ROOT ]] && LIBUV_ROOT=$(brew --prefix libuv)
       SONAME=dylib
   ;;

--- a/readout.sh
+++ b/readout.sh
@@ -27,7 +27,7 @@ incremental_recipe: |
 case $ARCHITECTURE in
     osx*) 
         [[ ! $BOOST_ROOT ]] && BOOST_ROOT=$(brew --prefix boost)
-        [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+        [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
         [[ ! $LZ4_ROOT ]] && LZ4_ROOT=$(brew --prefix lz4)
         [[ ! $ZEROMQ_ROOT ]] && ZEROMQ_ROOT=$(brew --prefix zeromq)
         [[ ! $FMT_ROOT ]] && FMT_ROOT=`brew --prefix fmt`

--- a/root.sh
+++ b/root.sh
@@ -70,7 +70,7 @@ case $ARCHITECTURE in
     COMPILER_LD=clang
     SONAME=dylib
     [[ ! $GSL_ROOT ]] && GSL_ROOT=$(brew --prefix gsl)
-    [[ ! $OPENSSL_ROOT ]] && SYS_OPENSSL_ROOT=$(brew --prefix openssl)
+    [[ ! $OPENSSL_ROOT ]] && SYS_OPENSSL_ROOT=$(brew --prefix openssl@1.1)
     [[ ! $LIBPNG_ROOT ]] && LIBPNG_ROOT=$(brew --prefix libpng)
   ;;
 esac

--- a/thrift.sh
+++ b/thrift.sh
@@ -16,7 +16,7 @@ prefer_system_check: |
 case $ARCHITECTURE in
   osx*) 
     export PATH=$(brew --prefix bison)/bin:$PATH
-    OPENSSL_ROOT=$(brew --prefix openssl)
+    OPENSSL_ROOT=$(brew --prefix openssl@1.1)
   ;;
 esac
 rsync -a --delete --exclude="**/.git" $SOURCEDIR/ ./

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -27,7 +27,7 @@ rsync -a --delete --exclude='**/.git' --delete-excluded \
 autoreconf -ivf
 case $ARCHITECTURE in
   osx*)
-    [[ "$OPENSSL_ROOT" != "" ]] || OPENSSL_ROOT=`brew --prefix openssl`
+    [[ "$OPENSSL_ROOT" != "" ]] || OPENSSL_ROOT=`brew --prefix openssl@1.1`
     EXTRA_PERL_CXXFLAGS="-I$(perl -MConfig -e 'print $Config{archlib}')/CORE"
   ;;
 esac

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -20,7 +20,7 @@ PYTHON_EXECUTABLE=$( $(realpath $(which python3)) -c 'import sys; print(sys.exec
 case $ARCHITECTURE in
   osx_x86-64)
     export ARCHFLAGS="-arch x86_64"
-    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
+    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 
     # NOTE: Python from Homebrew will have a hardcoded sysroot pointing to Xcode.app directory wchich might not exist.
     # This seems to be a robust way to discover a working SDK path and present it to Python setuptools.
@@ -29,7 +29,7 @@ case $ARCHITECTURE in
     unset UUID_ROOT
   ;;
   osx*)
-    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl)
+    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 
     # NOTE: Python from Homebrew will have a hardcoded sysroot pointing to Xcode.app directory wchich might not exist.
     # This seems to be a robust way to discover a working SDK path and present it to Python setuptools.


### PR DESCRIPTION
After an update 

`brew prefix openssl`

returns the prefix of openssl@3 which causes issues. The fix specifies explicitly openssl@1.1.