### PR TITLE
defaults-generators.sh - gcc-toolchain standards

### DIFF
--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -5,6 +5,9 @@ env:
   CMAKE_BUILD_TYPE: RELWITHDEBINFO
   CXXFLAGS: -fPIC -g -O2 -std=c++14
 overrides:
+  GCC-Toolchain:
+    tag: v10.2.0-alice2
+    version: v10.2.0-alice2
   boost:
     requires:
     - GCC-Toolchain:(?!osx)


### PR DESCRIPTION
In order to be inline with what is used for defaults-o2.sh (https://github.com/alisw/alidist/blob/master/defaults-o2.sh), we try to move AliGenerators to our most recent standards for gcc-toolchain.
By default, gcc-toolchain is still set to : v7.3.0-alice2 (https://github.com/alisw/alidist/blob/master/gcc-toolchain.sh).
Here we intend to define the defaults-generators behaviour set to : v10.2.0-alice2