### PR TITLE
Add explicit flatbuffers dependency to ODC

### DIFF
--- a/odc.sh
+++ b/odc.sh
@@ -4,14 +4,15 @@ version: "%(tag_basename)s"
 tag: "0.77.0"
 source: https://github.com/FairRootGroup/ODC.git
 requires:
-- boost
-- protobuf
-- DDS
-- FairLogger
-- FairMQ
-- grpc
-- libInfoLogger
+  - boost
+  - protobuf
+  - DDS
+  - FairLogger
+  - FairMQ
+  - grpc
+  - libInfoLogger
 build_requires:
+  - flatbuffers
   - CMake
   - GCC-Toolchain:(?!osx.*)
 ---


### PR DESCRIPTION
#4882 removed flatbuffers as a FairMQ dependency, but it is apparently needed for ODC. Not sure why the CI on #4882 didn't catch this.