### PR TITLE
ROOT Python scripts: don't hardcode build-time path to Python

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -90,12 +90,12 @@ if [[ -d $SOURCEDIR/interpreter/llvm ]]; then
   ROOT_HAS_PYTHON=1
   python_exec=$(python3 -c 'import distutils.sysconfig; print(distutils.sysconfig.get_config_var("exec_prefix"))')/bin/python3
   if [ "$python_exec" = "$(which python3)" ]; then
-    # By default, if there's nothing funny going on, use the first Python 3 in
+    # By default, if there's nothing funny going on, let ROOT pick the Python in
     # the PATH, which is the one built by us (unless disabled, in which case it
     # is the system one). This is substituted into ROOT's Python scripts'
     # shebang lines, so we cannot use an absolute path because the path to our
     # Python will differ between build time and runtime, e.g. on the Grid.
-    PYTHON_EXECUTABLE=python3
+    PYTHON_EXECUTABLE=
   else
     # If Python's exec_prefix doesn't point to the same place as $PATH, then we
     # have a shim script in between. This is used by things like pyenv and asdf.


### PR DESCRIPTION
ROOT is currently built using an absolute path specified as `$PYTHON_EXECUTABLE`. This is then hardcoded into Python scripts installed by ROOT, but the build-time Python executable is not necessarily the same as the runtime one (e.g. for packages built using Jenkins and installed on CVMFS).

This was initially done (in commit 226160ae138e8d72822895c8916df4eb42c3e2f9) in order to handle Python executables installed by environment managers like asdf and pyenv. See the message of the above commit for details.

Instead, when we aren't using a Python executable from an env manager, use just "python3" as the executable, so that it is looked up in `$PATH` at runtime. At runtime, we should be inside an alienv environment. If we built our own Python, it will be picked up from `$PATH`; if not, we will fall back to the system Python as expected.