### PR TITLE
Bump DataDistribution to v1.4.6

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.4.5
+tag: v1.4.6
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
This contains a non-critical bugfix for next upgrade cycle.