### PR TITLE
Fix XRootD 5.4.2 bindings on macOS / Ubuntu

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,7 +1,7 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.4.2"
-source: https://github.com/xrootd/xrootd
+tag: "v5.4.2-alice1"
+source: https://github.com/alisw/xrootd
 requires:
  - "OpenSSL:(?!osx)"
  - Python-modules

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -85,7 +85,11 @@ then
   popd
 fi
 
-find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
+case $ARCHITECTURE in
+  osx*)
+    find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
+  ;;
+esac
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -101,7 +101,7 @@ alibuild-generate-module --bin --lib > "$MODULEFILE"
 
 cat >> "$MODULEFILE" <<EoF
 if { $XROOTD_PYTHON } {
-  prepend-path PYTHONPATH \$PKGROOT/lib/python/site-packages
+  prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
   # This is probably redundant, but should not harm.
   module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
               ${PYTHON_MODULES_REVISION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -89,6 +89,7 @@ fi
 case $ARCHITECTURE in
   osx*)
     find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
+    find $INSTALLROOT/lib/ -name "*.dylib" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
   ;;
 esac
 

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -85,6 +85,8 @@ then
   popd
 fi
 
+find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -12,6 +12,7 @@ build_requires:
  - "osx-system-openssl:(osx.*)"
  - "GCC-Toolchain:(?!osx)"
  - UUID:(?!osx)
+ - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 [[ -e $SOURCEDIR/bindings ]] && { XROOTD_V4=True; XROOTD_PYTHON=True; } || XROOTD_PYTHON=False
@@ -95,27 +96,13 @@ esac
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 \
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}     \\
-            ${OPENSSL_REVISION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}                             \\
-            ${LIBXML2_REVISION:+libxml2/$LIBXML2_VERSION-$LIBXML2_REVISION}                             \\
-            ${ALIEN_RUNTIME_REVISION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION}
 
-# Our environment
-set XROOTD_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$XROOTD_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$XROOTD_ROOT/lib
+alibuild-generate-module --bin --lib > "$MODULEFILE"
+
+cat >> "$MODULEFILE" <<EoF
 if { $XROOTD_PYTHON } {
   prepend-path PYTHONPATH \${XROOTD_ROOT}/lib/python/site-packages
+  # This is probably redundant, but should not harm.
   module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
               ${PYTHON_MODULES_REVISION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}
 }

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -101,7 +101,7 @@ alibuild-generate-module --bin --lib > "$MODULEFILE"
 
 cat >> "$MODULEFILE" <<EoF
 if { $XROOTD_PYTHON } {
-  prepend-path PYTHONPATH \${XROOTD_ROOT}/lib/python/site-packages
+  prepend-path PYTHONPATH \$PKGROOT/lib/python/site-packages
   # This is probably redundant, but should not harm.
   module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
               ${PYTHON_MODULES_REVISION:+Python-modules/$PYTHON_MODULES_VERSION-$PYTHON_MODULES_REVISION}


### PR DESCRIPTION
$ORIGIN simply does not exists on mac