### PR TITLE
Bump abseil version

### DIFF
--- a/abseil.sh
+++ b/abseil.sh
@@ -1,6 +1,6 @@
 package: abseil
 version: "%(tag_basename)s"
-tag:  "20200225.2"
+tag:  "20211102.0"
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
@@ -25,11 +25,4 @@ make ${JOBS:+-j$JOBS} install
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module > "$MODULEFILE"
-cat >> "$MODULEFILE" <<EoF
-
-# Our environment
-set ABSEIL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$ABSEIL_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$ABSEIL_ROOT/lib
-EoF
+alibuild-generate-module --lib --bin > "$MODULEFILE"


### PR DESCRIPTION
We have reports of abseil not working with GCC 11.1 and ubuntu 21.1, so let's see if this is enough to fix it.