### PR TITLE
Bump Codechecker to be compatible to LLVM 15

### DIFF
--- a/o2codechecker.sh
+++ b/o2codechecker.sh
@@ -1,6 +1,6 @@
 package: o2codechecker
-version: v13.0
-tag: v13.0
+version: v15.0
+tag: v15.0
 requires:
   - Clang:(?!osx*)
 build_requires:


### PR DESCRIPTION
force-merging since currently broken after LLVM bump