### PR TITLE
Bump FairMQ to v1.4.55

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.54
+tag: v1.4.55
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
Fixes an issue in shmem region initialization, where a local region object would get created but immediately destroyed because a remote region object with the same ID already exists. Furthermore, the existing object would get marked as local, but with wrong configuration, leading to potential unexpected behavior.

The bug lead to DD cleaning up unmanaged region on shutdown, even when ShmManager keeps memory alive. This has been present since the first version of the ShmManager, but remained unnoticed, because the destroyed URs would get recreated by DD on subsequent runs.

Recent patch of ShmManager reveals the issue by monitoring the UR objects and reporting error if they are removed: https://alice.its.cern.ch/jira/browse/O2-3158