### PR TITLE
Bump xrootd to v5.3.2

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.3.1"
+tag: "v5.3.2"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
This fixes build problems with the latest Xcode on MacOS.

Cc: @Barthelemy