### PR TITLE
Point test to source dir

### DIFF
--- a/o2dpg-sim-tests.sh
+++ b/o2dpg-sim-tests.sh
@@ -17,7 +17,7 @@ pushd $BUILDDIR/o2dpg-sim_tests
 LOGFILE="o2dpg-sim-tests.log"
 
 O2DPG_TEST_EXITCODE=0
-{ "${O2DPG_ROOT}/test/run_tests.sh" &> ${LOGFILE} ; O2DPG_TEST_EXITCODE=$?; } || true  # don't quit immediately on error
+{ O2DPG_TEST_REPO_DIR=${SOURCEDIR} "${O2DPG_ROOT}/test/run_tests.sh" &> ${LOGFILE} ; O2DPG_TEST_EXITCODE=$?; } || true  # don't quit immediately on error
 if [ ${O2DPG_TEST_EXITCODE} != "0" ] ; then
   # something is wrong
   echo "error detected in ${PKGNAME}"


### PR DESCRIPTION
* in the source dir there is the entire git repo (.git)

* from there it is possible to collect based on
  * ALIBUILD_HEAD_HASH
  * ALIBUILD_BASE_HASH

* all tests will be executed in the build dir while the source dir will stay untouched