### PR TITLE
Openloops.sh - Fix compilation of 2.1.1 (Ubuntu)

### DIFF
--- a/openloops.sh
+++ b/openloops.sh
@@ -4,8 +4,9 @@ tag: "OpenLoops-2.1.1"
 source: https://gitlab.com/openloops/OpenLoops.git
 requires:
   - "GCC-Toolchain:(?!osx)"
-  - "Python:slc.*"
-  - "Python-system:(?!slc.*)"
+  - "Python:(?!osx)"
+  - "Python-modules:(?!osx)"
+  - "Python-system:(osx.*)"
 build_requires:
   - alibuild-recipe-tools
 ---

--- a/openloops.sh
+++ b/openloops.sh
@@ -14,10 +14,10 @@ rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ .
 
 unset HTTP_PROXY # unset this to build on slc6 system
 
-# Due to typical long install dir paths used by aliBuikd the string lenghts must be increased
-# In addition a trim statement is missing for the install path
+# Due to typical long install dir paths used by aliBuild, the string lengths must be increased
+# In addition a trim statement is missing for the install path 
 sed -i -e 's/max_string_length\ =\ 255/max_string_length\ =\ 1000/g' pyol/config/default.cfg
-sed -i -e 's/call\ set_parameter(\"install_path\",\ tmp,\ error)/call\ set_parameter(\"install_path\",\ trim(tmp),\ error)/g' lib_src/openloops/src/ol_interface.F90
+sed -i -e 's/call\ set_parameter(\"install_path\",\ tmp,\ error)/call\ set_parameter(\"install_path\",\ trim(tmp),\ error)/g' lib_src/openloops/src/ol_interface.F90 # fixed officially in Openloops 2.1.2, needed for 2.1.1 but not later.
 ./scons 
 
 JOBS=$((${JOBS:-1}*1/5))


### PR DESCRIPTION
Openloops is a package needed for computation of NLO physics processes, further used typically by MC generators SHERPA or HERWIG.

**Commit 1**
1. Fix a typo in existing comment

2. One of the sed command is needed for v2.1.1 but fixed for v2.1.2 in the official repo that we take the code from. Comment on this to anticipate, a line could be removed when switching to 2.1.2.

**Commit 2**

3. On Kubuntu 20.04 LTS (i.e. non-slc7, non-macOS), Openloops does not compile due a failing verification of a SSL certificate while calling the python script: `Openloops/pyol/bin/download_process.py`.

```
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: ++ Line 15: PROCESSES=(ppjj ppjj_ew ppjjj ppjjj_ew ppjjj_nf5 ppjjjj)
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: ++ Line 16: for proc in ${PROCESSES[@]}
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: ++ Line 17: ./scons --jobs=2 auto=ppjj
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: scons: Reading SConscript files ...
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: 
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: >>> OpenLoops Process Downloader <<<
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: 
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: Warning: Channel database update for repository public failed (<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:727)>). Skip this repository.
2022-08-08@16:41:11:DEBUG:AliGenerators:Openloops:vAN-2022: - process: ppjj ... ERROR: not available (installed: {})

```
The downloads are needed to get desired NLO physics processes for our needs (ex : ppjj = pp to dijets, etc), such a shopping list is defined in our recipe [alidist/openloops.sh](https://github.com/alisw/alidist/blob/master/openloops.sh).

What to do ?

A fix for this can be in place on the recipe side by requesting an explicit built-time and run-time dependency (`requires`) to Python package not only for slc platforms as done so far, but rather anything which is non-MacOs (e.g. Ubuntu).
Note that a similar policy has been set up recently by Peter Hristov for yoda.sh in [PR 4408](https://github.com/alisw/alidist/pull/4408/files#diff-cb293b8b75c624d7558525dda3b339201c2a6f5ac1322be6d80e9edcac6d5238).

```
 requires:
   - "GCC-Toolchain:(?!osx)"
-  - "Python:slc.*"
-  - "Python-system:(?!slc.*)"
+  - "Python:(?!osx)"
+  - "Python-modules:(?!osx)"
+  - "Python-system:(osx.*)"
 build_requires:
   - alibuild-recipe-tools

```
The trick is apparently in the python.sh where a SSL certificate is managed and anticipated properly.
Then requesting python as requirement for Openloops cures the thing on the way.

[alidist/python.sh](https://github.com/alisw/alidist/blob/c0329f1b3bbdd2ebe7a37becf9dfef5d13c67613/python.sh#L91), l.91 and later:
```
# Install Python SSL certificates right away
env PATH="$INSTALLROOT/bin:$PATH" \
    LD_LIBRARY_PATH="$INSTALLROOT/lib:$LD_LIBRARY_PATH" \
    PYTHONHOME="$INSTALLROOT" \
    python3 -m pip install 'certifi==2019.3.9'
```





Note for admins :  no squash merge please, but just regular merge of the successive commits.