### PR TITLE
Fix automatic PR action

### DIFF
--- a/.github/workflows/daily-tag-pr.yml
+++ b/.github/workflows/daily-tag-pr.yml
@@ -23,7 +23,7 @@ jobs:
           echo "::set-output name=base::${GITHUB_REF#refs/heads/rc/}"
 
       - name: Send pull request to regular branch
-        uses: repo-sync/pull-request@v2.5
+        uses: repo-sync/pull-request@v2
         with:
           destination_branch: ${{ steps.name.outputs.base }}
           pr_title: 'daily tags: auto-update dist definitions'


### PR DESCRIPTION
Due to a security mitigation by GitHub, v2.5 of the PR action stopped working. Use the v2 tag instead, which tracks these updates.

@ktf: This fixes the issue that caused today's daily builds not to open PRs with their changes.