### PR TITLE
Export ALICE_PHYSICS regardless of default

### DIFF
--- a/aliroot-guntest.sh
+++ b/aliroot-guntest.sh
@@ -7,6 +7,7 @@ requires:
 ---
 #!/bin/bash -e
 
+export ALICE_PHYSICS=$ALIPHYSICS_ROOT
 # A simple regression test launching a Geant3 + Geant4 gun simulation + reconstruction.
 # Tests if the processing runs through and yields a reasonable ESD.
 # Note that the test is limited to the default OCDB.


### PR DESCRIPTION
ALICE_PHYSICS is currently exported by the aliphysics.sh. However, due to the fact defaults-o2 overrides aliphysics attributes without adding back ALICE_PHYSICS, the gun test fails. Given in the end such a variable is only needed by the guntest, the best solution is to simply export it explicitly there from ALIPHYSICS_ROOT, which is guaranteed to be always there.