### PR TITLE
Increase string buffer and trim install path

### DIFF
--- a/openloops.sh
+++ b/openloops.sh
@@ -12,6 +12,10 @@ rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ .
 
 unset HTTP_PROXY # unset this to build on slc6 system
 
+# Due to typical long install dir paths used by aliBuikd the string lenghts must be increased
+# In addition a trim statement is missing for the install path
+sed -i 's/max_string_length\ =\ 255/max_string_length\ =\ 1000/g' pyol/config/default.cfg
+sed -i 's/call\ set_parameter(\"install_path\",\ tmp,\ error)/call\ set_parameter(\"install_path\",\ trim(tmp),\ error)/g' lib_src/openloops/src/ol_interface.F90
 ./scons 
 
 JOBS=$((${JOBS:-1}*1/5))


### PR DESCRIPTION
OpenLoops complains at runtime about install path exceeding
the buffersize allocated for strings. There are two reasons
for this:
- The max buffer is allocated to 255 chars, which is on
  modern systems rather conservative, and with the design
  of aliBuild the exceeding of the buffer can be easily
  achieved. 1000 characters is a safer setting.
- The install_path string is not trimmed, therefore any
  buffer will be exceeded (bug in OpenLoops itself)
The buffersize is a config parameter that must be patched
in any case, for the trim function an on-the-fly patch would
allow taking OpenLoops directly from the official repository.