### PR TITLE
Fix setuptools version detection in XRootD build

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -41,9 +41,9 @@ case $ARCHITECTURE in
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
     unset UUID_ROOT
-    SETUPTOOLS_VER=$(python3 -m pip show setuptools | grep Version | sed -e 's/[^0-9]*//')
-    if [ x"$SETUPTOOLS_VER" != x"60.8.2" ]; then
-	printf "Please install setuptools==60.8.2"; exit 1
+    if [ "$(python3 -c 'import setuptools; print(setuptools.__version__)')" != "60.8.2" ]; then
+      echo 'Please install setuptools==60.8.2'
+      exit 1
     fi
   ;;
 esac


### PR DESCRIPTION
Directly get the version string from setuptools, instead of relying on fragile parsing of pip's output.

New command tested on Linux using setuptools versions 39.2.0 and 61.3.1.