### PR TITLE
xjalienfs update

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.3"
+tag: "1.3.4"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* critical update : there was a limit on message size that blocks large listing of lfns; it was removed
* checkAddr command for connectivity checking 