### PR TITLE
PYTHONPATH for xjalienfs

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -8,6 +8,8 @@ requires:
  - XRootD
  - AliEn-Runtime
  - Python-modules
+prepend_path:
+  PYTHONPATH: ${XJALIENFS_ROOT}/lib/python/site-packages
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
Set python path for xjalienfs. This is needed to access alien.py functionality and alien tokens
during aliBuild execution (such as to access CCDB objects for simulation tests done
within aliBuild)