### PR TITLE
datadist: v1.4.8

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.4.7
+tag: v1.4.8
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
Hi @davidrohr @vascobarroso @lkrcal ,
This contains only alignment with O2 for EOS metadata values, and monitoring changes (O2-2393). Otherwise, it's fully compatible with previous versions, and can be bumped and tested on STAGING without coordinated upgrade.
