### PR TITLE
Bump geant3 to v4.2

### DIFF
--- a/geant3.sh
+++ b/geant3.sh
@@ -1,6 +1,6 @@
 package: GEANT3
 version: "%(tag_basename)s"
-tag: v4-1
+tag: v4-2
 requires:
   - ROOT
   - VMC


### PR DESCRIPTION
Includes fix of a segmentation violation observed on MacOSX with M1/M2 processors with AliRoot (https://github.com/vmc-project/geant3/pull/40)