### PR TITLE
Use builtin VMC fallback

### DIFF
--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,11 +1,10 @@
 package: MCStepLogger
 version: "%(tag_basename)s"
-tag: "v0.3.0"
+tag: "v0.4.0"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"
   - ROOT
-  - VMC
   - boost
 build_requires:
   - CMake

--- a/vmc.sh
+++ b/vmc.sh
@@ -1,6 +1,6 @@
 package: VMC
 version: "%(tag_basename)s"
-tag: "v1-0-p3"
+tag: "v1-1-p1"
 source: https://github.com/vmc-project/vmc
 requires:
   - ROOT


### PR DESCRIPTION
* use ROOT's 'builtin VMC as fallback for MC (bumped to version v0.4.0)

* update VMC recipe already to most recent

* temporarily VMC recipe is not used