### PR TITLE
Make sure an incremental_recipe can be used with O2DPG

### DIFF
--- a/o2dpg.sh
+++ b/o2dpg.sh
@@ -4,6 +4,10 @@ tag: "nightly-20220502"
 source: https://github.com/AliceO2Group/O2DPG.git
 build_requires:
   - alibuild-recipe-tools
+incremental_recipe: |
+  rsync -a --exclude='**/.git' --delete --delete-excluded \
+      $SOURCEDIR/ $INSTALLROOT/
+  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 ---
 #!/bin/bash -e
 rsync -a --exclude='**/.git' --delete --delete-excluded \


### PR DESCRIPTION
This is required to avoid having a separate folder each time one changes a file in O2DPG.