### PR TITLE
Revert "xrootd.sh :: fix the cases of weird destionations of python bindings"

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -5,8 +5,8 @@ source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"
  - Python-modules:(?!osx_arm64)
- - libxml2
  - AliEn-Runtime
+ - libxml2
 build_requires:
  - CMake
  - "osx-system-openssl:(osx.*)"
@@ -14,17 +14,10 @@ build_requires:
  - UUID:(?!osx)
  - alibuild-recipe-tools
 prepend_path:
-  PYTHONPATH: "${XROOTD_ROOT}/lib/python/site-packages"
+  PYTHONPATH: "$XROOTD_ROOT/lib/python/site-packages"
 ---
 #!/bin/bash -e
-
-if [[ $ALIEN_RUNTIME_VERSION ]]; then
-  # AliEn-Runtime: we take libxml2 from there, in case they were not taken from the system
-  LIBXML2_ROOT=${LIBXML2_REVISION:+$ALIEN_RUNTIME_ROOT}
-fi
-
-XROOTD_PYTHON=""
-[[ -e ${SOURCEDIR}/bindings ]] && XROOTD_PYTHON=True;
+[[ -e $SOURCEDIR/bindings ]] && { XROOTD_V4=True; XROOTD_PYTHON=True; } || XROOTD_PYTHON=False
 PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
 PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
 
@@ -55,78 +48,55 @@ case $ARCHITECTURE in
   ;;
 esac
 
-rsync -a --delete ${SOURCEDIR}/ ${BUILDDIR}
+rsync -a --delete $SOURCEDIR/ $BUILDDIR
 
 mkdir build
 pushd build
-cmake "${BUILDDIR}"                                                   \
+cmake "$BUILDDIR"                                                     \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                       \
-      -DCMAKE_INSTALL_PREFIX=${INSTALLROOT}                           \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                             \
       ${CMAKE_FRAMEWORK_PATH+-DCMAKE_FRAMEWORK_PATH=$CMAKE_FRAMEWORK_PATH} \
       -DCMAKE_INSTALL_LIBDIR=lib                                      \
       -DENABLE_CRYPTO=ON                                              \
       -DENABLE_PERL=OFF                                               \
       -DVOMSXRD_SUBMODULE=OFF                                         \
+      ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
+      ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \
       ${UUID_ROOT:+-DUUID_LIBRARY=$UUID_ROOT/lib/libuuid.so}          \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIRS=$UUID_ROOT/include}            \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIR=$UUID_ROOT/include}             \
-      ${LIBXML2_ROOT:+-DLIBXML2_INCLUDE_DIR=$LIBXML2_ROOT/include/libxml2}    \
-      ${LIBXML2_ROOT:+-DLIBXML2_LIBRARY=$LIBXML2_ROOT/lib/libxml2.so}         \
-      ${LIBXML2_ROOT:+-DLIBXML2_XMLLINT_EXECUTABLE=$LIBXML2_ROOT/bin/xmllint} \
       -DENABLE_KRB5=OFF                                               \
       -DENABLE_READLINE=OFF                                           \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}               \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
-      ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                                        \
-      ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}                    \
-      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'}       \
-      ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed -v'}   \
+      -DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'             \
+      -DPIP_OPTIONS='--force-reinstall --ignore-installed'            \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 popd
 
-if [[ x"$XROOTD_PYTHON" == x"True" ]]; then
-    pushd $INSTALLROOT
-
-    # there are cases where python bindings are installed as relative to INSTALLROOT
-    if [[ -d local/lib64 ]]; then
-        [[ -d local/lib64/python${PYTHON_VER} ]] && mv -f local/lib64/python${PYTHON_VER} lib/
-    fi
-    if [[ -d local/lib ]]; then
-        [[ -d local/lib/python${PYTHON_VER} ]] && mv -f local/lib/python${PYTHON_VER} lib/
-    fi
-
+if [[ x"$XROOTD_PYTHON" == x"True" ]];
+then
+  pushd $INSTALLROOT
     pushd lib
-    if [[ -d ../lib64/python${PYTHON_VER} ]]; then
+    if [ -d ../lib64 ]; then
       ln -s ../lib64/python${PYTHON_VER} python
-    elif [[ -d python${PYTHON_VER} ]]; then
+    else
       ln -s python${PYTHON_VER} python
     fi
-    [[ ! -e python ]] && echo "NO PYTHON DIRECTORY FOUND in $(pwd -P)"
     popd
-
-    popd
-
+  popd
   case $ARCHITECTURE in
     osx*)
       find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
       find $INSTALLROOT/lib/ -name "*.dylib" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
     ;;
   esac
-
-    # Print found XRootD python bindings
-    if [[ -d ${INSTALLROOT}/lib/python${PYTHON_VER} ]]; then
-        echo "Printing found XRootD python bindings"
-        LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
-        echo "END of printing XRootD python bindings info"
-    else
-        echo "NO PYTHON BINDINGS DIRECTORY FOUND!!!"
-        exit 1
-    fi
 fi
+
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
Reverts alisw/alidist#4407, as that PR breaks the XRootD modulefile. The problem is the `LIBXML2_ROOT=${LIBXML2_REVISION:+$ALIEN_RUNTIME_ROOT}` line, which confuses `alibuild-generate-module`.

Cc: @adriansev