### PR TITLE
datadist: bump to v1.4.0

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.3.13
+tag: v1.4.0
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
Hi @davidrohr @vascobarroso, 

This is planned DD version for the next upgrade cycle (contingency: v1.3.13). 
It requires simultaneous upgrade of FLP and EPN DD components!

Hopefully we can bump the grpc soon as well?

Let me know on any sign of trouble. 
Thanks