### PR TITLE
Bump JAliEn to 1.5.4

### DIFF
--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -17,7 +17,7 @@ overrides:
     tag: v3.4.0_1.045-alice1
   XRootD:
     source: https://github.com/xrootd/xrootd
-    tag: v5.4.2
+    tag: v5.4.3
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/jalien.sh
+++ b/jalien.sh
@@ -1,6 +1,6 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.5.3"
+tag: "1.5.4"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
  - JDK


### PR DESCRIPTION
Update JAliEn (Java components only). Doesn't affect AliPhysics / O2 in any way.

Also bumps XRootD in defaults-jalien to v5.4.3.