### PR TITLE
alidist/Openloops - bump from (2.1.1) to (2.1.2)

### DIFF
--- a/openloops.sh
+++ b/openloops.sh
@@ -1,6 +1,6 @@
 package: Openloops
 version: "%(tag_basename)s"
-tag: "OpenLoops-2.1.1"
+tag: "OpenLoops-2.1.2"
 source: https://gitlab.com/openloops/OpenLoops.git
 requires:
   - "GCC-Toolchain:(?!osx)"
@@ -16,9 +16,8 @@ rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ .
 unset HTTP_PROXY # unset this to build on slc6 system
 
 # Due to typical long install dir paths used by aliBuild, the string lengths must be increased
-# In addition a trim statement is missing for the install path 
 sed -i -e 's/max_string_length\ =\ 255/max_string_length\ =\ 1000/g' pyol/config/default.cfg
-sed -i -e 's/call\ set_parameter(\"install_path\",\ tmp,\ error)/call\ set_parameter(\"install_path\",\ trim(tmp),\ error)/g' lib_src/openloops/src/ol_interface.F90 # fixed officially in Openloops 2.1.2, needed for 2.1.1 but not later.
+
 ./scons 
 
 JOBS=$((${JOBS:-1}*1/5))


### PR DESCRIPTION
Change version of Openloops (NLO processes needed for Sherpa and Herwig MC gen),
from current v2.1.1 to v2.1.2.

Since a fix is now implemented in the official sources for the "missing trim statement" in lib_src/openloops/src/ol_interface.F90,
we remove the sed command in place in our openloops.sh recipe, because it does nothing anymore.