### PR TITLE
Fix of openssl linking in cmake build

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -28,6 +28,8 @@ SET(Java_JAVAC_EXECUTABLE FALSE CACHE BOOL "" FORCE)
 SET(BUILD_CursesDialog FALSE CACHE BOOL "" FORCE)
 EOF
 
+export OPENSSL_ROOT_DIR=$OPENSSL_ROOT
+
 $SOURCEDIR/bootstrap --prefix=$INSTALLROOT \
                      --init=build-flags.cmake \
                      ${JOBS:+--parallel=$JOBS}


### PR DESCRIPTION
When building latest CMake 3.19.2 against OpenSSL v1.0.2o, cmake looks for the OpenSSL library at wrong place. This should fix it.