### PR TITLE
Make CXXSTD and -std=c++X agree for next-root6 defaults

### DIFF
--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -3,7 +3,7 @@ version: v1
 disable:
   - arrow
 env:
-  CXXFLAGS: "-fPIC -g -O2 -std=c++11"
+  CXXFLAGS: "-fPIC -g -O2 -std=c++17"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
   CXXSTD: '17'


### PR DESCRIPTION
We specify `CXXSTD=17`, but `-std=c++11`, which confuses ROOT. ROOT v5-25-02 only supports C++14 and up, so its build fails with the wrong `-std=`.

Cc: @chiarazampolli 