### PR TITLE
xjalienfs 1.3.8

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.7"
+tag: "1.3.8"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
[detailed commit list](https://github.com/adriansev/jalien_py/compare/1.3.7...1.3.8)

Most important feature is the fixing of default xrootd timeouts.