### PR TITLE
Make XRootD Python module available to subsequent builds

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -13,6 +13,8 @@ build_requires:
  - "GCC-Toolchain:(?!osx)"
  - UUID:(?!osx)
  - alibuild-recipe-tools
+prepend_path:
+  PYTHONPATH: "$XROOTD_ROOT/lib/python/site-packages"
 ---
 #!/bin/bash -e
 [[ -e $SOURCEDIR/bindings ]] && { XROOTD_V4=True; XROOTD_PYTHON=True; } || XROOTD_PYTHON=False


### PR DESCRIPTION
Without this patch, the module is only available in an alienv environment, i.e. when its Modulefile is loaded.