### PR TITLE
modulefile for libunwind

### DIFF
--- a/libunwind.sh
+++ b/libunwind.sh
@@ -3,6 +3,7 @@ version: v1.6.2
 source: http://github.com/libunwind/libunwind
 build_requires:
   - libatomic_ops
+  - alibuild-recipe-tools
 ---
 #!/bin/sh
 (cd $SOURCEDIR && autoreconf -i)
@@ -14,3 +15,8 @@ $SOURCEDIR/configure \
 
 make ${JOBS+-j $JOBS}
 make install
+
+# Modulefile
+mkdir -p etc/modulefiles
+alibuild-generate-module --lib > etc/modulefiles/$PKGNAME
+mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
This is needed so that

`alienv enter IgProf`

correctly works (loading also the necessary libunwind dependency).