### PR TITLE
xjalienfs:: 1.3.6 hot bugfix

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.5"
+tag: "1.3.6"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
for in-zip files the url used is not the meta filepath! we should take this into account.
this bug affects all in-zip files downloads