### PR TITLE
Update xjalienfs to 1.4.5

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.4.2"
+tag: "1.4.4"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.4.4"
+tag: "1.4.5"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Optimizations and performance fixes mostly with addition of xrd_ related features

* restore cat/edit/more lfn type of commands
* makelist_lfn : give up if src is missing; fix DO_run
* websockets:: reduce the import surface, import only what is used
* gid2name:: try to avoid the breakage on macos for seemingly invalid gid numbers
* fix token (re)generation by passing the arguments to the InitConnection
* pfn-status :: convert to take lfns as input
* XRootD infrastrucure for xrdfs utilities (ping, config, stats), rework getSE command
* add xrd_ping command
* fix getSE arg processing
* add -exclude and -exclude_re to list_files_grid (used also by find2)
* add xrd_config for printing configuration details about a xrootd server
* add xrd_stats command; fix xrd queries to use only unix auth
* flake8 fixes
* pylint fixes
* refactor usage of urllib
* compact python version check
* move and refactor certificate validation to do it as early as possible
* wb_create:: catch invalid status code and if 401 instruct the user to check certificate registration
* fix 2 else before return
* deepsource 1
* more deepsource fixes
* more deepsource fixes 2
* explicit check false for subprocess.run; iter over items(); add verify for certkey match
* use staticmethod where is the case
* ca verify: set the arguments and then try the load
* bail out hard and fast from ssl context creation; re-initialize logging when -debug option is used
* rework exceptions WIP
* fix unused vars
* force ssl verify for CertKeyMatch; remove some unused vard
* fix variable renaming
* fix logging to be lazy
* fix logging to be lazy v2
* disable errenous warning on deepsource
* fix -json arg
* fix json output of queryML

* for token info operations use get_valid_tokens to be able to read JALIEN_ exports