### PR TITLE
Bump 

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.3.4
+tag: v1.3.7
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost

--- a/ppconsul.sh
+++ b/ppconsul.sh
@@ -1,6 +1,6 @@
 package: Ppconsul
 version: "%(tag_basename)s"
-tag: v0.2.2
+tag: v0.2.3
 source: https://github.com/oliora/ppconsul
 requires:
   - boost

--- a/ucx.sh
+++ b/ucx.sh
@@ -1,6 +1,6 @@
 package: ucx
 version: "%(tag_basename)s"
-tag: v1.12.1-rc2
+tag: v1.12.1
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:


### PR DESCRIPTION
Bump DataDist to v1.3.7
@vascobarroso The memory usage default is decreased to 128MB

Requires ppconsul bump to v0.2.3