### PR TITLE
Adding faster zlib implementation from Cloudflare

### DIFF
--- a/zlib-cloudflare.sh
+++ b/zlib-cloudflare.sh
@@ -1,0 +1,24 @@
+package: zlib-cloudflare
+version: "%(tag_basename)s"
+tag: gcc.amd64
+source: https://github.com/cloudflare/zlib/
+build_requires:
+ - "GCC-Toolchain:(?!osx)"
+ - CMake
+ - alibuild-recipe-tools
+---
+#!/bin/sh
+
+echo "Building optimized zlib"
+
+cmake ${SOURCEDIR} -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
+
+# Build and install
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --lib > $MODULEFILE
+cat >> "$MODULEFILE" <<EOF


### PR DESCRIPTION
Known to be a faster replacement for zlib.
Has the potential to speedup ROOT IO heavy
workflows by some ~10%.

A free lunch since drop-in replacement.