### PR TITLE
Move to VMC standalone

### DIFF
--- a/aegis.sh
+++ b/aegis.sh
@@ -1,8 +1,9 @@
 package: AEGIS
 version: "%(tag_basename)s"
-tag: v1.4
+tag: v1.4-alice1
 requires:
   - ROOT
+  - VMC
   - pythia6
 build_requires:
   - CMake

--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -7,7 +7,6 @@ env:
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "11"
-  ENABLE_VMC: "ON"
 overrides:
   AliRoot:
     version: "%(tag_basename)s_ROOT6"

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -6,6 +6,7 @@ requires:
   - generators
   - simulation
   - ROOT
+  - VMC
   - boost
   - protobuf
   - FairLogger

--- a/fluka_vmc.sh
+++ b/fluka_vmc.sh
@@ -1,10 +1,11 @@
 package: FLUKA_VMC
 version: "%(tag_basename)s"
-tag: "4-1.1-vmc1"
+tag: "4-1.1-vmc2"
 source: https://gitlab.cern.ch/ALICEPrivateExternals/FLUKA_VMC.git
 requires:
   - "GCC-Toolchain:(?!osx)"
   - ROOT
+  - VMC
 build_requires:
   - CMake
   - FLUKA
@@ -41,7 +42,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+module load BASE/1.0 ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} ${VMC_REVISION:+VMC/$VMC_VERSION-$VMC_REVISION} ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
 # Our environment
 set FLUKA_VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv FLUKA_VMC_ROOT \$FLUKA_VMC_ROOT

--- a/geant3.sh
+++ b/geant3.sh
@@ -1,8 +1,9 @@
 package: GEANT3
 version: "%(tag_basename)s"
-tag: v3-7
+tag: v3-9
 requires:
   - ROOT
+  - VMC
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
@@ -40,7 +41,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION
+module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION VMC/$VMC_VERSION-$VMC_REVISION
 # Our environment
 set GEANT3_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv GEANT3_ROOT \$GEANT3_ROOT

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,9 +1,10 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v5-3"
+tag: "v5-4"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT
+  - VMC
   - GEANT4
   - vgm
 build_requires:
@@ -40,7 +41,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${GEANT4_REVISION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION} ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} vgm/$VGM_VERSION-$VGM_REVISION
+module load BASE/1.0 ${GEANT4_REVISION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION} ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} ${VMC_REVISION:+VMC/$VMC_VERSION-$VMC_REVISION} vgm/$VGM_VERSION-$VGM_REVISION
 # Our environment
 set GEANT4_VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv GEANT4_VMC_ROOT \$GEANT4_VMC_ROOT

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -5,6 +5,7 @@ source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"
   - ROOT
+  - VMC
   - boost
 build_requires:
   - CMake

--- a/root.sh
+++ b/root.sh
@@ -42,7 +42,7 @@ COMPILER_CXX=c++
 COMPILER_LD=c++
 case $PKGVERSION in
   v6-*)
-     ENABLE_VMC=1
+     [ "0${ENABLE_VMC}" == "0" ] && BUILD_VMC_INTERNAL=1 || true
      [[ "$CXXFLAGS" == *'-std=c++11'* ]] && CMAKE_CXX_STANDARD=11 || true
      [[ "$CXXFLAGS" == *'-std=c++14'* ]] && CMAKE_CXX_STANDARD=14 || true
      [[ "$CXXFLAGS" == *'-std=c++17'* ]] && CMAKE_CXX_STANDARD=17 || true
@@ -155,7 +155,7 @@ cmake $SOURCEDIR                                                                
       -Dgviz=OFF                                                                       \
       -Dbuiltin_davix=OFF                                                              \
       -Dbuiltin_afterimage=ON                                                          \
-      ${ENABLE_VMC:+-Dvmc=ON}                                                          \
+      ${BUILD_VMC_INTERNAL:+-Dvmc=ON}                                                  \
       -Ddavix=OFF                                                                      \
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
       ${ROOT_HAS_PYTHON:+-DPYTHON_PREFER_VERSION=3}                                    \

--- a/vmc.sh
+++ b/vmc.sh
@@ -8,21 +8,34 @@ build_requires:
   - CMake
   - "Xcode:(osx.*)"
   - alibuild-recipe-tools
+prepend_path:
+  ROOT_INCLUDE_PATH: "$VMC_ROOT/include/vmc"
 ---
 #!/bin/bash -e
-cmake "$SOURCEDIR"                             \
-  -DCMAKE_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-  -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"        \
-  -DCMAKE_INSTALL_LIBDIR=lib                   \
-    ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}
 
-cmake --build . -- ${JOBS:+-j$JOBS} install
-
-# Modulefile
+# Make basic modufile first
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --bin --lib > $MODULEFILE
+alibuild-generate-module > $MODULEFILE
+
+[ "0$ENABLE_VMC" == "0" ] && exit 0 || true
+
+cmake "$SOURCEDIR"                                 \
+      -DCMAKE_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"        \
+      -DCMAKE_INSTALL_LIBDIR=lib                   \
+      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}
+
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# Make backward compatible in case a depending (older) package still needs libVMC.so
+ln -s $INSTALLROOT/lib/libVMCLibrary.so $INSTALLROOT/lib/libVMC.so
+# update modulefile
 cat >> "$MODULEFILE" <<EoF
-setenv VMC_ROOT \$PKG_ROOT
+# Our environment
+set VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv VMC_ROOT \$VMC_ROOT
+prepend-path LD_LIBRARY_PATH \$VMC_ROOT/lib
+prepend-path ROOT_INCLUDE_PATH \$VMC_ROOT/include/vmc
 EoF


### PR DESCRIPTION
* swap logic of ENABLE_VMC: only if set, VMC standalone is built
  -> for all other ROOT6 builds, builtin is still used
     * defaults-next-root6
     * defaults-user-next-root6
     * defaults-jalien
     * defaults-o2-dataflow (see below)
  -> ROOT5 builds not affected

* default-o2-dataflow not changed, no simulation used, so in that case
  ROOT would still be built with buitlin VMC

* defaults-generators not primarily meant for builds including detector
  simulation -> ENABLE_VMC not set