### PR TITLE
Revert changes to O2 modulefile (ROOT env)

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -262,12 +262,7 @@ prepend-path ROOT_DYN_PATH \$O2_ROOT/lib
 $([[ ${ARCHITECTURE:0:3} == osx && ! $BOOST_VERSION ]] && echo "prepend-path ROOT_INCLUDE_PATH $BOOST_ROOT/include")
 prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include/GPU
 prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include
-EoF
 
-case $ARCHITECTURE in
-  osx*);;
-  *)
-cat >> etc/modulefiles/$PKGNAME <<EoF
 # ALICE specific adjustments to speedup ROOT launches
 set searchpath [exec env LD_DEBUG=libs LD_PRELOAD=DOESNOTEXIST /bin/true |& sed -rn {/system search path/{s/.*search path=(.*)[[:space:]]+\(system search path\)$/\1/p; q}}]
 set includepath [exec env LC_ALL=C c++ -xc++ -E -v /dev/null |& sed -rn {/^.include/,\$s/^ (\/.*\+\+.*)/\1/p}]
@@ -275,9 +270,6 @@ set includepath [string map {"\n" :} \$includepath]
 setenv ROOT_LDSYSPATH \$searchpath
 setenv ROOT_CPPSYSINCL \$includepath
 EoF
-    ;;
-esac
-
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 
 if [[ $ALIBUILD_O2_TESTS ]]; then

--- a/o2.sh
+++ b/o2.sh
@@ -262,13 +262,6 @@ prepend-path ROOT_DYN_PATH \$O2_ROOT/lib
 $([[ ${ARCHITECTURE:0:3} == osx && ! $BOOST_VERSION ]] && echo "prepend-path ROOT_INCLUDE_PATH $BOOST_ROOT/include")
 prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include/GPU
 prepend-path ROOT_INCLUDE_PATH \$O2_ROOT/include
-
-# ALICE specific adjustments to speedup ROOT launches
-set searchpath [exec env LD_DEBUG=libs LD_PRELOAD=DOESNOTEXIST /bin/true |& sed -rn {/system search path/{s/.*search path=(.*)[[:space:]]+\(system search path\)$/\1/p; q}}]
-set includepath [exec env LC_ALL=C c++ -xc++ -E -v /dev/null |& sed -rn {/^.include/,\$s/^ (\/.*\+\+.*)/\1/p}]
-set includepath [string map {"\n" :} \$includepath]
-setenv ROOT_LDSYSPATH \$searchpath
-setenv ROOT_CPPSYSINCL \$includepath
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 


### PR DESCRIPTION
The recent changes with dynamic Tcl execution in the o2 modulefile seem to be unstable ("race condition") and need more testing/refinement.

See https://alice.its.cern.ch/jira/browse/O2-2981