### PR TITLE
Bump FairLogger to v1.11.0

### DIFF
--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -1,6 +1,6 @@
 package: FairLogger
 version: "%(tag_basename)s"
-tag: v1.10.4
+tag: v1.11.0
 source: https://github.com/FairRootGroup/FairLogger
 requires:
  - fmt


### PR DESCRIPTION
This introduces the "detail" level which we can use for debug messages which should not be removed when compiling optimised builds and should not end up to info logger.