### PR TITLE
Bump ODC to v0.68 to fix compilation error

### DIFF
--- a/odc.sh
+++ b/odc.sh
@@ -1,7 +1,7 @@
 #Online Device Control
 package: ODC
 version: "%(tag_basename)s"
-tag: "0.67"
+tag: "0.68"
 source: https://github.com/FairRootGroup/ODC.git
 requires:
 - boost


### PR DESCRIPTION
Would it be OK to bump ODC again @lkrcal ?
There is a compilation error which is fixed in this new tag: https://github.com/FairRootGroup/ODC/commit/2def9473543e2a1e262de5c76990eb9222e88361
And it seems on the build machines this was not creating troubles, because there the readline package is installed and so the affected lines were not compiled.

Me and @chiarazampolli ran into this problem today independently