### PR TITLE
Revert "Bump qualitycontrol to v1.36.0"

### DIFF
--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -1,6 +1,6 @@
 package: QualityControl
 version: "%(tag_basename)s"
-tag: v1.36.0
+tag: v1.35.2
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Reverts alisw/alidist#3485

Reverting since the latest O2PDPSuite with QC 1.36 failed on the EPN during data taking tests, and there were some issues in QC.
I am not 100 % sure this PR is to blame, but we need a build without the new QC tomorrow for the EPNs, so I am reverting this such that the nightly is using the old QC version.