### PR TITLE
xjalienfs tag 1.3.7

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.6"
+tag: "1.3.7"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
hot bug-fix release : 
* return the right exitcode of the last executed command
O2 CCDB API use this return exitcode to check for token validity and presence