### PR TITLE
Avoid installing libraries in lib64 on cvmfs

### DIFF
--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -30,6 +30,7 @@ mkdir -p $INSTALLROOT
 cmake "$SOURCEDIR/cmake" \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
       -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
+      -DCMAKE_INSTALL_LIBDIR=lib \
       -Donnxruntime_DEV_MODE=OFF \
       -Donnxruntime_BUILD_UNIT_TESTS=OFF \
       -Donnxruntime_ENABLE_PYTHON=ON \


### PR DESCRIPTION
As one can see below, the latest builds on cvmfs have the wrong path for the libs leading to crashes (reported by @fgrosa) while running on hyperloop and co.

```
[O2Physics/nightly-20220120-1] ~ > ls /cvmfs/alice.cern.ch/el7-x86_64/Packages/ONNXRuntime/v1.7.2-alice1-7
cmake  etc  include  lib64  relocate-me.sh
```