### PR TITLE
Bump geant4_vmc to v6.1.p2

### DIFF
--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v6-1-p1"
+tag: "v6-1-p2"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT


### PR DESCRIPTION
This version allows to switch on hyper-nuclei EM physics, by adding `"+hyperNuclei"` option to the physics list name in `g4Config.C`