### PR TITLE
Bump FairMQ to v1.4.55

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: v1.4.54
+tag: v1.4.55
 source: https://github.com/FairRootGroup/FairMQ
 requires:
  - boost


### PR DESCRIPTION
This fixes an issues with handling initialization orders in FairMQ when
ShmManager is involved: https://alice.its.cern.ch/jira/browse/O2-3158

Ping @rbx and @davidrohr 