### PR TITLE
Tweak DelphesO2 to enable Jenkins builds

### DIFF
--- a/delpheso2.sh
+++ b/delpheso2.sh
@@ -5,10 +5,7 @@ requires:
   - ROOT
   - Delphes
   - O2
-overrides:
-  O2:
-    version: "%(short_hash)s%(defaults_upper)s"
-    tag: dev
+  - O2Physics
 build_requires:
   - alibuild-recipe-tools
   - CMake
@@ -16,21 +13,18 @@ build_requires:
 source: https://github.com/AliceO2Group/DelphesO2.git
 ---
 #!/bin/bash -ex
-cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
-                 -DCMAKE_INSTALL_LIBDIR=lib                \
-                 ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
-                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
-                 -DCMAKE_SKIP_RPATH=TRUE
+cmake "$SOURCEDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"     \
+                   -DCMAKE_INSTALL_LIBDIR=lib                \
+                   ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
+                   -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"    \
+                   -DCMAKE_SKIP_RPATH=TRUE
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
 #ModuleFile
-mkdir -p $INSTALLROOT/etc/modulefiles
-alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 
-cat << EOF >> $INSTALLROOT/etc/modulefiles/$PKGNAME
-set DELPHESO2_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv DELPHESO2_ROOT \$DELPHESO2_ROOT
-prepend-path PATH \$DELPHESO2_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$DELPHESO2_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$DELPHESO2_ROOT/include
+cat << EOF >> "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+setenv DELPHESO2_ROOT \$PKG_ROOT
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EOF


### PR DESCRIPTION
In addition to the required changes (removing `override:` and adding `O2Physics` dependency), I also took the opportunity to fix shell quoting issues in the build recipe.