### PR TITLE
Bump FairMQ to v1.4.48

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.47
+tag: v1.4.48
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Contains changes for R3C-646 to allow "soft" shmem reset after a crash (previously only possible after an orderly shutdown).

Also adds UnmangedRegion size to shmmonitor debug output.
