### PR TITLE
python:: use proper pip and coherent triad of pip,setuptools,wheel

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -40,7 +40,6 @@ env:
     pandas==1.2.3
     scikit-learn==0.24.1
   PIP39_REQUIREMENTS: |
-    setuptools<=60.8.2
     numpy==1.21.4
     scipy==1.7.3
     Cython==0.29.21

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -51,11 +51,9 @@ mkdir -p $PYTHON_MODULES_INSTALLROOT
 python3 -m venv $PYTHON_MODULES_INSTALLROOT
 . $PYTHON_MODULES_INSTALLROOT/bin/activate
 
-# Upgrade pip
-python3 -m pip install -IU pip
-# Install setuptools upfront, since this seems to create issues now...
-python3 -m pip install -IU "setuptools<=60.8.2"
-python3 -m pip install -IU wheel
+# Upgrade pip setuptools wheel
+# see https://docs.python.org/3.6/distributing/index.html#installing-the-tools
+python3 -m pip install --no-cache-dir --ignore-installed --upgrade pip setuptools wheel
 
 # FIXME: required because of the newly introduced dependency on scikit-garden requires
 # a numpy to be installed separately

--- a/python.sh
+++ b/python.sh
@@ -85,13 +85,13 @@ popd
 env PATH="$INSTALLROOT/bin:$PATH"                       \
     LD_LIBRARY_PATH="$INSTALLROOT/lib:$LD_LIBRARY_PATH" \
     PYTHONHOME="$INSTALLROOT"                           \
-    pip3 install --upgrade pip
+    python3 -m pip install --no-cache-dir --upgrade pip
 
 # Install Python SSL certificates right away
 env PATH="$INSTALLROOT/bin:$PATH" \
     LD_LIBRARY_PATH="$INSTALLROOT/lib:$LD_LIBRARY_PATH" \
     PYTHONHOME="$INSTALLROOT" \
-    pip3 install 'certifi==2019.3.9'
+    python3 -m pip install 'certifi==2019.3.9'
 
 # Uniform Python library path
 pushd "$INSTALLROOT/lib"


### PR DESCRIPTION
@ktf FYI
* usage of the safe form of `python3 -m pip` for pip operations
* use latest of pip, setuptools, wheel

this was tried on centos7, ubuntu 20.04 and fedora 35
for reference the change logs of involved packages are below
* https://github.com/pypa/pip/blob/main/NEWS.rst
* https://github.com/pypa/setuptools/blob/main/CHANGES.rst
* https://github.com/pypa/wheel/blob/main/docs/news.rst

Hopefully this will solve the problems encountered by others (but which i could not reproduce)