### PR TITLE
Fix alidist recipe linter errors

### DIFF
--- a/abseil.sh
+++ b/abseil.sh
@@ -1,6 +1,6 @@
 package: abseil
 version: "%(tag_basename)s"
-tag:  "20220623.1"
+tag: "20220623.1"
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:

--- a/alice-grid-utils.sh
+++ b/alice-grid-utils.sh
@@ -21,3 +21,4 @@ proc ModulesHelp { } {
 }
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+EoF

--- a/aliroot-coverage.sh
+++ b/aliroot-coverage.sh
@@ -1,6 +1,6 @@
 package: AliRoot-coverage
 version: "%(year)s%(month)s%(day)s"
-force_rebuild: 1
+force_rebuild: true
 requires:
   - lcov
   - AliRoot-test

--- a/aliroot-csa.sh
+++ b/aliroot-csa.sh
@@ -1,13 +1,13 @@
 package: AliRoot-csa
 version: "%(short_hash)s"
+tag: master
 requires:
   - ROOT
   - SAS
 env:
   ALICE_ROOT: "$ALIROOT_ROOT"
 source: http://git.cern.ch/pub/AliRoot
-write_repo: https://git.cern.ch/reps/AliRoot 
-tag: master
+write_repo: https://git.cern.ch/reps/AliRoot
 ---
 #!/bin/sh
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \

--- a/aliroot-guntest.sh
+++ b/aliroot-guntest.sh
@@ -1,6 +1,6 @@
 package: AliRoot-guntest
 version: v1
-force_rebuild: 1
+force_rebuild: true
 requires:
   - AliRoot
   - AliRoot-OCDB

--- a/aliroot-test.sh
+++ b/aliroot-test.sh
@@ -1,6 +1,6 @@
 package: AliRoot-test
 version: "%(year)s%(month)s%(day)s"
-force_rebuild: 1
+force_rebuild: true
 requires:
   - AliPhysics
   - GEANT3

--- a/aliroot-test.sh
+++ b/aliroot-test.sh
@@ -7,7 +7,7 @@ requires:
   - OCDB-test
   - "IgProf:slc7.*"
 ---
-#!/bin/sh
+#!/bin/bash -e
 export ALICE_ROOT=$ALIROOT_ROOT
 echo "`date +%s`:aliroot-test: $x STARTED"
 WORKSPACE=${WORKSPACE:-$BUILDDIR}

--- a/alo-aliroot.sh
+++ b/alo-aliroot.sh
@@ -12,7 +12,6 @@ build_requires:
   - flatbuffers
   - ms_gsl
 source: https://github.com/mrrtf/alo
-common_recipe: |
 incremental_recipe: |
   cmake --build . -- ${JOBS+-j $JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/alo-aliroot.sh
+++ b/alo-aliroot.sh
@@ -18,7 +18,7 @@ incremental_recipe: |
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   # install the compilation database so that we can post-check the code
   cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}
-  
+
   DEVEL_SOURCES="$(readlink $SOURCEDIR || echo $SOURCEDIR)"
   # This really means we are in development mode. We need to make sure we
   # use the real path for sources in this case. We also copy the

--- a/alo-o2.sh
+++ b/alo-o2.sh
@@ -15,7 +15,7 @@ incremental_recipe: |
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   # install the compilation database so that we can post-check the code
   cp ${BUILDDIR}/compile_commands.json ${INSTALLROOT}
-  
+
   DEVEL_SOURCES="$(readlink $SOURCEDIR || echo $SOURCEDIR)"
   # This really means we are in development mode. We need to make sure we
   # use the real path for sources in this case. We also copy the

--- a/autotools.sh
+++ b/autotools.sh
@@ -10,8 +10,8 @@ prefer_system_check: |
 prepend_path:
   PKG_CONFIG_PATH: $(pkg-config --debug 2>&1 | grep 'Scanning directory' | sed -e "s/.*'\(.*\)'/\1/" | xargs echo | sed -e 's/ /:/g')
 build_requires:
- - termcap
- - make
+  - termcap
+  - make
 ---
 #!/bin/bash -e
 

--- a/autotools.sh
+++ b/autotools.sh
@@ -38,12 +38,11 @@ export PATH=$INSTALLROOT/bin:$PATH
 export LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH
 
 # help2man
-if [ -d help2man* ]; then
-  pushd help2man*
-    ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-    make ${JOBS+-j $JOBS}
-    make install
-    hash -r
+if pushd help2man*; then
+  ./configure --disable-dependency-tracking --prefix "$INSTALLROOT"
+  make ${JOBS+-j $JOBS}
+  make install
+  hash -r
   popd
 fi
 

--- a/configuration.sh
+++ b/configuration.sh
@@ -1,6 +1,6 @@
 package: Configuration
 version: "%(tag_basename)s"
-tag:  v2.6.3
+tag: v2.6.3
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"

--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -1,3 +1,5 @@
+package: defaults-generators
+version: v1
 disable:
   - arrow
 env:
@@ -6,20 +8,17 @@ env:
   CXXFLAGS: -fPIC -g -O2 -std=c++14
 overrides:
   GCC-Toolchain:
-    tag: v10.2.0-alice2
     version: v10.2.0-alice2
+    tag: v10.2.0-alice2
   boost:
     requires:
       - GCC-Toolchain:(?!osx)
   fastjet:
-    tag: v3.4.0_1.045-alice1
     version: v3.4.0_1.045-alice1
+    tag: v3.4.0_1.045-alice1
   pythia:
     tag: v8304
     requires:
       - lhapdf
       - boost
-package: defaults-generators
-version: v1
-
 ---

--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -1,5 +1,5 @@
 disable:
-- arrow
+  - arrow
 env:
   CFLAGS: -fPIC -g -O2
   CMAKE_BUILD_TYPE: RELWITHDEBINFO
@@ -10,15 +10,15 @@ overrides:
     version: v10.2.0-alice2
   boost:
     requires:
-    - GCC-Toolchain:(?!osx)
+      - GCC-Toolchain:(?!osx)
   fastjet:
     tag: v3.4.0_1.045-alice1
     version: v3.4.0_1.045-alice1
   pythia:
-    requires:
-    - lhapdf
-    - boost
     tag: v8304
+    requires:
+      - lhapdf
+      - boost
 package: defaults-generators
 version: v1
 

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -46,10 +46,10 @@ overrides:
         setuptools==65.5.1
   O2-customization:
     env:
-      ENABLE_UPGRADES: OFF # Disable detector upgrades in O2
-      BUILD_ANALYSIS: OFF # Disable analysis in O2
-      BUILD_EXAMPLES: OFF # Disable examples in O2
-      O2_BUILD_FOR_FLP: ON
+      ENABLE_UPGRADES: 'OFF'  # Disable detector upgrades in O2
+      BUILD_ANALYSIS: 'OFF'   # Disable analysis in O2
+      BUILD_EXAMPLES: 'OFF'   # Disable examples in O2
+      O2_BUILD_FOR_FLP: 'ON'
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -1,3 +1,5 @@
+package: defaults-o2-epn
+version: v1
 env:
   CFLAGS: -fPIC -O3 -march=znver2
   CMAKE_BUILD_TYPE: RELWITHDEBINFO
@@ -26,8 +28,8 @@ overrides:
       - ZeroMQ
       - JAliEn-ROOT
   GCC-Toolchain:
-    tag: v10.2.0-alice2
     version: v10.2.0-alice2
+    tag: v10.2.0-alice2
   cgal:
     version: 4.12.2
   fastjet:
@@ -37,9 +39,6 @@ overrides:
     requires:
       - lhapdf
       - boost
-package: defaults-o2
-version: v1
-
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -15,16 +15,16 @@ overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'
   AliRoot:
-    requires:
-    - ROOT
-    - DPMJET
-    - fastjet:(?!.*ppc64)
-    - GEANT3
-    - GEANT4_VMC
-    - Vc
-    - ZeroMQ
-    - JAliEn-ROOT
     version: '%(commit_hash)s_O2'
+    requires:
+      - ROOT
+      - DPMJET
+      - fastjet:(?!.*ppc64)
+      - GEANT3
+      - GEANT4_VMC
+      - Vc
+      - ZeroMQ
+      - JAliEn-ROOT
   GCC-Toolchain:
     tag: v10.2.0-alice2
     version: v10.2.0-alice2
@@ -33,10 +33,10 @@ overrides:
   fastjet:
     tag: v3.4.0_1.045-alice1
   pythia:
-    requires:
-    - lhapdf
-    - boost
     tag: v8304
+    requires:
+      - lhapdf
+      - boost
 package: defaults-o2
 version: v1
 

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -13,16 +13,16 @@ overrides:
   AliPhysics:
     version: '%(commit_hash)s_O2'
   AliRoot:
-    requires:
-    - ROOT
-    - DPMJET
-    - fastjet:(?!.*ppc64)
-    - GEANT3
-    - GEANT4_VMC
-    - Vc
-    - ZeroMQ
-    - JAliEn-ROOT
     version: '%(commit_hash)s_O2'
+    requires:
+      - ROOT
+      - DPMJET
+      - fastjet:(?!.*ppc64)
+      - GEANT3
+      - GEANT4_VMC
+      - Vc
+      - ZeroMQ
+      - JAliEn-ROOT
   GCC-Toolchain:
     tag: v10.2.0-alice2
     version: v10.2.0-alice2
@@ -31,10 +31,10 @@ overrides:
   fastjet:
     tag: v3.4.0_1.045-alice1
   pythia:
-    requires:
-    - lhapdf
-    - boost
     tag: v8304
+    requires:
+      - lhapdf
+      - boost
 package: defaults-o2
 version: v1
 

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -1,3 +1,5 @@
+package: defaults-o2
+version: v1
 env:
   CFLAGS: -fPIC -O2
   CMAKE_BUILD_TYPE: RELWITHDEBINFO
@@ -24,8 +26,8 @@ overrides:
       - ZeroMQ
       - JAliEn-ROOT
   GCC-Toolchain:
-    tag: v10.2.0-alice2
     version: v10.2.0-alice2
+    tag: v10.2.0-alice2
   cgal:
     version: 4.12.2
   fastjet:
@@ -35,9 +37,6 @@ overrides:
     requires:
       - lhapdf
       - boost
-package: defaults-o2
-version: v1
-
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-prod-latest.sh
+++ b/defaults-prod-latest.sh
@@ -76,5 +76,4 @@ overrides:
   boost:
     requires:
       - "GCC-Toolchain:(?!osx)"
-
 ---

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -76,5 +76,4 @@ overrides:
   boost:
     requires:
       - "GCC-Toolchain:(?!osx)"
-
 ---

--- a/epos-test.sh
+++ b/epos-test.sh
@@ -1,6 +1,6 @@
 package: EPOS-test
 version: v1
-force_rebuild: 1
+force_rebuild: true
 requires:
   - EPOS
 ---

--- a/epos-test.sh
+++ b/epos-test.sh
@@ -4,7 +4,7 @@ force_rebuild: true
 requires:
   - EPOS
 ---
-#!/bin/bash -ex
+#!/bin/bash -e
 export OPT=$PWD
 export CHK=$PWD
 cp "$EPO"/test/bp5nohnoc10n10f.optns .

--- a/evtgen.sh
+++ b/evtgen.sh
@@ -1,7 +1,7 @@
 package: EVTGEN
 version: "%(tag_basename)s"
 tag: "R02-02-00"
-source:  https://github.com/alisw/EVTGEN
+source: https://github.com/alisw/EVTGEN
 requires:
   - HepMC
   - pythia
@@ -11,7 +11,7 @@ build_requires:
   - alibuild-recipe-tools
   - "GCC-Toolchain:(?!osx)"
 env:
-   EVTGENDATA: "$EVTGEN_ROOT/share"
+  EVTGENDATA: "$EVTGEN_ROOT/share"
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' $SOURCEDIR/ ./

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -17,8 +17,9 @@ incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 prepend_path:
-  ROOT_INCLUDE_PATH: "$FAIRMQ_ROOT/include"
-  ROOT_INCLUDE_PATH: "$FAIRMQ_ROOT/include/fairmq"
+  ROOT_INCLUDE_PATH:
+    - "$FAIRMQ_ROOT/include"
+    - "$FAIRMQ_ROOT/include/fairmq"
 ---
 mkdir -p $INSTALLROOT
 

--- a/fairmq.sh
+++ b/fairmq.sh
@@ -3,16 +3,16 @@ version: "%(tag_basename)s"
 tag: v1.4.55
 source: https://github.com/FairRootGroup/FairMQ
 requires:
- - boost
- - FairLogger
- - ZeroMQ
- - asiofi
- - asio
+  - boost
+  - FairLogger
+  - ZeroMQ
+  - asiofi
+  - asio
 build_requires:
- - flatbuffers
- - CMake
- - "GCC-Toolchain:(?!osx)"
- - FairCMakeModules
+  - flatbuffers
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
+  - FairCMakeModules
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/geant-vmc-test.sh
+++ b/geant-vmc-test.sh
@@ -1,6 +1,6 @@
 package: GEANT-VMC-test
 version: "%(year)s%(month)s%(day)s"
-force_rebuild: 1
+force_rebuild: true
 requires:
   - GEANT4_VMC
   - geant3_vmc-examples

--- a/geant-vmc-test.sh
+++ b/geant-vmc-test.sh
@@ -5,7 +5,7 @@ requires:
   - GEANT4_VMC
   - geant3_vmc-examples
 ---
-#!/bin/sh
+#!/bin/bash -e
 
 g3vmc_testE01
 g3vmc_testE02

--- a/geant4.sh
+++ b/geant4.sh
@@ -1,7 +1,7 @@
 package: GEANT4
 version: "%(tag_basename)s"
 tag: "v11.0.3"
-#source: https://github.com/alisw/geant4.git
+# source: https://github.com/alisw/geant4.git
 source: https://gitlab.cern.ch/geant4/geant4.git
 requires:
   - "GCC-Toolchain:(?!osx)"
@@ -14,8 +14,7 @@ incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
 env:
-  G4INSTALL : $GEANT4_ROOT
-
+  G4INSTALL: $GEANT4_ROOT
 ---
 # If this variable is not defined default it to OFF
 : ${GEANT4_BUILD_MULTITHREADED:=OFF}

--- a/geant4.sh
+++ b/geant4.sh
@@ -9,7 +9,9 @@ build_requires:
   - CMake
   - "Xcode:(osx.*)"
 prepend_path:
-  ROOT_INCLUDE_PATH: "$GEANT4_ROOT/include:$GEANT4_ROOT/include/Geant4"
+  ROOT_INCLUDE_PATH:
+    - "$GEANT4_ROOT/include"
+    - "$GEANT4_ROOT/include/Geant4"
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/glog.sh
+++ b/glog.sh
@@ -2,9 +2,10 @@ package: glog
 version: v0.4.0
 source: https://github.com/google/glog
 build_requires:
- - "autotools:(slc6|slc7)"
- - "GCC-Toolchain:(?!osx)"
---- 
+  - "autotools:(slc6|slc7)"
+  - "GCC-Toolchain:(?!osx)"
+---
+#!/bin/bash -e
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .
 autoreconf -ivf
 ./configure --prefix="$INSTALLROOT"

--- a/grpc.sh
+++ b/grpc.sh
@@ -1,6 +1,6 @@
 package: grpc
 version: "%(tag_basename)s"
-tag:  v1.50.1
+tag: v1.50.1
 requires:
   - protobuf
   - c-ares

--- a/hijing.sh
+++ b/hijing.sh
@@ -7,7 +7,6 @@ requires:
   - GCC-Toolchain:(?!osx)
 build_requires:
   - CMake
-
 ---
 #!/bin/sh
 cmake ${SOURCEDIR}                           \

--- a/igprof-packaging.sh
+++ b/igprof-packaging.sh
@@ -5,7 +5,7 @@ force_rebuild: true
 requires:
   - IgProf
 ---
-#!/bin/sh
+#!/bin/bash -e
 mkdir -p igprof/usr libunwind/usr libatomic_ops/usr
 tar xzf /sw/TARS/$ARCHITECTURE/IgProf/IgProf-$IGPROF_VERSION-$IGPROF_REVISION.$ARCHITECTURE.tar.gz --strip-components=4 -C igprof/usr
 tar xzf /sw/TARS/$ARCHITECTURE/libunwind/libunwind-$LIBUNWIND_VERSION-$LIBUNWIND_REVISION.$ARCHITECTURE.tar.gz --strip-components=4 -C libunwind/usr

--- a/igprof-packaging.sh
+++ b/igprof-packaging.sh
@@ -1,7 +1,7 @@
 package: IgProf-packaging
 version: master
 source: https://github.com/alisw/ali-bot
-force_rebuild: 1
+force_rebuild: true
 requires:
   - IgProf
 ---

--- a/kernel-devel.sh
+++ b/kernel-devel.sh
@@ -7,5 +7,4 @@ system_requirement_missing: |
   * Ubuntu-compatible systems: Please install linux-headers-`uname -r` , libpci-dev, and libkmod-dev
 system_requirement: ".*"
 system_requirement_check: "find /usr/src -name kernel.h | grep include/linux/kernel.h  > /dev/null 2>&1 && ls /usr/include/libkmod.h  > /dev/null 2>&1 && find /usr/include -name pci.h | grep pci/pci.h  > /dev/null 2>&1"
-
 ---

--- a/looptools.sh
+++ b/looptools.sh
@@ -3,9 +3,9 @@ version: "%(tag_basename)s"
 tag: v2.16-alice1
 source: https://github.com/alisw/LoopTools
 requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
- - alibuild-recipe-tools
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 rsync -a $SOURCEDIR/ ./

--- a/looptools.sh
+++ b/looptools.sh
@@ -25,6 +25,5 @@ setenv LOOPTOOLS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(LOOPTOOLS_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(LOOPTOOLS_ROOT)/lib
 prepend-path LD_LIBRARY_PATH \$::env(LOOPTOOLS_ROOT)/lib64
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(LOOPTOOLS_ROOT)/lib: \$::env(LOOPTOOLS_ROOT)/lib64")
 EoF
 mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -11,7 +11,6 @@ build_requires:
   - CMake
   - alibuild-recipe-tools
 ---
-
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
           ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \

--- a/mesos-workqueue.sh
+++ b/mesos-workqueue.sh
@@ -3,13 +3,14 @@ version: 0.0.2-%(short_hash)s
 tag: master
 source: https://github.com/alisw/mesos-workqueue
 requires:
-- mesos
-- protobuf
-- boost
-- glog
+  - mesos
+  - protobuf
+  - boost
+  - glog
 build_requires:
-- CMake
---- 
+  - CMake
+---
+#!/bin/bash -e
 case $ARCHITECTURE in 
   osx*)
     [[ -z "$BOOST_ROOT" ]] && BOOST_ROOT=$(brew --prefix boost)

--- a/o2-full-system-test.sh
+++ b/o2-full-system-test.sh
@@ -7,7 +7,7 @@ requires:
   - O2sim
   - O2Physics
   - jq
-force_rebuild: 1
+force_rebuild: true
 ---
 #!/bin/bash -e
 

--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -5,7 +5,7 @@ requires:
   - o2codechecker
 build_requires:
   - CMake
-force_rebuild: 1
+force_rebuild: true
 ---
 #!/bin/bash -e
 

--- a/objcmp.sh
+++ b/objcmp.sh
@@ -8,7 +8,6 @@ requires:
 build_requires:
   - CMake
 ---
-
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
           ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \

--- a/openloops.sh
+++ b/openloops.sh
@@ -23,13 +23,11 @@ sed -i -e 's/max_string_length\ =\ 255/max_string_length\ =\ 1000/g' pyol/config
 JOBS=$((${JOBS:-1}*1/5))
 [[ $JOBS -gt 0 ]] || JOBS=1
 
-PROCESSES=(ppjj ppjj_ew ppjjj ppjjj_ew ppjjj_nf5 ppjjjj)
-for proc in ${PROCESSES[@]}; do
+for proc in ppjj ppjj_ew ppjjj ppjjj_ew ppjjj_nf5 ppjjjj; do
     ./scons --jobs=$JOBS auto="$proc"  
 done
 
-INSTALL=(examples include lib openloops proclib pyol)
-for inst in ${INSTALL[@]}; do
+for inst in examples include lib openloops proclib pyol; do
     cp -r $inst $INSTALLROOT/
 done
 

--- a/openmp.sh
+++ b/openmp.sh
@@ -1,5 +1,5 @@
 package: openmp
-version: 1.0
+version: '1.0'
 system_requirement_missing: |
   Please install openmp (libomp) on your system:
     * On MacOS systems: brew install libomp

--- a/parquet-cpp.sh
+++ b/parquet-cpp.sh
@@ -2,13 +2,12 @@ package: parquet-cpp
 version: release-0.1-rc0
 source: https://github.com/apache/parquet-cpp
 build_requires:
-- protobuf
-- snappy
-- zlib
-- thrift
-build_requires:
-- CMake
-- googletest
+  - protobuf
+  - snappy
+  - zlib
+  - thrift
+  - CMake
+  - googletest
 ---
 
 export THRIFT_HOME=$(brew --prefix thrift)

--- a/pda.sh
+++ b/pda.sh
@@ -7,9 +7,8 @@ requires:
 build_requires:
   - kernel-devel
   - "autotools:(slc6|slc7)"
-
---- 
-#!/bin/sh
+---
+#!/bin/bash -e
 
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 ./configure --debug=false --numa=true --modprobe=true --prefix=$INSTALLROOT

--- a/rivet-test.sh
+++ b/rivet-test.sh
@@ -1,6 +1,6 @@
 package: Rivet-test
 version: v1
-force_rebuild: 1
+force_rebuild: true
 requires:
   - ThePEG
   - Rivet

--- a/rivet-test.sh
+++ b/rivet-test.sh
@@ -5,7 +5,7 @@ requires:
   - ThePEG
   - Rivet
 ---
-#!/bin/bash
+#!/bin/bash -e
 cat > DIPSYpp_HepMC.in <<\EOF
 read Tune27.in
 cd /DIPSY

--- a/rivettask.sh
+++ b/rivettask.sh
@@ -3,7 +3,7 @@ version: "%{year}s%{month}s%{day}s"
 source: https://gitlab.cern.ch/cholm/alice-rivet-task
 requires:
   - Rivet
-  - AliRoot 
+  - AliRoot
 build_requires:
   - GCC-Toolchain:(?!osx)
   - alibuild-recipe-tools

--- a/rivettask.sh
+++ b/rivettask.sh
@@ -1,5 +1,5 @@
 package: RivetTask
-version: "%{year}s%{month}s%{day}s"
+version: "%(year)s%(month)s%(day)s"
 source: https://gitlab.cern.ch/cholm/alice-rivet-task
 requires:
   - Rivet

--- a/swig.sh
+++ b/swig.sh
@@ -14,7 +14,7 @@ prefer_system_check: |
       [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
   }
   # Check for swig 3.0.12 or later
-  which swig && verge 3.0.12 $(swig -version | grep Version | sed -e 's/[^0-9]*//') 
+  which swig && verge 3.0.12 $(swig -version | grep Version | sed -e 's/[^0-9]*//')
 ---
 #!/bin/sh
 rsync -av --delete --exclude '**/.git' $SOURCEDIR/ .

--- a/template-recipe.sh
+++ b/template-recipe.sh
@@ -2,7 +2,7 @@ package: MyGenerator
 version: "v1.0.0"
 source: https://github.com/alisw/MyGenerator
 requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
 ---

--- a/template-recipe.sh
+++ b/template-recipe.sh
@@ -1,4 +1,4 @@
-package: MyGenerator
+package: Template-Recipe   # e.g. MyGenerator
 version: "v1.0.0"
 source: https://github.com/alisw/MyGenerator
 requires:

--- a/thepeg-test.sh
+++ b/thepeg-test.sh
@@ -4,7 +4,7 @@ force_rebuild: true
 requires:
   - ThePEG
 ---
-#!/bin/bash
+#!/bin/bash -e
 cat > DIPSYpp_HepMC.in <<\EOF
 read Tune27.in
 cd /DIPSY

--- a/thepeg-test.sh
+++ b/thepeg-test.sh
@@ -1,6 +1,6 @@
 package: ThePEG-test
 version: v1
-force_rebuild: 1
+force_rebuild: true
 requires:
   - ThePEG
 ---

--- a/vecgeom.sh
+++ b/vecgeom.sh
@@ -10,7 +10,6 @@ build_requires:
   - CMake
   - ninja
 ---
-
 #!/bin/bash -e
 case $ARCHITECTURE in
     osx_arm64)

--- a/zlib-cloudflare.sh
+++ b/zlib-cloudflare.sh
@@ -3,11 +3,11 @@ version: "%(tag_basename)s"
 tag: gcc.amd64
 source: https://github.com/cloudflare/zlib/
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
- - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
 ---
-#!/bin/sh
+#!/bin/bash -e
 
 echo "Building optimized zlib"
 
@@ -18,7 +18,5 @@ cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --lib > $MODULEFILE
-cat >> "$MODULEFILE" <<EOF
+alibuild-generate-module --lib > "$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
This fixes errors in alidist recipes that would be found by the linter in https://github.com/alisw/alidist/pull/4730.

I expect these changes won't be controversial, as it's mostly just whitespace and formatting fixes in YAML headers. However, there are a few formatting and syntax fixes for recipes, too.

See individual commits for details and rationale of individual changes.