### PR TITLE
Fix rc/flp-suite-* exclusion from automatic PRs

### DIFF
--- a/.github/workflows/daily-tag-pr.yml
+++ b/.github/workflows/daily-tag-pr.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.deleted }}
+    # For pushes to rc/flp-suite-*, DON'T open a PR.
+    if: ${{ !github.event.deleted && !startsWith(github.ref, 'refs/heads/rc/flp-suite-') }}
 
     steps:
       - name: Get rc branch
@@ -22,8 +23,6 @@ jobs:
           echo "::set-output name=base::${GITHUB_REF#refs/heads/rc/}"
 
       - name: Send pull request to regular branch
-        # For pushes to rc/flp-suite-*, DON'T open a PR.
-        if: ${{ !startsWith(github.ref, 'refs/heads/rc/flp-suite-') }}
         uses: repo-sync/pull-request@v2.5
         with:
           destination_branch: ${{ steps.name.outputs.base }}


### PR DESCRIPTION
GitHub ignores the `if:` key on the PR step, so move the check to the action-wide `if:` instead.

Tested using https://github.com/TimoWilken/auto-pr-test.