### PR TITLE
xrootd.sh :: fix the cases of weird destionations of python bindings

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -121,7 +121,7 @@ if [[ x"$XROOTD_PYTHON" == x"True" ]]; then
     # Print found XRootD python bindings
     if [[ -d ${INSTALLROOT}/lib/python${PYTHON_VER} ]]; then
         echo "Printing found XRootD python bindings"
-        PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");' 2> /dev/null
+        LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
         echo "END of printing XRootD python bindings info"
     else
         echo "NO PYTHON BINDINGS DIRECTORY FOUND!!!"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -88,9 +88,8 @@ cmake "${BUILDDIR}"                                                   \
 cmake --build . -- ${JOBS:+-j$JOBS} install
 popd
 
-if [[ x"$XROOTD_PYTHON" == x"True" ]];
-then
-  pushd $INSTALLROOT
+if [[ x"$XROOTD_PYTHON" == x"True" ]]; then
+    pushd $INSTALLROOT
 
     # there are cases where python bindings are installed as relative to INSTALLROOT
     if [[ -d local/lib64 ]]; then
@@ -108,23 +107,25 @@ then
     fi
     [[ ! -e python ]] && echo "NO PYTHON DIRECTORY FOUND in $(pwd -P)"
     popd
-  popd
+
+    popd
+
   case $ARCHITECTURE in
     osx*)
       find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
       find $INSTALLROOT/lib/ -name "*.dylib" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
     ;;
   esac
-fi
 
-# Print found XRootD python bindings
-if [[ -d ${INSTALLROOT}/lib/python${PYTHON_VER} ]]; then
-    echo "Printing found XRootD python bindings"
-    PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");' 2> /dev/null
-    echo "END of printing XRootD python bindings info"
-else
-    echo "NO PYTHON BINDINGS DIRECTORY FOUND!!!"
-    exit 1
+    # Print found XRootD python bindings
+    if [[ -d ${INSTALLROOT}/lib/python${PYTHON_VER} ]]; then
+        echo "Printing found XRootD python bindings"
+        PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");' 2> /dev/null
+        echo "END of printing XRootD python bindings info"
+    else
+        echo "NO PYTHON BINDINGS DIRECTORY FOUND!!!"
+        exit 1
+    fi
 fi
 
 # Modulefile

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -81,7 +81,6 @@ cmake "${BUILDDIR}"                                                   \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}               \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
-      -DXRDCL_ONLY=ON                                                 \
       -DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'             \
       -DPIP_OPTIONS='--force-reinstall --ignore-installed -v'         \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -67,8 +67,6 @@ cmake "${BUILDDIR}"                                                   \
       -DENABLE_CRYPTO=ON                                              \
       -DENABLE_PERL=OFF                                               \
       -DVOMSXRD_SUBMODULE=OFF                                         \
-      ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
-      ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \
       ${UUID_ROOT:+-DUUID_LIBRARY=$UUID_ROOT/lib/libuuid.so}          \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIRS=$UUID_ROOT/include}            \
@@ -81,8 +79,10 @@ cmake "${BUILDDIR}"                                                   \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}               \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
-      -DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'             \
-      -DPIP_OPTIONS='--force-reinstall --ignore-installed -v'         \
+      ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                                        \
+      ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}                    \
+      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'}       \
+      ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed -v'}   \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
 
 cmake --build . -- ${JOBS:+-j$JOBS} install

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -23,7 +23,8 @@ if [[ $ALIEN_RUNTIME_VERSION ]]; then
   LIBXML2_ROOT=${LIBXML2_REVISION:+$ALIEN_RUNTIME_ROOT}
 fi
 
-[[ -e ${SOURCEDIR}/bindings ]] && { XROOTD_V4=True; XROOTD_PYTHON=True; } || XROOTD_PYTHON=False
+XROOTD_PYTHON=""
+[[ -e ${SOURCEDIR}/bindings ]] && XROOTD_PYTHON=True;
 PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
 PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
 


### PR DESCRIPTION
@ktf @TimoWilken on fedora the destination of python bindings is relative to INSTALLROOT instead of relative to INSTALLROOT/lib.. i added a check to take this into account
and added the libxml2 dependency to xrootd (which is used by default). Let me know what do you think.. Thanks a lot!