### PR TITLE
Bump FairMQ to v1.4.46

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.45
+tag: v1.4.46
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
v1.4.46 fixes a bug that was introduced in v1.4.45 (which you have so far not observed afaik).