### PR TITLE
Build the ACTS example framework

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,5 +1,8 @@
 package: ACTS
 version: v23.4.0
+requires:
+    - ROOT
+    - pythia
 build_requires:
     - "GCC-Toolchain:(?!osx)"
     - CMake
@@ -12,7 +15,12 @@ source: https://github.com/acts-project/acts.git
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
                  -DCMAKE_SKIP_RPATH=TRUE                   \
-                 -DACTS_BUILD_EXAMPLES=OFF
+                 -DACTS_BUILD_FATRAS=ON                    \
+                 -DACTS_BUILD_EXAMPLES=ON                  \
+                 -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON  \
+                 -DACTS_BUILD_EXAMPLES_PYTHIA8=ON          \
+                 -DCMAKE_PREFIX_PATH=${PYTHIA_ROOT}
+
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 


### PR DESCRIPTION
This PR extends the #4856 in order to build the ACTS example framework and selected examples. 
Tagging @mconcas and @sawenzel: I added the required 
```
-DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
-DACTS_BUILD_FATRAS=ON
```
w.r.t. to the config in the email exchange which should work out of the box.