### PR TITLE
Enable ONNXruntime on FLP and EPN

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -29,8 +29,6 @@ disable:
   - O2sim
   - O2-full-system-test
   - O2Physics
-  - ONNXRuntime
-  - MLModels
   # Fall back to the system OpenSSL and curl.
   - OpenSSL
   - curl

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -8,7 +8,6 @@ env:
   GEANT4_BUILD_MULTITHREADED: 'ON'
 disable:
   - O2Physics
-  - ONNXRuntime
   - OpenSSL
   - curl
   - mesos


### PR DESCRIPTION
@ktf @ihrivnac As discussed at the last WP3 meeting, this PR enables the installation of the onnxruntime library for FLPs and EPNs. The use case is the QC (FLP) and calibration (EPN) for the EMCAL that will need to run the inference of machine learning models @mfasDa. 
Of course, let me know if there is any concern.