### PR TITLE
Use Catalina as deployment target.

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -5,6 +5,7 @@ env:
   CXXSTD: '17'
   ENABLE_VMC: 'ON'
   GEANT4_BUILD_MULTITHREADED: 'ON'
+  MACOSX_DEPLOYMENT_TARGET: '10.15'
 overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'


### PR DESCRIPTION
This is the version supported by cling of Root v6-24-06 (MacOSX Monterey)