### PR TITLE
Added ONNXRuntime as requirement to O2

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -29,6 +29,7 @@ disable:
   - O2sim
   - O2-full-system-test
   - O2Physics
+  - ONNXRuntime
 overrides:
   protobuf:
     version: v3.14.0

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -8,6 +8,7 @@ env:
   GEANT4_BUILD_MULTITHREADED: 'ON'
 disable:
   - O2Physics
+  - ONNXRuntime
 overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'

--- a/o2.sh
+++ b/o2.sh
@@ -26,6 +26,7 @@ requires:
   - KFParticle
   - VecGeom
   - FFTW3
+  - ONNXRuntime
 build_requires:
   - GMP
   - MPFR


### PR DESCRIPTION
ONNXRuntime is required for the fastsim module to work