### PR TITLE
Bump VMC dependent packages:

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,6 +1,6 @@
 package: FairRoot
 version: "%(short_hash)s"
-tag: "v18.4.2"
+tag: "v18.4.7"
 source: https://github.com/FairRootGroup/FairRoot
 requires:
   - generators

--- a/fluka_vmc.sh
+++ b/fluka_vmc.sh
@@ -1,6 +1,6 @@
 package: FLUKA_VMC
 version: "%(tag_basename)s"
-tag: "4-1.1-vmc2"
+tag: "4-1.1-vmc3"
 source: https://gitlab.cern.ch/ALICEPrivateExternals/FLUKA_VMC.git
 requires:
   - "GCC-Toolchain:(?!osx)"

--- a/geant3.sh
+++ b/geant3.sh
@@ -1,6 +1,6 @@
 package: GEANT3
 version: "%(tag_basename)s"
-tag: v3-9
+tag: v4-1
 requires:
   - ROOT
   - VMC

--- a/geant4.sh
+++ b/geant4.sh
@@ -1,7 +1,8 @@
 package: GEANT4
 version: "%(tag_basename)s"
-tag: "v10.7.2-alice1"
-source: https://github.com/alisw/geant4.git
+tag: "v11.0.1"
+#source: https://github.com/alisw/geant4.git
+source: https://gitlab.cern.ch/geant4/geant4.git
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -11,7 +11,7 @@ build_requires:
   - CMake
   - "Xcode:(osx.*)"
 prepend_path:
-  ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc:$GEANT4_VMC_ROOT/include/mtroot"
+  ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc"
 env:
   G4VMCINSTALL: "$GEANT4_VMC_ROOT"
 ---
@@ -49,7 +49,6 @@ setenv G4VMCINSTALL \$GEANT4_VMC_ROOT
 setenv GEANT4VMC_MACRO_DIR \$GEANT4_VMC_ROOT/share/examples/macro
 setenv USE_VGM 1
 prepend-path PATH \$GEANT4_VMC_ROOT/bin
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/mtroot
 prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/geant4vmc
 prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/g4root
 prepend-path LD_LIBRARY_PATH \$GEANT4_VMC_ROOT/lib

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v5-4"
+tag: "v6-1"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,6 +1,6 @@
 package: MCStepLogger
 version: "%(tag_basename)s"
-tag: "v0.4.0"
+tag: "v0.5.0"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"

--- a/vgm.sh
+++ b/vgm.sh
@@ -1,6 +1,6 @@
 package: vgm
 version: "%(tag_basename)s"
-tag: "v4-9"
+tag: "v5-0"
 source: https://github.com/vmc-project/vgm
 requires:
   - ROOT

--- a/vmc.sh
+++ b/vmc.sh
@@ -1,6 +1,6 @@
 package: VMC
 version: "%(tag_basename)s"
-tag: "v1-1-p1"
+tag: "v2-0"
 source: https://github.com/vmc-project/vmc
 requires:
   - ROOT


### PR DESCRIPTION
- VMC: v2-0
- GEANT4_VMC: v6-1
- GEANT3: v4-1
- FLUKA_VMC: 4-1.1-vmc3
- GEANT4: v11.0.1
- MCStepLogger: v0.5.0
- vgm: v5-0
- FairRoot: v18.4.7