### PR TITLE
Added missing compilation flag -lpthread and module file creation.

### DIFF
--- a/clhep.sh
+++ b/clhep.sh
@@ -2,10 +2,23 @@ package: CLHEP
 version: "2.2.0.8"
 source: https://github.com/alisw/clhep
 tag: CLHEP_2_2_0_8
+build_requires:
+  - CMake
 ---
 #!/bin/sh
 cmake $SOURCEDIR \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"
-  
+
 make ${JOBS+-j $JOBS}
 make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+
+alibuild-generate-module --bin --lib > $MODULEFILE
+
+cat >> "$MODULEFILE" <<EoF
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
+EoF


### PR DESCRIPTION
When building CLHEP with --no-system build on current C++ Toolset (10.2), phtread was missing to sucessfully build the CLHEP. Also module creation was added to be able to link to CLHEP from other projects.