### PR TITLE
xjalienfs::Hot bugfix release to 1.4.0

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.3.9"
+tag: "1.4.0"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Fix typo that prevents copy operations on systems where uid != gid