### PR TITLE
Remove CXXSTD for next-root6 build

### DIFF
--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -6,7 +6,6 @@ env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++11"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
-  CXXSTD: "11"
 overrides:
   AliRoot:
     version: "%(tag_basename)s_ROOT6"

--- a/geant4.sh
+++ b/geant4.sh
@@ -26,6 +26,7 @@ env:
 cmake $SOURCEDIR                                                \
   -DGEANT4_INSTALL_DATA_TIMEOUT=2000                            \
   -DCMAKE_CXX_FLAGS="-fPIC"                                     \
+  ${CXXSTD:+-DCMAKE_CXX_STANDARD="$CXXSTD"}                     \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                    \
   -DCMAKE_INSTALL_LIBDIR="lib"                                  \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo                             \
@@ -42,7 +43,6 @@ cmake $SOURCEDIR                                                \
   ${GEANT4_DATADIR:+-DGEANT4_INSTALL_DATADIR="$GEANT4_DATADIR"} \
   -DGEANT4_USE_SYSTEM_EXPAT=OFF                                 \
   ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}             \
-  ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                      \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS}


### PR DESCRIPTION
This seems to cause build failures for GEANT4 in the AliPhysics CI, like the following:

```
CMake Warning at cmake/Modules/G4BuildSettings.cmake:171 (message):
  The GEANT4_BUILD_CXXSTD argument is deprecated.

  Please use CMAKE_CXX_STANDARD to set the required C++ Standard.  The value
  supplied will be used to set CMAKE_CXX_STANDARD, but this behaviour will be
  removed in future releases.
Call Stack (most recent call first):
  cmake/Modules/G4CMakeMain.cmake:53 (include)
  CMakeLists.txt:50 (include)

CMake Error at cmake/Modules/G4CMakeUtilities.cmake:112 (message):
  Value '11' for variable CMAKE_CXX_STANDARD is not allowed

  It must be selected from the set: 17;20 (DEFAULT: 17)

Call Stack (most recent call first):
  cmake/Modules/G4BuildSettings.cmake:179 (enum_option)
  cmake/Modules/G4CMakeMain.cmake:53 (include)
  CMakeLists.txt:50 (include)

-- Configuring incomplete, errors occurred!
```