### PR TITLE
Fix missing LD_LIBRARY_PATH for fmt

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -4,6 +4,7 @@ tag: 8.0.1
 source: https://github.com/fmtlib/fmt
 requires:
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 build_requires:
   - CMake
 prepend_path:
@@ -19,18 +20,8 @@ make install
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set FMT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv FMT_ROOT \$FMT_ROOT
-prepend-path ROOT_INCLUDE_PATH \$FMT_ROOT/include
-EoF
+
+alibuild-generate-module --lib > $MODULEFILE
+cat << EOF >> $MODULEFILE
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
+EOF


### PR DESCRIPTION
Now that we have the library version, we must make sure we have the module adapted accordingly.