### PR TITLE
[ALIROOT-8833] Re-enable debug info for AliRoot and AliPhysics

### DIFF
--- a/aliphysics.sh
+++ b/aliphysics.sh
@@ -57,7 +57,7 @@ if [[ ! $CMAKE_GENERATOR && $DISABLE_NINJA != 1 && $DEVEL_SOURCES != $SOURCEDIR 
 fi
 
 cmake "$SOURCEDIR"                                                 \
-      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"                \
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error -g"             \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                        \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                           \
       -DROOTSYS="$ROOT_ROOT"                                       \

--- a/aliroot.sh
+++ b/aliroot.sh
@@ -75,7 +75,7 @@ if [[ ! $CMAKE_GENERATOR && $DISABLE_NINJA != 1 && $DEVEL_SOURCES != $SOURCEDIR 
 fi
 
 cmake $SOURCEDIR                                                     \
-      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"                  \
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error -g"               \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                          \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                             \
       -DCMAKE_Fortran_COMPILER=gfortran                              \


### PR DESCRIPTION
The move from `next-root6` defaults to `o2` defaults changed the default `CXXFLAGS` variable, specifically removing the `-g` option. This option is responsible for adding debug information to the resulting binaries. Apparently CMake doesn't add it, even when specifying `CMAKE_BUILD_TYPE=RELWITHDEBINFO`, if it's not there. This has made debugging segfaults in analysis trains more difficult.