### PR TITLE
Bump FairCMakeModules to v1.0.0

### DIFF
--- a/faircmakemodules.sh
+++ b/faircmakemodules.sh
@@ -1,6 +1,6 @@
 package: FairCMakeModules
 version: "%(tag_basename)s"
-tag: v0.2.0
+tag: v1.0.0
 source: https://github.com/FairRootGroup/FairCMakeModules
 build_requires:
   - CMake


### PR DESCRIPTION
This version will be required for the upcoming ODC versions.

Should be non-breaking. [Changelog](https://fairrootgroup.github.io/FairCMakeModules/latest/changelog.html#v1-0-0-2021-09-08).