### PR TITLE
Revert "Disable ODC in O2 defaults "

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -8,7 +8,6 @@ env:
   MACOSX_DEPLOYMENT_TARGET: '10.15'
 disable:
   - mesos
-  - ODC
 overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'


### PR DESCRIPTION
Reverts alisw/alidist#4117

@ktf @lkrcal @rbx : Sorry, but I don't agree to disabling ODC for the O2 defaults.
We need to test it in the alidist CI. Yesterday we bumped ODC in alidist, and the new version was simply not compiled, so we didn't spot a compile error, so we cannot deploy it today.

@dennisklein @rbx : What is the status on the OpenSSL issue that @ktf reported with ODC before? Can this be fixed?