### PR TITLE
Added dynamic Python library folder definition

### DIFF
--- a/agile.sh
+++ b/agile.sh
@@ -34,6 +34,8 @@ autoreconf -ifv
 make -j$JOBS
 make install
 
+PYVER="$(basename $(find $INSTALLROOT/lib -type d -name 'python*'))"
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
@@ -51,7 +53,7 @@ module load BASE/1.0 HepMC/$HEPMC_VERSION-$HEPMC_REVISION lhapdf5/${LHAPDF5_VERS
 # Our environment
 set AGILE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv AGILE_ROOT \$AGILE_ROOT
-prepend-path PYTHONPATH \$AGILE_ROOT/lib/python2.7/site-packages
+prepend-path PYTHONPATH \$AGILE_ROOT/lib/$PYVER/site-packages
 prepend-path PATH \$AGILE_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$AGILE_ROOT/lib
 EoF

--- a/rivet.sh
+++ b/rivet.sh
@@ -76,6 +76,7 @@ done
 cat $INSTALLROOT/bin/rivet-config | sed -e "$SED_EXPR" > $INSTALLROOT/bin/rivet-config.0
 mv $INSTALLROOT/bin/rivet-config.0 $INSTALLROOT/bin/rivet-config
 chmod 0755 $INSTALLROOT/bin/rivet-config
+PYVER="$(basename $(find $INSTALLROOT/lib -type d -name 'python*'))"
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
@@ -94,8 +95,8 @@ module load BASE/1.0 ${GSL_REVISION:+GSL/$GSL_VERSION-$GSL_REVISION} ${CGAL_REVI
 # Our environment
 set RIVET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv RIVET_ROOT \$RIVET_ROOT
-prepend-path PYTHONPATH \$RIVET_ROOT/lib/python3.6/site-packages
-prepend-path PYTHONPATH \$RIVET_ROOT/lib64/python3.6/site-packages
+prepend-path PYTHONPATH \$RIVET_ROOT/lib/$PYVER/site-packages
+prepend-path PYTHONPATH \$RIVET_ROOT/lib64/$PYVER/site-packages
 prepend-path PATH \$RIVET_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$RIVET_ROOT/lib
 


### PR DESCRIPTION
Automatic assignment of python library folder to Rivet, making it run without issues (if texlive-latex-extra is installed: to be included in the future as a prerequisite).
AGILe needs to be edited as well in order to be able to run PYTHIA6 events. 