### PR TITLE
Simplify versions for AliRoot and AliPhysics

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -1,6 +1,6 @@
 package: AliPhysics
-version: "%(commit_hash)s"
-tag: master
+version: "%(commit_hash)s%(defaults_upper)s"
+tag: v5-09-59e-01
 requires:
   - AliRoot
   - RooUnfold

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -1,6 +1,6 @@
 package: AliRoot
-version: "%(commit_hash)s"
-tag: master
+version: "%(commit_hash)s%(defaults_upper)s"
+tag: v5-09-59e
 requires:
   - ROOT
   - DPMJET

--- a/defaults-jalien.sh
+++ b/defaults-jalien.sh
@@ -7,12 +7,6 @@ env:
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELWITHDEBINFO"
 overrides:
-  AliRoot:
-    version: "%(tag_basename)s_JALIEN"
-    tag: v5-09-57h
-  AliPhysics:
-    version: "%(tag_basename)s_JALIEN"
-    tag: v5-09-57h-01
   fastjet:
     tag: v3.4.0_1.045-alice1
 ---

--- a/defaults-next-root6.sh
+++ b/defaults-next-root6.sh
@@ -10,8 +10,6 @@ env:
 overrides:
   AliRoot:
     version: "%(tag_basename)s_ROOT6"
-    tag: v5-09-57h
   AliPhysics:
     version: "%(tag_basename)s_ROOT6"
-    tag: v5-09-57h-01
 ---

--- a/defaults-user-next-root6.sh
+++ b/defaults-user-next-root6.sh
@@ -13,8 +13,6 @@ disable:
 overrides:
   AliRoot:
     version: "%(tag_basename)s"
-    tag: v5-09-57h
   AliPhysics:
     version: "%(tag_basename)s"
-    tag: v5-09-57h-01
 ---


### PR DESCRIPTION
Cc: @ktf

Instead of overriding the tag in every defaults-*.sh file, just specify it once.

I've left ROOT5 defaults alone.

Unfortunately, it turns out that the current aliBuild **cannot** reuse already-built tarballs for development packages (only for non-development packages that were built against a different pointer to the same commit, e.g. `refs/heads/rc/nightly-20221020` and `refs/tags/nightly-20221020`). We'd need to change aliBuild to get the CI speedup if this PR is merged.