### PR TITLE
Bump FairLogger to v1.10.4

### DIFF
--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -1,6 +1,6 @@
 package: FairLogger
 version: "%(tag_basename)s"
-tag: v1.10.2
+tag: v1.10.4
 source: https://github.com/FairRootGroup/FairLogger
 requires:
  - fmt


### PR DESCRIPTION
- Add back the deprecation of the upper case severity names.
- Adapt to fmt's deprecation of format_to memory buffer overload.