### PR TITLE
Adjustments to compile on ARM/aarch64

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -28,6 +28,7 @@ esac
 case $ARCHITECTURE in
   *_x86-64) LLVM_TARGETS_TO_BUILD=X86 ;;
   *_arm64) LLVM_TARGETS_TO_BUILD=AArch64 ;;
+  *_aarch64) LLVM_TARGETS_TO_BUILD=AArch64 ;;
   *) echo 'Unknown LLVM target for architecture' >&2; exit 1 ;;
 esac
 

--- a/o2.sh
+++ b/o2.sh
@@ -22,7 +22,6 @@ requires:
   - libuv
   - libjalienO2
   - cgal
-  - KFParticle
   - VecGeom
   - FFTW3
   - ONNXRuntime
@@ -244,7 +243,6 @@ module load BASE/1.0 \\
             ${FMT_REVISION:+fmt/$FMT_VERSION-$FMT_REVISION}                                         \\
             ${AEGIS_REVISION:+AEGIS/$AEGIS_VERSION-$AEGIS_REVISION}                                 \\
             ${LIBJALIENO2_REVISION:+libjalienO2/$LIBJALIENO2_VERSION-$LIBJALIENO2_REVISION}         \\
-            ${KFPARTICLE_REVISION:+KFParticle/$KFPARTICLE_VERSION-$KFPARTICLE_REVISION}             \\
             ${CURL_REVISION:+curl/$CURL_VERSION-$CURL_REVISION}                                     \\
             ${FAIRMQ_REVISION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION}                             \\
             ${FFTW3_REVISION:+FFTW3/$FFTW3_VERSION-$FFTW3_REVISION}                                 \\

--- a/o2physics.sh
+++ b/o2physics.sh
@@ -5,6 +5,7 @@ requires:
   - O2
   - ONNXRuntime
   - libjalienO2
+  - KFParticle
 build_requires:
   - CMake
   - ninja

--- a/vecgeom.sh
+++ b/vecgeom.sh
@@ -25,6 +25,17 @@ case $ARCHITECTURE in
 	      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                   \
 	      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 	;;
+    *_aarch64)
+	cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT -DROOT=ON  \
+	      -DBACKEND=Scalar                                          \
+              -GNinja                                                   \
+              -DBENCHMARK=OFF                                           \
+              -DCTEST=OFF                                               \
+              -DBUILD_TESTING=OFF                                       \
+              -DVALIDATION=OFF                                          \
+	      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                   \
+	      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+	;;
     *)
 	cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT -DROOT=ON  \
 	      -DBACKEND=Vc                                              \


### PR DESCRIPTION
* O2 does not depend on KFParticle anymore (KFParticle does not compile currently on ARM)
* adjust Clang and VecGeom to compile on ARM


see https://alice.its.cern.ch/jira/browse/O2-3278