### PR TITLE
Update root.sh : Option to speed up initialization

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -1,7 +1,7 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-24-06"
-source: https://github.com/root-project/root.git
+tag: "v6-24-06-patches-alice1"
+source: https://github.com/alisw/root.git
 requires:
   - arrow
   - AliEn-Runtime:(?!.*ppc64)


### PR DESCRIPTION
Use ALICE specific version of ROOT (until available upstream).

With this, startup of ROOT can be sped up by defining env variables
`ROOT_LDSYSPATH` and `ROOT_CPPSYSINCL` to inject information, which ROOT would otherwise
determine via invocation of ~5 sub-processes during initialization of binary loading.

The idea is that we can put this initialization into the module file loading phase, with something like (equivalent
of what ROOT does internally):

a) ` export ROOT_LDSYSPATH=$(LD_DEBUG=libs LD_PRELOAD=DOESNOTEXIST ls /tmp/DOESNOTEXIST 2>&1 | grep -m 1 "system search path" | sed 's/.*=//g' | awk '//{print $1}')`

b) ` export ROOT_CPPSYSINCL=$(LC_ALL=C c++ -xc++ -E -v /dev/null 2>&1 | sed -n '/^.include/,${/^ \/.*++/{p}}' # | sed 's/ //')`

In a DPL topology or MC workflow with O(100) of DPL devices, we'll avoid a significant amount
of short-lived sub-processes being created. This leads indeed to a noticeable lower-latency in the startup phase. 

By default, nothing will change for the user with this commit. 
Definition of the env variables will follow in a separate PR (or can be done locally)