### PR TITLE
Bump O2DPG

### DIFF
--- a/o2dpg.sh
+++ b/o2dpg.sh
@@ -1,6 +1,6 @@
 package: O2DPG
 version: "%(tag_basename)s"
-tag: 9ba38e202024c2d844bbafca191331155a685be1
+tag: dataflow-20211219
 source: https://github.com/AliceO2Group/O2DPG.git
 build_requires:
   - alibuild-recipe-tools


### PR DESCRIPTION
This bumps O2DPG manually, since the automatic nightly bump seems not to work. With the new version we should have the increase of the soft ulimit in.