### PR TITLE
Add python as dependency

### DIFF
--- a/openloops.sh
+++ b/openloops.sh
@@ -4,6 +4,8 @@ tag: "OpenLoops-2.1.1"
 source: https://gitlab.com/openloops/OpenLoops.git
 requires:
   - "GCC-Toolchain:(?!osx)"
+  - "Python:slc.*"
+  - "Python-system:(?!slc.*)"
 build_requires:
   - alibuild-recipe-tools
 ---


### PR DESCRIPTION
Build and run phase of openloops depend on python, a
check for system or ALICE python is required.