### PR TITLE
update xrootd to 5.4.2

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.4.0"
+tag: "v5.4.2"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
https://github.com/xrootd/xrootd/blob/v5.4.2/docs/ReleaseNotes.txt
diff from 5.4.0
--------------
Version 5.4.2
--------------
+ **Major bug fixes**
    **[XrdCl]** xrdfs rm: make sure status for all files is reported.
    **[XrdCrypto]** Add DH_get0_p for OPENSSL_VERSION_NUMBER < 0x10100000L.

--------------
Version 5.4.1
--------------
+ **Major bug fixes**
  **[Posix]** Make sure pointer is set to 0 to avoid memory corruption.
  **[GSI]** Generate DH parameters on first call to XrdCryptosslCipher.
  **[Server]** Prevent SEGV due to missing lock call for background jobs.
  **[SciTokens]** Correct deletion from std::map to avoid SEGV.
  **[cmsd]** Avoid SEGV, avoid using pointers after deleting them.
  **[XrdCl]** Make sure HS wait is not handled after channel has been TTLed.
  **[XrdCl]** Avoid derefferencing null ptr when trasforming ChunkInfo
              into PageInfo.
  **[XrdEc]** Ensure parallel execution of Reader::Read is thread-safe.
  **[CMake]** Add XrdSysTrace.hh to private headers.
  **[PIP]** Use shutil.which over distutils.spawn.find_executable when
            possible.
  **[Posix]** Make sure pointer is set to 0 to avoid memory corruption.
  **[Macaroons]** Avoid undefined behaviour (e.g. SEGV) using std::vector.

+ **Minor bug fixes**
  **[SciTokens]** Regularize paths used for authorization.
  **[pip]** Sanitize version to be PEP 440 compliant.
  **[Python]** Use context manager for opening files.
  **[Python]** Install Python bindings with pip if available.
  **[RPM]** Add python2-pip to BuildRequires.
  **[RPM]** Add python2-pip to BuildRequires.
  **[Debian]** Add python3-pip, python3-setuptools as required packages.

+ **Miscellaneous**
  **[Utils]** Redefine ENODATA when missing.
  **[CMake]** Add support for static openssl libraries
  **[CI]** Add GitHub Actions based CI
  **[IOEvents]** Improve tracing.
  **[XrdCl/XrdEc]** Make XrdEc compatible with vanilla xrootd servers.
  **[XrdCl]** xrdfs: allow rm multiple files.
