### PR TITLE
Bump ODC to 0.74.0

### DIFF
--- a/odc.sh
+++ b/odc.sh
@@ -1,7 +1,7 @@
 #Online Device Control
 package: ODC
 version: "%(tag_basename)s"
-tag: "0.73.2"
+tag: "0.74.0"
 source: https://github.com/FairRootGroup/ODC.git
 requires:
 - boost


### PR DESCRIPTION
More stable operation with `calib` zone in resource request: https://alice.its.cern.ch/jira/browse/EPN-187