### PR TITLE
Fix auto PRs for rc/ branches

### DIFF
--- a/.github/workflows/daily-tag-pr.yml
+++ b/.github/workflows/daily-tag-pr.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Enable auto-merge for newly-created pull request
         uses: alisw/enable-pull-request-automerge@v2
+        # If the PR already exists, we won't get the number
+        # (and we probably shouldn't toggle auto-merge anyway).
+        if: steps.open_pr.outputs.pr_number
         with:
           pull-request-number: ${{ steps.open_pr.outputs.pr_number }}
           merge-method: squash


### PR DESCRIPTION
If a PR already exists for the branch, don't try to toggle auto-merge.