### PR TITLE
Allowed to choose precision in FFTW3

### DIFF
--- a/fftw3.sh
+++ b/fftw3.sh
@@ -8,21 +8,37 @@ build_requires:
   - CMake
 ---
 #!/bin/bash -e
+export FFTW3_WITH_AVX # use AVX with float or double. Unset automatically for long double and quad
+
+if [[ $FFTW3_DOUBLE == "ON" ]]; then # ensure only one option is set and AVX is disabled if necessary
+  FFTW3_FLOAT="OFF"
+  FFTW3_LONG_DOUBLE="OFF"
+elif [[ $FFTW3_LONG_DOUBLE == "ON" ]]; then
+  unset FFTW3_WITH_AVX
+  FFTW3_FLOAT="OFF"
+  FFTW3_DOUBLE="OFF"
+else # keep FLOAT default option as it was
+  FFTW3_FLOAT="ON"
+  FFTW3_DOUBLE="OFF"
+  FFTW3_LONG_DOUBLE="OFF"
+fi
 
 case $ARCHITECTURE in
     osx_arm64)
-	cmake $SOURCEDIR                                   \
-	      -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}" \
-	      -DCMAKE_INSTALL_LIBDIR:PATH="lib"            \
-	      -DENABLE_FLOAT=ON
-	;;
+  cmake $SOURCEDIR                                          \
+        -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}"        \
+        -DCMAKE_INSTALL_LIBDIR:PATH="lib"                   \
+        -DENABLE_LONG_DOUBLE=${FFTW3_LONG_DOUBLE-OFF}       \
+        -DENABLE_FLOAT=${FFTW3_FLOAT-OFF}
+  ;;
     *)
-	cmake $SOURCEDIR                                   \
-	      -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}" \
-	      -DCMAKE_INSTALL_LIBDIR:PATH="lib"            \
-	      -DENABLE_FLOAT=ON                            \
-	      -DENABLE_AVX=ON
-	;;
+  cmake $SOURCEDIR                                          \
+        -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}"        \
+        -DCMAKE_INSTALL_LIBDIR:PATH="lib"                   \
+        -DENABLE_LONG_DOUBLE=${FFTW3_LONG_DOUBLE-OFF}       \
+        -DENABLE_FLOAT=${FFTW3_FLOAT-OFF}                   \
+        ${FFTW3_WITH_AVX:+-DENABLE_AVX=ON}
+  ;;
 esac
 
 make ${JOBS+-j $JOBS}


### PR DESCRIPTION
This pull request allows user to choose FFTW3 precision by setting environment variables FFTW3_DOUBLE or FFTW3_LONG_DOUBLE to ON. If no variable is set, original behavior (build in single precision) is kept.