### PR TITLE
Reverting VMC and Geant4 to previous version

### DIFF
--- a/geant3.sh
+++ b/geant3.sh
@@ -1,6 +1,6 @@
 package: GEANT3
 version: "%(tag_basename)s"
-tag: v4-1
+tag: v3-9
 requires:
   - ROOT
   - VMC

--- a/geant4.sh
+++ b/geant4.sh
@@ -1,8 +1,7 @@
 package: GEANT4
 version: "%(tag_basename)s"
-tag: "v11.0.1-alice1"
+tag: "v10.7.2-alice1"
 source: https://github.com/alisw/geant4.git
-#source: https://gitlab.cern.ch/geant4/geant4.git
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
@@ -27,7 +26,6 @@ env:
 cmake $SOURCEDIR                                                \
   -DGEANT4_INSTALL_DATA_TIMEOUT=2000                            \
   -DCMAKE_CXX_FLAGS="-fPIC"                                     \
-  ${CXXSTD:+-DCMAKE_CXX_STANDARD="$CXXSTD"}                     \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"                    \
   -DCMAKE_INSTALL_LIBDIR="lib"                                  \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo                             \
@@ -44,6 +42,7 @@ cmake $SOURCEDIR                                                \
   ${GEANT4_DATADIR:+-DGEANT4_INSTALL_DATADIR="$GEANT4_DATADIR"} \
   -DGEANT4_USE_SYSTEM_EXPAT=OFF                                 \
   ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}             \
+  ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                      \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 make ${JOBS+-j $JOBS}

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v6-1"
+tag: "v5-4"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT
@@ -11,7 +11,7 @@ build_requires:
   - CMake
   - "Xcode:(osx.*)"
 prepend_path:
-  ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc"
+  ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc:$GEANT4_VMC_ROOT/include/mtroot"
 env:
   G4VMCINSTALL: "$GEANT4_VMC_ROOT"
 ---
@@ -49,6 +49,7 @@ setenv G4VMCINSTALL \$GEANT4_VMC_ROOT
 setenv GEANT4VMC_MACRO_DIR \$GEANT4_VMC_ROOT/share/examples/macro
 setenv USE_VGM 1
 prepend-path PATH \$GEANT4_VMC_ROOT/bin
+prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/mtroot
 prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/geant4vmc
 prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/g4root
 prepend-path LD_LIBRARY_PATH \$GEANT4_VMC_ROOT/lib

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,6 +1,6 @@
 package: MCStepLogger
 version: "%(tag_basename)s"
-tag: "v0.5.0"
+tag: "v0.4.0"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"

--- a/vgm.sh
+++ b/vgm.sh
@@ -1,6 +1,6 @@
 package: vgm
 version: "%(tag_basename)s"
-tag: "v5-0"
+tag: "v4-9"
 source: https://github.com/vmc-project/vgm
 requires:
   - ROOT

--- a/vmc.sh
+++ b/vmc.sh
@@ -1,6 +1,6 @@
 package: VMC
 version: "%(tag_basename)s"
-tag: "v2-0"
+tag: "v1-1-p1"
 source: https://github.com/vmc-project/vmc
 requires:
   - ROOT


### PR DESCRIPTION
Latest G4(_VMC) seems to have a potential issue
with physics processes/cuts leading to an observable reduction
in TPC tracks in our MC processing.

Reverting for now to previous version in order to stabilize situation
and give time to provide and validate fix.