### PR TITLE
Remove unneeded XRootD override in defaults-o2.sh

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -22,9 +22,6 @@ overrides:
   GCC-Toolchain:
     tag: v10.2.0-alice2
     version: v10.2.0-alice2
-  XRootD:
-    source: https://github.com/xrootd/xrootd
-    tag: v5.3.1
   cgal:
     version: 4.12.2
   fastjet:


### PR DESCRIPTION
This was masking the updated xrootd.sh for some checks.

Cc: @Barthelemy 