### PR TITLE
Bump DDS to 3.7.3

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -1,5 +1,5 @@
 package: DDS
-version: "3.5.21"
+version: "3.7.3"
 source: https://github.com/FairRootGroup/DDS
 requires:
   - boost


### PR DESCRIPTION
currently broken (no idea why the CI build with ODC 0.65 was not broken yesterday).
Just testing it locally, will then merge it.