### PR TITLE
Bookkeeping api requires protobuf

### DIFF
--- a/bookkeeping-api.sh
+++ b/bookkeeping-api.sh
@@ -3,6 +3,7 @@ version: "v0.49.1"
 tag: "@aliceo2/bookkeeping@0.49.1"
 requires:
   - grpc
+  - protobuf
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - CMake


### PR DESCRIPTION
doesn't compile without for me, no idea why it works in the CI.
But the bookkeeping API Cmake clearly needs protobuf