### PR TITLE
xjalienfs 1.4.2 critical bugfix

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.4.0"
+tag: "1.4.1"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.4.1"
+tag: "1.4.2"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
@ktf 
critical bugfix for downloads in directories with parents not writable by user.
whilst checking for writability of destination hierarchy, the actual destination was not taken into account, so the download would fail because the parent of destination is not writable.
affects MC productions/DPG