### PR TITLE
Disable libfabric backends pulling in infiniband verbs or RDMA

### DIFF
--- a/ofi.sh
+++ b/ofi.sh
@@ -12,7 +12,7 @@ prefer_system_check: |
 ---
 rsync -a --exclude='**/.git' --delete --delete-excluded "$SOURCEDIR/" ./
 autoreconf -ivf
-./configure --prefix="$INSTALLROOT" --enable-mlx=no
+./configure --prefix="$INSTALLROOT" --enable-mlx=no --enable-verbs=no --enable-efa=no --enable-usnic=no --enable-psm2=no --enable-psm3=no
 make ${JOBS:+-j $JOBS} install
 
 # Modulefile


### PR DESCRIPTION
@ktf @chiarazampolli : This removes the libibverbs and librdmacm dependencies for me.