### PR TITLE
Allow releasing AliPhysics built with o2 defaults

### DIFF
--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -12,7 +12,10 @@ disable:
 overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'
+    tag: v5-09-57h-01
   AliRoot:
+    version: '%(commit_hash)s_O2'
+    tag: v5-09-57h
     requires:
     - ROOT
     - DPMJET
@@ -22,7 +25,6 @@ overrides:
     - Vc
     - ZeroMQ
     - JAliEn-ROOT
-    version: '%(commit_hash)s_O2'
   GCC-Toolchain:
     tag: v10.2.0-alice2
     version: v10.2.0-alice2


### PR DESCRIPTION
The current release procedure replaces the "current" AliPhysics tag in overrides, but this didn't work before when building with o2 defaults, as there was no override.

With this change, the current AliRoot/AliPhysics release script works with o2 defaults too.