### PR TITLE
Revert "Revert "Bump qualitycontrol to v1.36.0""

### DIFF
--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -1,6 +1,6 @@
 package: QualityControl
 version: "%(tag_basename)s"
-tag: v1.35.2
+tag: v1.36.0
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Reverts alisw/alidist#3497
We can bump this again, since we will not create any more builds for the pilot beam