### PR TITLE
Add temporary repository for ML model storage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -73,3 +73,6 @@ xjalienfs*          @alisw/alien-experts
 datadistribution*   @alisw/epn-experts
 dds*                @alisw/epn-experts
 odc*                @alisw/epn-experts
+
+# ML
+mlmodels*           @fcatalan92

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -30,6 +30,7 @@ disable:
   - O2-full-system-test
   - O2Physics
   - ONNXRuntime
+  - MLModels
   # Fall back to the system OpenSSL and curl.
   - OpenSSL
   - curl

--- a/mlmodels.sh
+++ b/mlmodels.sh
@@ -1,0 +1,19 @@
+package: MLModels
+version: "%(tag_basename)s"
+tag: "e087b6c"
+source: https://github.com/fcatalan92/MLModels.git
+build_requires:
+ - alibuild-recipe-tools
+---
+#!/bin/bash -e
+
+rsync -a $SOURCEDIR/models $INSTALLROOT/
+
+#ModuleFile
+mkdir -p etc/modulefiles
+alibuild-generate-module > etc/modulefiles/$PKGNAME
+cat >> etc/modulefiles/$PKGNAME <<EoF
+# Our environment
+setenv MLMODELS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+EoF
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/mlmodels.sh
+++ b/mlmodels.sh
@@ -1,7 +1,7 @@
 package: MLModels
 version: "%(tag_basename)s"
 tag: "e087b6c"
-source: https://github.com/fcatalan92/MLModels.git
+source: https://github.com/alisw/MLModels.git
 build_requires:
  - alibuild-recipe-tools
 ---

--- a/o2.sh
+++ b/o2.sh
@@ -26,6 +26,7 @@ requires:
   - VecGeom
   - FFTW3
   - ONNXRuntime
+  - MLModels
 build_requires:
   - GMP
   - MPFR
@@ -247,7 +248,8 @@ module load BASE/1.0 \\
             ${CURL_REVISION:+curl/$CURL_VERSION-$CURL_REVISION}                                     \\
             ${FAIRMQ_REVISION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION}                             \\
             ${FFTW3_REVISION:+FFTW3/$FFTW3_VERSION-$FFTW3_REVISION}                                 \\
-            ${ONNXRUNTIME_REVISION:+ONNXRuntime/$ONNXRUNTIME_VERSION-$ONNXRUNTIME_REVISION}
+            ${ONNXRUNTIME_REVISION:+ONNXRuntime/$ONNXRUNTIME_VERSION-$ONNXRUNTIME_REVISION}         \\
+            ${MLMODELS_REVISION:+MLModels/$MLMODELS_VERSION-$MLMODELS_REVISION}
 # Our environment
 set O2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv O2_ROOT \$O2_ROOT


### PR DESCRIPTION
@ktf As discussed by mail, I have created a temporary repository to store the ML models for the inference on Hyperloop. It will be deleted when CCDB storage will be available.

I made the module an O2 requirement since there are developments that could need this feature. 