### PR TITLE
Disable OpenSSL and curl for o2-epn defaults, the system packages will do fine

### DIFF
--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -9,6 +9,8 @@ env:
 disable:
   - O2Physics
   - ONNXRuntime
+  - OpenSSL
+  - curl
 overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'


### PR DESCRIPTION
This solves the problem with mixing of SSL libraries on the EPN.
Not tested by CI anyway, merging