### PR TITLE
Bump DD to 1.5.2

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.5.1
+tag: v1.5.2
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
no functional change, just replaced a deprecated logging function that was used by DD