### PR TITLE
Bump FairMQ to v1.4.47

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.46
+tag: v1.4.47
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Contains @ktf's contribution with the GUI mode for the built-in controller plugin.
Needed for https://github.com/AliceO2Group/AliceO2/pull/8004.