### PR TITLE
Fix typo in readout recipe

### DIFF
--- a/readout.sh
+++ b/readout.sh
@@ -51,7 +51,7 @@ cmake $SOURCEDIR                                                         \
       ${LZ4_ROOT:+-DLZ4_DIR=$LZ4_ROOT}                                   \
       ${CONTROL_OCCPLUGIN_REVISION:+-DOcc_ROOT=$CONTROL_OCCPLUGIN_ROOT}   \
       ${ZEROMQ_ROOT:+-DZMQ_ROOT=$ZEROMQ_ROOT}                             \
-      ${BOOKKEEPINGAPI_REVISION:+-DBookkeepingApi_ROOT=$BOOKKEEPINGAPI_ROOT} \
+      ${BOOKKEEPING_API_REVISION:+-DBookkeepingApi_ROOT=$BOOKKEEPINGAPI_ROOT} \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                  \
       -DBUILD_SHARED_LIBS=ON
 

--- a/readout.sh
+++ b/readout.sh
@@ -51,7 +51,7 @@ cmake $SOURCEDIR                                                         \
       ${LZ4_ROOT:+-DLZ4_DIR=$LZ4_ROOT}                                   \
       ${CONTROL_OCCPLUGIN_REVISION:+-DOcc_ROOT=$CONTROL_OCCPLUGIN_ROOT}   \
       ${ZEROMQ_ROOT:+-DZMQ_ROOT=$ZEROMQ_ROOT}                             \
-      ${BOOKKEEPINGAPI_REVISION:+-DBookeepingApi_ROOT=$BOOKKEEPINGAPI_ROOT} \
+      ${BOOKKEEPINGAPI_REVISION:+-DBookkeepingApi_ROOT=$BOOKKEEPINGAPI_ROOT} \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                  \
       -DBUILD_SHARED_LIBS=ON
 


### PR DESCRIPTION
Fix `bookkeeping` typo in readout recipe
