### PR TITLE
Fix copy & paste error

### DIFF
--- a/vecgeom.sh
+++ b/vecgeom.sh
@@ -57,8 +57,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 Vc/$VC_VERSION-$VC_REVISION ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION}
 # Our environment
 set osname [uname sysname]
-set VC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv VC_ROOT \$VC_ROOT
-prepend-path PATH \$VC_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$VC_ROOT/lib
+set VECGEOM_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv VECGEOM_ROOT \$VECGEOM_ROOT
+prepend-path PATH \$VECGEOM_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$VECGEOM_ROOT/lib
 EoF


### PR DESCRIPTION
I assume this was a copy and paste error when vecgeom.sh was updated, taking vc.sh as input.
Depending on load order, it can override the VC settings and make then point to VecGeom such that Vc is not found.