### PR TITLE
Revert "datadist: bump to v1.2.0"

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.2.0
+tag: v1.1.0
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
Reverting, such that the next nightly builds use the old DD; until this if fully validated, and will be deployed in parallel on EPN and FLP farms.