### PR TITLE
Revert DD back to 1.3.4 (breaks FLP Suite CI)

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.3.6
+tag: v1.3.4
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
1.3.6 does not pass the FLP Suite CI. The proposed solution of increased buffers does not work because we already use `2xlarge` CERN cloud instances.