### PR TITLE
datadist: bump to v1.2.0 again

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.1.0
+tag: v1.2.0
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
New FLPSuite is at 1.2.0, so we have to bump to make the O2 build for the EPN use the right version