### PR TITLE
Fix sed invocations for MacOS

### DIFF
--- a/evtgen.sh
+++ b/evtgen.sh
@@ -17,8 +17,8 @@ env:
 rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./
 
 # adjust the configure scripts
-sed -i -e "s/FLIBS=.*$/FLIBS=\"-lgfortran\"/" configure
-sed -i -e "s/PYTHIALIBLIST=.*$/PYTHIALIBLIST=\"-lpythia8 -lpythia8lhapdf6\"/" configure
+sed -i.bak 's/FLIBS=.*$/FLIBS="-lgfortran"/; s/PYTHIALIBLIST=.*$/PYTHIALIBLIST="-lpythia8 -lpythia8lhapdf6"/' configure
+rm -f configure.bak
 
 export HEPMCLOCATION="$HEPMC_ROOT"
 ./configure --prefix=$INSTALLROOT \

--- a/openloops.sh
+++ b/openloops.sh
@@ -16,8 +16,9 @@ unset HTTP_PROXY # unset this to build on slc6 system
 
 # Due to typical long install dir paths used by aliBuikd the string lenghts must be increased
 # In addition a trim statement is missing for the install path
-sed -i -e 's/max_string_length\ =\ 255/max_string_length\ =\ 1000/g' pyol/config/default.cfg
-sed -i -e 's/call\ set_parameter(\"install_path\",\ tmp,\ error)/call\ set_parameter(\"install_path\",\ trim(tmp),\ error)/g' lib_src/openloops/src/ol_interface.F90
+sed -i.bak -e 's/max_string_length\ =\ 255/max_string_length\ =\ 1000/g' pyol/config/default.cfg
+sed -i.bak -e 's/call\ set_parameter(\"install_path\",\ tmp,\ error)/call\ set_parameter(\"install_path\",\ trim(tmp),\ error)/g' lib_src/openloops/src/ol_interface.F90
+rm -f pyol/config/default.cfg.bak lib_src/openloops/src/ol_interface.F90.bak
 ./scons 
 
 JOBS=$((${JOBS:-1}*1/5))

--- a/pythia.sh
+++ b/pythia.sh
@@ -28,7 +28,8 @@ esac
 if [[ $ARCHITECTURE =~ "slc5.*" ]]; then
     ln -s LHAPDF5.h include/Pythia8Plugins/LHAPDF5.cc
     ln -s LHAPDF6.h include/Pythia8Plugins/LHAPDF6.cc
-    sed -i -e 's#\$(CXX) -x c++ \$< -o \$@ -c -MD -w -I\$(LHAPDF\$\*_INCLUDE) \$(CXX_COMMON)#\$(CXX) -x c++ \$(<:.h=.cc) -o \$@ -c -MD -w -I\$(LHAPDF\$\*_INCLUDE) \$(CXX_COMMON)#' Makefile
+    sed -i.bak -e 's#\$(CXX) -x c++ \$< -o \$@ -c -MD -w -I\$(LHAPDF\$\*_INCLUDE) \$(CXX_COMMON)#\$(CXX) -x c++ \$(<:.h=.cc) -o \$@ -c -MD -w -I\$(LHAPDF\$\*_INCLUDE) \$(CXX_COMMON)#' Makefile
+    rm -f Makefile.bak
 fi
 
 make ${JOBS+-j $JOBS}

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -47,9 +47,10 @@ export PATH="$PWD/fakeperl/bin:$PATH"
 
 # special treatment for ThePEG version used for DIPSY
 if [[ "$PKGVERSION" =~ "v2015-08-11" ]]; then
-    sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/Config/interfaces.pl.in
-    sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.am
-    sed -i -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.in
+    sed -i.bak -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/Config/interfaces.pl.in
+    sed -i.bak -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.am
+    sed -i.bak -e 's#@PYTHIA8_DIR@/xmldoc#@PYTHIA8_DIR@/share/Pythia8/xmldoc#' TheP8I/src/Makefile.in
+    rm -f TheP8I/Config/interfaces.pl.in.bak TheP8I/src/Makefile.*.bak
 fi
 
 autoreconf -ivf


### PR DESCRIPTION
`sed -i` on Mac needs an argument specifying the backup suffix.