### PR TITLE
Fix Clang compilation with newer Apple SDKs

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -20,20 +20,10 @@ unset CXXFLAGS
 unset CFLAGS
 unset LDFLAGS
 
-case $ARCHITECTURE in 
+case $ARCHITECTURE in
   # Needed to have the C headers
-  osx*)
-    XCODE_PATH=`xcode-select -p`
-    DEFAULT_SYSROOT=$(find $XCODE_PATH -type d -path "*/MacOSX.sdk/usr/include" | sed -e 's|/usr/include||g')
-    if [ "X$DEFAULT_SYSROOT" = X ]; then
-      DEFAULT_SYSROOT=`xcrun --show-sdk-path`
-    fi
-  ;;
-  # This will most likely fail if we start producing binary packages for Ubuntu, but for the moment we do not.
-  ubuntu*) DEFAULT_SYSROOT="" ;;
-  debian*) DEFAULT_SYSROOT="" ;;
-  unknown*) DEFAULT_SYSROOT="" ;;
-  *) DEFAULT_SYSROOT="" ;;
+  osx_*) DEFAULT_SYSROOT=$(xcrun --show-sdk-path) ;;
+  *) DEFAULT_SYSROOT= ;;
 esac
 # note that BUILD_SHARED_LIBS=ON IS NEEDED FOR ADDING DYNAMIC PLUGINS
 # to clang-tidy (for instance)
@@ -45,7 +35,7 @@ cmake $SOURCEDIR/llvm \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT" \
   -DLLVM_INSTALL_UTILS=ON \
   -DPYTHON_EXECUTABLE=$(which python3) \
-  -DDEFAULT_SYSROOT=${DEFAULT_SYSROOT} \
+  -DDEFAULT_SYSROOT="$DEFAULT_SYSROOT" \
   -DLLVM_BUILD_LLVM_DYLIB=ON \
   -DBUILD_SHARED_LIBS=OFF
 
@@ -64,26 +54,21 @@ cmake ../ \
 cmake --build . -- ${JOBS:+-j$JOBS} install
 popd
 
-#add correct rpath to dylibs on mac as long as there is no better way to controll rpath in the LLVM CMake.
 case $ARCHITECTURE in
   osx*)
-  # add rpath to all libraries in lib and change their IDs to be absolute paths
-  find ${INSTALLROOT}/lib -name "*.dylib" ! -name "*ios*.dylib" -exec install_name_tool -add_rpath "${INSTALLROOT}/lib" {} \; -exec install_name_tool -id {} {} \;
-  # in lib/clang/*/lib/darwin, the relative rpath is wrong and needs to be corrected from "@loader_path/../lib" to "@loader_path/../darwin" 
-  find ${INSTALLROOT}/lib/clang/*/lib/darwin \( -name "*.dylib" -a \( ! -name "*ios*.dylib" \) \) -exec install_name_tool -add_rpath "@loader_path/../darwin" {} \;
-  ;;
-esac
+    # Add correct rpath to dylibs on Mac as long as there is no better way to
+    # control rpath in the LLVM CMake.
+    # Add rpath to all libraries in lib and change their IDs to be absolute paths.
+    find "$INSTALLROOT/lib" -name '*.dylib' -not -name '*ios*.dylib' \
+         -exec install_name_tool -add_rpath "$INSTALLROOT/lib" '{}' \; \
+         -exec install_name_tool -id '{}' '{}' \;
+    # In lib/clang/*/lib/darwin, the relative rpath is wrong and needs to be
+    # corrected from "@loader_path/../lib" to "@loader_path/../darwin".
+    find "$INSTALLROOT"/lib/clang/*/lib/darwin -name '*.dylib' -not -name '*ios*.dylib' \
+         -exec install_name_tool -rpath '@loader_path/../lib' '@loader_path/../darwin' '{}' \;
 
-# Needed to be able to find C++ headers.
-case $ARCHITECTURE in
-  osx*)
-    ln -sf "$(find `xcode-select -p` -type d -path "*MacOSX.sdk/usr/include/c++" -o -path "*/XcodeDefault.xctoolchain/usr/include/c++" | head -1)" "$INSTALLROOT/include/c++"
-  ;;
-  *)
-  if [ "X$GCC_TOOLCHAIN_ROOT" = X ]; then
-    find $GCC_TOOLCHAIN_ROOT -type d -path "*/include/c++" -exec ln -sf {} $INSTALLROOT/include/c++ \;
-  fi
-  ;;
+    # Needed to be able to find C++ headers.
+    ln -sf "$(xcrun --show-sdk-path)/usr/include/c++" "$INSTALLROOT/include/c++" ;;
 esac
 
 # We do not want to have the clang executables in path

--- a/clang.sh
+++ b/clang.sh
@@ -25,12 +25,18 @@ case $ARCHITECTURE in
   osx_*) DEFAULT_SYSROOT=$(xcrun --show-sdk-path) ;;
   *) DEFAULT_SYSROOT= ;;
 esac
+case $ARCHITECTURE in
+  *_x86-64) LLVM_TARGETS_TO_BUILD=X86 ;;
+  *_arm64) LLVM_TARGETS_TO_BUILD=AArch64 ;;
+  *) echo 'Unknown LLVM target for architecture' >&2; exit 1 ;;
+esac
+
 # note that BUILD_SHARED_LIBS=ON IS NEEDED FOR ADDING DYNAMIC PLUGINS
 # to clang-tidy (for instance)
 cmake $SOURCEDIR/llvm \
   -G Ninja \
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt" \
-  -DLLVM_TARGETS_TO_BUILD="X86" \
+  -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD:?}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT" \
   -DLLVM_INSTALL_UTILS=ON \


### PR DESCRIPTION
`xcrun --show-sdk-path` seems to give the correct result, no need for `find`.

@ktf or @davidrohr: is there a case where this doesn't work that the previous code was guarding against?

In addition, fix the build on `osx_arm64`. Tested on Mac M1.