### PR TITLE
datadist: bump to v1.1.0

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.0.17
+tag: v1.1.0
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
This contains support for adoption of existing SHM segments. 
Online run script will need a parameter update (tfbuilder.sh)