### PR TITLE
Fixed root.sh to properly find for libxml2

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -127,6 +127,8 @@ cmake $SOURCEDIR                                                                
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT=$OPENSSL_ROOT}                                    \
       ${OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIR=$OPENSSL_ROOT/include}                     \
       ${LIBXML2_ROOT:+-DLIBXML2_ROOT=$LIBXML2_ROOT}                                    \
+      ${LIBXML2_ROOT:+-DPC_LIBXML_INCLUDEDIR=$LIBXML2_ROOT/include}                    \
+      ${LIBXML2_ROOT:+-DPC_LIBXML_LIBDIR=$LIBXML2_ROOT/lib}                            \
       ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                                                 \
       ${LIBPNG_ROOT:+-DPNG_INCLUDE_DIRS="${LIBPNG_ROOT}/include"}                      \
       ${LIBPNG_ROOT:+-DPNG_LIBRARY="${LIBPNG_ROOT}/lib/libpng.${SONAME}"}              \


### PR DESCRIPTION
When building ROOT v6-24-06 with libxml2/v2.9.3 (--no-system build), proper variable for LIBXML2 libdir and include dir has to be set in ROOT configuration.

Signed-off-by: Jan Busa Jr <busa@jinr.ru>