### PR TITLE
Bump FairMQ to 1.4.43 - DON't MERGE YET

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.42
+tag: v1.4.43
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Should be merged only when there will be no more FLPSuite before the pilot beam.