### PR TITLE
Add own valgrind

### DIFF
--- a/valgrind.sh
+++ b/valgrind.sh
@@ -1,0 +1,30 @@
+package: valgrind
+source: git://sourceware.org/git/valgrind.git
+version: "3.18.1"
+tag: VALGRIND_3_18_1
+build_requires:
+- autotools
+- GCC-Toolchain
+- alibuild-recipe-tools
+---
+
+rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
+CONF_OPTS="--enable-only64bit"
+case $ARCHITECTURE in
+  osx*)
+    CFLAGS="-D__private_extern__=extern"
+    ;;
+esac
+
+./autogen.sh
+./configure --prefix=$INSTALLROOT --without-mpicc --disable-static ${CONF_OPTS}
+make -j 20
+make install
+
+#ModuleFile
+mkdir -p etc/modulefiles
+alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
+cat >> etc/modulefiles/$PKGNAME <<EoF
+prepend-path VALGRIND_LIB \$PKG_ROOT/libexec/valgrind
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
Apparently compiling with GCC 10.2 and using system valgrind creates troubles on some systems (e.g. Ubuntu 18.04) which are not able to properly find the  debug symbols. Using valgrind consistently compiled for our stack solves that problem. 