### PR TITLE
Bump FairMQ to v1.4.54

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.53
+tag: v1.4.54
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
- Fixes a regression that can lead to failure when mapping unmanaged regions (crash with `Cannot allocate memory` during Init).