### PR TITLE
Bump FairMQ to v1.4.45

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.43
+tag: v1.4.45
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Contains APIs needed for R3C-646 and improvements to significantly improve behavior described in O2-2737.