### PR TITLE
Add ITSResponse package

### DIFF
--- a/itsresponse.sh
+++ b/itsresponse.sh
@@ -7,8 +7,8 @@ build_requires:
 ---
 #!/bin/bash -e
 
-mkdir -p ${INSTALLROOT}/response
-cp -r ${SOURCEDIR}/* $INSTALLROOT/response
+mkdir -p "$INSTALLROOT/response"
+cp -r "$SOURCEDIR"/* "$INSTALLROOT/response"
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/itsresponse.sh
+++ b/itsresponse.sh
@@ -1,0 +1,23 @@
+package: ITSResponse
+version: "%(tag_basename)s"
+tag: v1.0.0
+source: https://github.com/AliceO2Group/ITSChipResponseData.git
+build_requires:
+  - alibuild-recipe-tools
+---
+#!/bin/bash -e
+
+mkdir -p ${INSTALLROOT}/response
+cp -r ${SOURCEDIR}/* $INSTALLROOT/response
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module > "$MODULEFILE"
+cat >> "$MODULEFILE" <<EoF
+
+# Our environment
+set ITSRESPONSE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv ITSRESPONSE_ROOT \$ITSRESPONSE_ROOT
+EoF

--- a/o2.sh
+++ b/o2.sh
@@ -26,6 +26,7 @@ requires:
   - FFTW3
   - ONNXRuntime
   - MLModels
+  - ITSResponse
 build_requires:
   - GMP
   - MPFR


### PR DESCRIPTION
Hi @shahor02 @ktf, @TimoWilken 

As briefly discussed I moved the numerous files related to ITS ALPIDE chip responses to a dedicated repository: https://github.com/AliceO2Group/ITSChipResponseData
Here I am adding a recipe to get them as a prerequisite during O2 installation.
In pull-request https://github.com/AliceO2Group/AliceO2/pull/10352 the files are used to create the .root file.
Can this work? Let me know if something should be done differently.

Giulio, does this approach still require not to be run during the CI?
