### PR TITLE
Fix setuptools on Ubuntu 21.10

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -40,6 +40,7 @@ env:
     pandas==1.2.3
     scikit-learn==0.24.1
   PIP39_REQUIREMENTS: |
+    setuptools==60.8.2
     numpy==1.21.4
     scipy==1.7.3
     Cython==0.29.21

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -54,7 +54,7 @@ python3 -m venv $PYTHON_MODULES_INSTALLROOT
 # Upgrade pip
 python3 -m pip install -IU pip
 # Install setuptools upfront, since this seems to create issues now...
-python3 -m pip install -IU setuptools
+python3 -m pip install -IU "setuptools==60.8.2"
 python3 -m pip install -IU wheel
 
 # FIXME: required because of the newly introduced dependency on scikit-garden requires


### PR DESCRIPTION
Ciao @ktf ,

this is the solution that enabled me to build full O2Physics stack.
It was enough to specify precise, older setuptools version in both Python-modules and Python-modules-list, no change to versions of other packages.