### PR TITLE
Bump ODC to v0.66 and DDS to v3.7.5

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -1,5 +1,5 @@
 package: DDS
-version: "3.7.3"
+version: "3.7.5"
 source: https://github.com/FairRootGroup/DDS
 requires:
   - boost

--- a/odc.sh
+++ b/odc.sh
@@ -1,7 +1,7 @@
 #Online Device Control
 package: ODC
 version: "%(tag_basename)s"
-tag: "0.65"
+tag: "0.66"
 source: https://github.com/FairRootGroup/ODC.git
 requires:
 - boost


### PR DESCRIPTION
https://github.com/FairRootGroup/ODC/blob/master/ReleaseNotes.md#066-2022-03-18
https://github.com/FairRootGroup/DDS/blob/master/ReleaseNotes.md#v38-not-yet-released (DDS does not have release notes for 3.7 versions)