### PR TITLE
bump ppconsul to v0.2.3

### DIFF
--- a/ppconsul.sh
+++ b/ppconsul.sh
@@ -1,6 +1,6 @@
 package: Ppconsul
 version: "%(tag_basename)s"
-tag: v0.2.2
+tag: v0.2.3
 source: https://github.com/oliora/ppconsul
 requires:
   - boost


### PR DESCRIPTION
Please bump ppconsul to allow setting of timeout for connection establishing. Note that the default connection timeout with this version changed from 5 minuntes to 5 seconds.