### PR TITLE
jq: do not load GCC runtime

### DIFF
--- a/jq.sh
+++ b/jq.sh
@@ -36,8 +36,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0                                                                        \\
-       ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+module load BASE/1.0                                                                       
 # Our environment
 set JQ_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$JQ_ROOT/bin


### PR DESCRIPTION
There is no need for it and it can only break things if jq is loaded together with something which used a different GCC version.