### PR TITLE
Annotate FLP builds with special env variable

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -5,7 +5,6 @@ env:
   CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "17"
-  O2_BUILD_FOR_FLP: "ON"
 disable:
   - AEGIS
   - AliEn-Runtime
@@ -62,6 +61,7 @@ overrides:
       ENABLE_UPGRADES: OFF # Disable detector upgrades in O2
       BUILD_ANALYSIS: OFF # Disable analysis in O2
       BUILD_EXAMPLES: OFF # Disable examples in O2
+      O2_BUILD_FOR_FLP: ON
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -5,6 +5,7 @@ env:
   CFLAGS: "-fPIC -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: "17"
+  O2_BUILD_FOR_FLP: "ON"
 disable:
   - AEGIS
   - AliEn-Runtime


### PR DESCRIPTION
This is in order to be able to know when we are
buiding for FLP and to take build decisions based
in this flag

See for instance https://alice.its.cern.ch/jira/browse/O2-2975