### PR TITLE
Introduce VMC recipe

### DIFF
--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -4,6 +4,7 @@ tag: "v0.3.0"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"
+  - ROOT
   - VMC
   - boost
 build_requires:

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,10 +1,10 @@
 package: MCStepLogger
 version: "%(tag_basename)s"
-tag: "v0.2.0"
+tag: "v0.3.0"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"
-  - ROOT
+  - VMC
   - boost
 build_requires:
   - CMake

--- a/vmc.sh
+++ b/vmc.sh
@@ -1,0 +1,27 @@
+package: VMC
+version: "%(tag_basename)s"
+tag: "v1-0-p3"
+source: https://github.com/vmc-project/vmc
+requires:
+  - ROOT
+build_requires:
+  - CMake
+  - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
+---
+#!/bin/bash -e
+cmake "$SOURCEDIR"                             \
+  -DCMAKE_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+  -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"        \
+    ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}
+
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --bin --lib > $MODULEFILE
+cat >> "$MODULEFILE" <<EoF
+setenv VMC_ROOT \$PKG_ROOT
+EoF


### PR DESCRIPTION
* adiabatic approach

  * VMC recipe depends on ROOT, therefore remove ROOT dependency from all
    VMC related recipes and add VMC as the actual dependency

  * for now do not touch anything else and still take ROOT's VMC
    (this keeps everything working as before as for instance O2
     compilation would crash otherwise)

  * following this, everything will move to VMC standalone