### PR TITLE
Provide HEPMC3 ROOT_INCLUDE_PATH during alibuild stage

### DIFF
--- a/hepmc3.sh
+++ b/hepmc3.sh
@@ -7,6 +7,8 @@ requires:
   - ROOT
 build_requires:
   - CMake
+prepend_path:
+  ROOT_INCLUDE_PATH: "$HEPMC3_ROOT/include"
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
This fixes `Missing FileEntry for HepMC3/...` that appear during
full-CI FST or O2Physics compilation.

In this case, the module files are not used and hence the ROOT_INCLUDE_PATH was not correctly set.