### PR TITLE
Python-modules-list:: update requests to latest supported by 3.6

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -2,7 +2,7 @@ package: Python-modules-list
 version: "1.0"
 env:
   PIP_REQUIREMENTS: |
-    requests==2.21.0
+    requests==2.27.1
     ipykernel==5.1.0
     ipython==7.4.0
     ipywidgets==7.4.2


### PR DESCRIPTION
Would be useful to make use of latest available requests module (and not the 2018 released one). Moreover, for the python3.6 compatibility this will be the latest version, so we could settle with this one (and if required, at a later time, for higher python versions we can specify separately)
A list of bugfixes can be inspected here:
https://github.com/urllib3/urllib3/blob/main/CHANGES.rst

for the underlying urllib3 that is always at the latest version (as it not explicitly specified) the change log can be inspected here:
https://github.com/urllib3/urllib3/blob/main/CHANGES.rst