### PR TITLE
Add the ACTS recipe

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,0 +1,33 @@
+package: ACTS
+version: v23.4.0
+build_requires:
+    - "GCC-Toolchain:(?!osx)"
+    - CMake
+    - boost
+source: https://github.com/acts-project/acts.git
+---
+#!/bin/bash -ex
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
+                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
+                 -DCMAKE_SKIP_RPATH=TRUE
+cmake --build . -- ${JOBS:+-j$JOBS}
+
+#ModuleFile
+mkdir -p etc/modulefiles
+cat > etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# ACTS environment
+set ACTS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv ACTS_ROOT \$ACTS_ROOT
+
+prepend-path PATH \$ACTS_ROOT/bin
+prepend-path LD_LIBRARY_PATH \$ACTS_ROOT/lib
+prepend-path LD_LIBRARY_PATH \$ACTS_ROOT/lib64
+prepend-path ROOT_INCLUDE_PATH \$ACTS_ROOT/include
+EoF

--- a/eigen3.sh
+++ b/eigen3.sh
@@ -1,0 +1,12 @@
+package: Eigen3
+version: 3.4.0
+build_requires:
+    - "GCC-Toolchain:(?!osx)"
+    - CMake
+source: https://gitlab.com/libeigen/eigen.git
+---
+#!/bin/bash -ex
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
+                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
+                 -DCMAKE_SKIP_RPATH=TRUE
+cmake --build . -- ${JOBS:+-j$JOBS} install


### PR DESCRIPTION
This work in progress PR adds a recipe to build ACTS, currently it's core libraries, using aliBuild. 
Requires a locally installed [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) package. Currently the environment is failed to enter after the build.
Adding @mconcas for the discussion.