### PR TITLE
Fix modulefile for infologger

### DIFF
--- a/infologger.sh
+++ b/infologger.sh
@@ -53,6 +53,6 @@ set INFOLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv INFOLOGGER_ROOT \$INFOLOGGER_ROOT
 prepend-path PATH \$INFOLOGGER_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$INFOLOGGER_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
+prepend-path ROOT_INCLUDE_PATH \$INFOLOGGER_ROOT/include
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
PKG_ROOT is only available when using alibuild-generate-module.