### PR TITLE
Bump Monitoring to v3.8.10 and InfoLogger to v2.3.0

### DIFF
--- a/infologger.sh
+++ b/infologger.sh
@@ -1,6 +1,6 @@
 package: InfoLogger
 version: "%(tag_basename)s"
-tag: v2.2.0
+tag: v2.3.0
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v3.8.9
+tag: v3.8.10
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
@davidrohr This should stop Monitoring from flooding InfoLogger