### PR TITLE
Revert "Bump arrow to accept LLVM 13.0"

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v5.0.0-alice2"
-tag: 53be31087b0d3c7cca9acaa015902f7ae89b69c4
+version: "v5.0.0-alice1"
+tag: 453fc01ec151410a19cf681d626b6b601f0d3c13
 source: https://github.com/alisw/arrow.git
 requires:
   - boost


### PR DESCRIPTION
This reverts commit 98ae34c. This is needed because otherwise in the GPU containers the build fails with:

```
/sw/slc8_x86-64/GCC-Toolchain/v10.2.0-alice2-1/bin/../lib/gcc/x86_64-unknown-linux-gnu/10.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /sw/slc8_x86-64/arrow/v5.0.0-alice2-1/lib/libgandiva.so.500.0.0: undefined reference to `llvm::createNewGVNPass()'
/sw/slc8_x86-64/GCC-Toolchain/v10.2.0-alice2-1/bin/../lib/gcc/x86_64-unknown-linux-gnu/10.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /sw/slc8_x86-64/arrow/v5.0.0-alice2-1/lib/libgandiva.so.500.0.0: undefined reference to `llvm::Type::getInt128Ty(llvm::LLVMContext&)'
/sw/slc8_x86-64/GCC-Toolchain/v10.2.0-alice2-1/bin/../lib/gcc/x86_64-unknown-linux-gnu/10.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /sw/slc8_x86-64/arrow/v5.0.0-alice2-1/lib/libgandiva.so.500.0.0: undefined reference to `llvm::createTargetTransformInfoWrapperPass(llvm::TargetIRAnalysis)'
collect2: error: ld returned 1 exit status
```

due to the fact it finds the (modified?) llvm-amdgpu-13.0.0.21295.40300-52.el7.x86_64 package which is needed for the ROCm runtime.