### PR TITLE
Explicitly add O2Physics' fastjet dependency

### DIFF
--- a/o2physics.sh
+++ b/o2physics.sh
@@ -4,6 +4,7 @@ tag: "nightly-20221013"
 requires:
   - O2
   - ONNXRuntime
+  - fastjet
   - libjalienO2
 build_requires:
   - CMake
@@ -28,6 +29,7 @@ cmake "$SOURCEDIR" "-DCMAKE_INSTALL_PREFIX=$INSTALLROOT"          \
       ${CXXSTD:+"-DCMAKE_CXX_STANDARD=$CXXSTD"}                   \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                          \
       ${ONNXRUNTIME_ROOT:+-DONNXRuntime_DIR=$ONNXRUNTIME_ROOT}    \
+      ${FASTJET_ROOT:+-Dfjcontrib_ROOT="$FASTJET_ROOT"}           \
       ${LIBJALIENO2_ROOT:+-DlibjalienO2_ROOT=$LIBJALIENO2_ROOT}
 cmake --build . -- ${JOBS+-j $JOBS} install
 


### PR DESCRIPTION
Introduced in https://github.com/AliceO2Group/O2Physics/pull/1353.

Without this, fastjet is still loaded implicitly through O2, which seems suboptimal.