### PR TITLE
Bump odc.sh to version 0.68

### DIFF
--- a/odc.sh
+++ b/odc.sh
@@ -1,7 +1,7 @@
 #Online Device Control
 package: ODC
 version: "%(tag_basename)s"
-tag: "0.67"
+tag: "0.68"
 source: https://github.com/FairRootGroup/ODC.git
 requires:
 - boost


### PR DESCRIPTION
Version 0.67 had a compile bug on some platforms (for instance alibit) due to typo std::cout != std::endl. See here: https://github.com/FairRootGroup/ODC/commit/2def9473543e2a1e262de5c76990eb9222e88361.

