### PR TITLE
Using C++17

### DIFF
--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -6,6 +6,7 @@ env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++11"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
+  CXXSTD: '17'
 overrides:
   AliRoot:
     version: "%(tag_basename)s_ROOT6"


### PR DESCRIPTION
Temporary fix, later we should move to defaults-o2 and remove both defaults-next-root6.sh and defaults-user-next-root6.sh.