### PR TITLE
Do not require Python modules on osx_arm64. 

### DIFF
--- a/agile.sh
+++ b/agile.sh
@@ -7,7 +7,7 @@ requires:
   - boost
   - lhapdf5
   - HepMC
-  - Python-modules
+  - Python-modules:(?!osx_arm64)
 build_requires:
   - "autotools:(slc6|slc7)"
   - SWIG

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -6,7 +6,7 @@ env:
   LHAPATH: "$LHAPDF5_ROOT/share/lhapdf"
 requires:
   - "GCC-Toolchain:(?!osx)"
-  - Python-modules
+  - Python-modules:(?!osx_arm64)
 build_requires:
   - curl
 ---

--- a/mesos.sh
+++ b/mesos.sh
@@ -18,7 +18,7 @@ requires:
 build_requires:
 - "autotools:(slc6|slc7|slc8)"
 - protobuf
-- Python-modules
+- Python-modules:(?!osx_arm64)
 - abseil
 prepend_path:
   PATH: "$MESOS_ROOT/sbin"

--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/onnxruntime.git
 requires:
   - protobuf
   - re2
-  - Python-modules
+  - Python-modules:(?!osx_arm64)
 build_requires:
   - CMake
   - alibuild-recipe-tools

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -11,7 +11,7 @@ requires:
   - O2
   - arrow
   - Control-OCCPlugin
-  - Python-modules
+  - Python-modules:(?!osx_arm64)
   - libjalienO2
 build_requires:
   - CMake

--- a/root.sh
+++ b/root.sh
@@ -9,7 +9,7 @@ requires:
   - opengl:(?!osx)
   - Xdevel:(?!osx)
   - FreeType:(?!osx)
-  - Python-modules
+  - Python-modules:(?!osx_arm64)
   - "GCC-Toolchain:(?!osx)"
   - libpng
   - lzma

--- a/sacrifice.sh
+++ b/sacrifice.sh
@@ -7,7 +7,7 @@ requires:
   - boost
   - lhapdf
   - HepMC
-  - Python-modules
+  - Python-modules:(?!osx_arm64)
   - pythia
 build_requires:
   - "autotools:(slc6|slc7)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -7,7 +7,7 @@ requires:
  - "osx-system-openssl:(osx.*)"
  - XRootD
  - AliEn-Runtime
- - Python-modules
+ - Python-modules:(?!osx_arm64)
 prepend_path:
   PYTHONPATH: ${XJALIENFS_ROOT}/lib/python/site-packages
 ---

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -4,7 +4,7 @@ tag: "v5.4.2-alice1"
 source: https://github.com/alisw/xrootd
 requires:
  - "OpenSSL:(?!osx)"
- - Python-modules
+ - Python-modules:(?!osx_arm64)
  - AliEn-Runtime
  - libxml2
 build_requires:
@@ -38,6 +38,10 @@ case $ARCHITECTURE in
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
     unset UUID_ROOT
+    SETUPTOOLS_VER=$(python3 -m pip show setuptools | grep Version | sed -e 's/[^0-9]*//')
+    if [ x"$SETUPTOOLS_VER" != x"60.8.2" ]; then
+	printf "Please install setuptools==60.8.2"; exit 1
+    fi
   ;;
 esac
 


### PR DESCRIPTION
Check for specific setuptools==60.8.2 that work for XRootD on Mac M1.