### PR TITLE
Bump JAliEn-ROOT 0.6.7

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.6.6"
+tag: "0.6.7"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
This drops the dependency of JAliEn-ROOT on RDataframe and Graf3d.