### PR TITLE
Add missing dependency to alibuild-recipe-tools

### DIFF
--- a/libinfologger.sh
+++ b/libinfologger.sh
@@ -6,6 +6,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 source: https://github.com/AliceO2Group/InfoLogger
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install


### PR DESCRIPTION
trivial and obviously broken, no idea why it worked in the CI.
Merging.