### PR TITLE
Bump googlebenchmark 1.3.0 -> 1.6.1

### DIFF
--- a/googlebenchmark.sh
+++ b/googlebenchmark.sh
@@ -1,6 +1,6 @@
 package: googlebenchmark
-version: "1.3.0"
-tag: v1.3.0
+version: "1.6.1"
+tag: v1.6.1
 source: https://github.com/google/benchmark
 build_requires:
  - "GCC-Toolchain:(?!osx)"
@@ -9,6 +9,7 @@ build_requires:
 #!/bin/bash -e
 cmake $SOURCEDIR                           \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT  \
+      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}
 make ${JOBS+-j $JOBS}
 make install


### PR DESCRIPTION
Bump googlebenchmark to the latest version to profit from new features.