### PR TITLE
Install pkgconfig file for UUID

### DIFF
--- a/uuid.sh
+++ b/uuid.sh
@@ -3,32 +3,38 @@ version: v2.27.1
 tag: alice/v2.27.1
 source: https://github.com/alisw/uuid
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - "autotools:(slc6|slc7)"
+  - "GCC-Toolchain:(?!osx)"
+  - "autotools:(slc6|slc7)"
+append_path:
+  PKG_CONFIG_PATH: "$UUID_ROOT/share/pkgconfig"
 ---
-rsync -av --delete --exclude "**/.git" $SOURCEDIR/ .
+rsync -av --delete --exclude '**/.git' "$SOURCEDIR/" .
 if [[ $AUTOTOOLS_ROOT == "" ]]  && which brew >/dev/null; then
-  PATH=$PATH:`brew --prefix gettext`/bin
+  PATH=$PATH:$(brew --prefix gettext)/bin
 fi
 
 perl -p -i -e 's/AM_GNU_GETTEXT_VERSION\(\[0\.18\.3\]\)/AM_GNU_GETTEXT_VERSION([0.18.2])/' configure.ac
 
+case $ARCHITECTURE in
+  osx_*) disable_shared=yes ;;
+  *) disable_shared= ;;
+esac
+
 autoreconf -ivf
-./configure $([[ ${ARCHITECTURE:0:3} == osx ]] && echo --disable-shared)  \
-            --libdir=$INSTALLROOT/lib                                     \
-            --prefix=$INSTALLROOT                                         \
-            --disable-all-programs                                        \
-            --disable-silent-rules                                        \
-            --disable-tls                                                 \
-            --disable-rpath                                               \
-            --without-ncurses                                             \
+./configure ${disable_shared:+--disable-shared}   \
+            "--libdir=$INSTALLROOT/lib"           \
+            "--prefix=$INSTALLROOT"               \
+            --disable-all-programs                \
+            --disable-silent-rules                \
+            --disable-tls                         \
+            --disable-rpath                       \
+            --without-ncurses                     \
             --enable-libuuid
-make ${JOBS:+-j$JOBS} libuuid.la
-mkdir -p $INSTALLROOT/lib
-cp -a .libs/libuuid.a* $INSTALLROOT/lib
-if [[ ${ARCHITECTURE:0:3} != osx ]]; then
-  cp -a .libs/libuuid.so* $INSTALLROOT/lib
+make ${JOBS:+-j$JOBS} libuuid.la libuuid/uuid.pc install-uuidincHEADERS
+mkdir -p "$INSTALLROOT/lib" "$INSTALLROOT/share/pkgconfig"
+cp -a libuuid/uuid.pc "$INSTALLROOT/share/pkgconfig"
+cp -a .libs/libuuid.a* "$INSTALLROOT/lib"
+if [ -z "$disable_shared" ]; then
+  cp -a .libs/libuuid.so* "$INSTALLROOT/lib"
 fi
-mkdir -p $INSTALLROOT/include
-make install-uuidincHEADERS
-rm -rf $INSTALLROOT/man
+rm -rf "$INSTALLROOT/man"

--- a/uuid.sh
+++ b/uuid.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/uuid
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - "autotools:(slc6|slc7)"
-append_path:
+prepend_path:
   PKG_CONFIG_PATH: "$UUID_ROOT/share/pkgconfig"
 ---
 rsync -av --delete --exclude '**/.git' "$SOURCEDIR/" .


### PR DESCRIPTION
XRootD requires this, as it searches for libuuid using pkg-config in its CMake recipes. This leads to build failures on Ubuntu. While users can install libuuid on their system to provide the `*.pc` file, this seems silly if we're building the library anyway.

I've also fixed some linter errors related to quoting issues in the script, as this seemed like a good opportunity.