### PR TITLE
Bump FairMQ to v1.4.52

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.51
+tag: v1.4.52
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Contains the functionality necessary for resolution of https://alice.its.cern.ch/jira/browse/EPN-106.
And also reduced severity for the missing channel config message (https://github.com/FairRootGroup/FairMQ/issues/426).