### PR TITLE
XRootD update to 5.5.2

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.5.0"
+tag: "v5.5.2"
 source: https://github.com/xrootd/xrootd
 requires:
  - "OpenSSL:(?!osx)"


### PR DESCRIPTION
[Release notes](https://github.com/xrootd/xrootd/blob/v5.5.2/docs/ReleaseNotes.txt)
Detailed commit list relative to 5.5.0 [here](https://github.com/xrootd/xrootd/compare/v5.5.0...v5.5.2)