### PR TITLE
Add missing GCC dependencies

### DIFF
--- a/asio.sh
+++ b/asio.sh
@@ -4,6 +4,7 @@ tag: v1.19.1
 source: https://github.com/FairRootGroup/asio
 build_requires:
   - CMake
+  - "GCC-Toolchain:(?!osx)"
 prepend_path:
   ROOT_INCLUDE_PATH: "$ASIO_ROOT/include"
 ---

--- a/double-conversion.sh
+++ b/double-conversion.sh
@@ -3,6 +3,7 @@ version: v3.1.5
 source: https://github.com/google/double-conversion
 build_requires:
   - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 
 mkdir -p $INSTALLROOT

--- a/faircmakemodules.sh
+++ b/faircmakemodules.sh
@@ -4,6 +4,7 @@ tag: v1.0.0
 source: https://github.com/FairRootGroup/FairCMakeModules
 build_requires:
   - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/sh
 

--- a/fftw3.sh
+++ b/fftw3.sh
@@ -6,6 +6,7 @@ prefer_system: (?!slc5.*)
 build_requires:
   - alibuild-recipe-tools
   - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
 export FFTW3_WITH_AVX # use AVX with float or double. Unset automatically for long double and quad

--- a/ms_gsl.sh
+++ b/ms_gsl.sh
@@ -6,6 +6,7 @@ prepend_path:
   ROOT_INCLUDE_PATH: "$MS_GSL_ROOT/include"
 build_requires:
   - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
 

--- a/rapidjson.sh
+++ b/rapidjson.sh
@@ -4,6 +4,7 @@ tag: 091de040edb3355dcf2f4a18c425aec51b906f08
 source: https://github.com/Tencent/rapidjson.git
 build_requires:
   - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/sh
 

--- a/ucx.sh
+++ b/ucx.sh
@@ -6,6 +6,7 @@ requires:
 build_requires:
   - "autotools:(slc6|slc7)"
   - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
 source: https://github.com/openucx/ucx
 ---
 #!/bin/bash -e


### PR DESCRIPTION
@ktf : I have no understood what happened last time: When we have a new enough system CMake, but an old system GCC, then we pick up the system CMake, and then we do not pull in GCC-Toolchahin via CMake, and then we can fail when the system GCC is too old for these packages.
And it fails also for header-only stuff, since even there the CMake checks the C compiler with the requested compile flags, i.e. even though it doesn't compile anything, also the header only stuff fails if the system GCC does not understand the requested CMAKE_CXXFLAGS.