### PR TITLE
Alidist - freetype.sh - change system check

### DIFF
--- a/freetype.sh
+++ b/freetype.sh
@@ -7,7 +7,7 @@ build_requires:
   - system-curl
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include <ft2build.h>\n" | c++ -xc++ - `pkg-config freetype2 --cflags` -c -M 2>&1;
+  printf "#include <ft2build.h>\n" | c++ -xc++ - `freetype-config --cflags 2>/dev/null` `pkg-config freetype2 --cflags 2>/dev/null` -c -M 2>&1;
   if [ $? -ne 0 ]; then printf "FreeType is missing on your system.\n * On RHEL-compatible systems you probably need: freetype freetype-devel\n * On Ubuntu-compatible systems you probably need: libfreetype6 libfreetype6-dev\n"; exit 1; fi
 ---
 #!/bin/bash -ex

--- a/freetype.sh
+++ b/freetype.sh
@@ -7,7 +7,7 @@ build_requires:
   - system-curl
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include <ft2build.h>\n" | c++ -xc++ - `freetype-config --cflags` -c -M 2>&1;
+  printf "#include <ft2build.h>\n" | c++ -xc++ - `pkg-config freetype2 --cflags` -c -M 2>&1;
   if [ $? -ne 0 ]; then printf "FreeType is missing on your system.\n * On RHEL-compatible systems you probably need: freetype freetype-devel\n * On Ubuntu-compatible systems you probably need: libfreetype6 libfreetype6-dev\n"; exit 1; fi
 ---
 #!/bin/bash -ex


### PR DESCRIPTION
Apparently, the command 'freetype-config' has been deprecated. 
e.g. it has been removed from the package libfreetype6-dev in Ubuntu 20.04. 
The command used here to check the Freetype version potentially available on system (system check) will never work under Ubuntu 20.04.

It is by now recommended to use pkg-config i.e. 'pkg-config freetype2 --cflags'

. Under Ubuntu 18.04 LTS, both option should work (freetype-config redirect silently towards pkg-config, transitional package).
Not tested but expected from http://manpages.ubuntu.com/manpages/bionic/en/man1/freetype-config.1.html
. Under CentOS7, same : both options work (commands tested on lxplus)

I checked the response of the command under Ubuntu 20.04 LTS.
After the change on such an OS, 'aliDoctor AliGenerators' plans now to take FreeType from the system.