### PR TITLE
Fix linter errors that don't change hashes

### DIFF
--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -11,7 +11,6 @@ build_requires:
   - CMake
   - alibuild-recipe-tools
 ---
-
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
           ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \

--- a/o2dpg-sim-tests.sh
+++ b/o2dpg-sim-tests.sh
@@ -2,7 +2,7 @@ package: O2DPG-sim-tests
 version: "1.0"
 requires:
   - O2sim
-force_rebuild: 1
+force_rebuild: true
 ---
 #!/bin/bash -e
 

--- a/objcmp.sh
+++ b/objcmp.sh
@@ -8,7 +8,6 @@ requires:
 build_requires:
   - CMake
 ---
-
 #!/bin/bash -e
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
           ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \

--- a/vecgeom.sh
+++ b/vecgeom.sh
@@ -10,7 +10,6 @@ build_requires:
   - CMake
   - ninja
 ---
-
 #!/bin/bash -e
 case $ARCHITECTURE in
     osx_arm64)


### PR DESCRIPTION
aliBuild strips newlines off recipes, so removing the empty line at the start (to get the shebang in the right place) is harmless.

`force_rebuild` should be a boolean, and changing it doesn't matter as the recipe is rebuilt every time anyway.

Needed for #4730.