### PR TITLE
alidist - defaults-generators : package name

### DIFF
--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -16,7 +16,7 @@ overrides:
     - lhapdf
     - boost
     tag: v8304
-package: defaults-dev
+package: defaults-generators
 version: v1
 
 ---


### PR DESCRIPTION
Make the package name consistent : "defaults-dev" now moved to "defaults-generators"