### PR TITLE
Fix linter messages that cause no hash change

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,14 +1,14 @@
 package: ACTS
 version: v23.4.0
 requires:
-    - ROOT
-    - pythia
+  - ROOT
+  - pythia
 build_requires:
-    - "GCC-Toolchain:(?!osx)"
-    - CMake
-    - boost
-    - Eigen3
-    - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - boost
+  - Eigen3
+  - alibuild-recipe-tools
 source: https://github.com/acts-project/acts.git
 ---
 #!/bin/bash -ex

--- a/alien-runtime.sh
+++ b/alien-runtime.sh
@@ -1,17 +1,17 @@
 package: AliEn-Runtime
 version: "v2-19-le"
 requires:
- - "GCC-Toolchain:(?!osx)"
- - "Xcode:(osx.*)"
+  - "GCC-Toolchain:(?!osx)"
+  - "Xcode:(osx.*)"
 build_requires:
- - zlib
- - libxml2
- - "OpenSSL:(?!osx)"
- - "osx-system-openssl:(osx.*)"
- - AliEn-CAs
- - ApMon-CPP
- - UUID
- - alibuild-recipe-tools
+  - zlib
+  - libxml2
+  - "OpenSSL:(?!osx)"
+  - "osx-system-openssl:(osx.*)"
+  - AliEn-CAs
+  - ApMon-CPP
+  - UUID
+  - alibuild-recipe-tools
 env:
   X509_CERT_DIR: "$ALIEN_RUNTIME_ROOT/globus/share/certificates"
 ---

--- a/alien-workqueue.sh
+++ b/alien-workqueue.sh
@@ -2,10 +2,10 @@ package: AliEn-WorkQueue
 version: v1.3
 source: https://github.com/alisw/alien-workqueue
 requires:
- - "GCC-Toolchain:(?!osx)"
- - cctools
+  - "GCC-Toolchain:(?!osx)"
+  - cctools
 build_requires:
- - CMake
+  - CMake
 ---
 #!/bin/bash -e
 cmake $SOURCEDIR                          \

--- a/ampt.sh
+++ b/ampt.sh
@@ -3,8 +3,8 @@ version: "%(tag_basename)s"
 tag: "v1.26t7b-v2.26t7b-alice1"
 source: https://github.com/alisw/ampt
 requires:
- - "GCC-Toolchain:(?!osx)"
- - HepMC
+  - "GCC-Toolchain:(?!osx)"
+  - HepMC
 ---
 #!/bin/bash -e
 

--- a/apmon-cpp.sh
+++ b/apmon-cpp.sh
@@ -3,9 +3,9 @@ version: "%(tag_basename)s"
 tag: v2.2.8-alice5
 source: https://github.com/alisw/apmon-cpp.git
 build_requires:
- - "libtirpc:(?!osx)"
- - "autotools:(slc6|slc7)"
- - "GCC-Toolchain:(?!osx)"
+  - "libtirpc:(?!osx)"
+  - "autotools:(slc6|slc7)"
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
 rsync -a --exclude='**/.git' --delete --delete-excluded \

--- a/bz2.sh
+++ b/bz2.sh
@@ -3,7 +3,7 @@ version: "1.0.8"
 tag: 8ca1faa31f396d94ab927b257f3a05236c84e330
 source: https://github.com/alisw/bzip2
 build_requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <bzlib.h>\n" | c++ -xc++ - -c -o /dev/null

--- a/cctools.sh
+++ b/cctools.sh
@@ -2,10 +2,10 @@ package: cctools
 version: v5.4.17-alice2
 source: https://github.com/alisw/cctools
 requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
- - zlib
- - SWIG
+  - zlib
+  - SWIG
 ---
 #!/bin/bash
 rsync -a --delete --exclude "**/.git" $SOURCEDIR/ .

--- a/clhep.sh
+++ b/clhep.sh
@@ -1,7 +1,7 @@
 package: CLHEP
 version: "2.2.0.8"
-source: https://github.com/alisw/clhep
 tag: CLHEP_2_2_0_8
+source: https://github.com/alisw/clhep
 build_requires:
   - CMake
 ---

--- a/cmake.sh
+++ b/cmake.sh
@@ -3,11 +3,11 @@ version: "%(tag_basename)s"
 tag: "v3.23.1"
 source: https://github.com/Kitware/CMake
 requires:
- - "OpenSSL:(?!osx)"
- - "GCC-Toolchain:(?!osx)"
+  - "OpenSSL:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
- - make
- - alibuild-recipe-tools
+  - make
+  - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
   verge() { [[  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]]; }

--- a/cpprestsdk.sh
+++ b/cpprestsdk.sh
@@ -3,10 +3,10 @@ version: v2.10.18
 tag: 2.10.18
 source: https://github.com/Microsoft/cpprestsdk
 requires:
-- boost
-- OpenSSL:(?!osx)
+  - boost
+  - OpenSSL:(?!osx)
 build_requires:
-- CMake
+  - CMake
 ---
 #!/bin/sh
 

--- a/curl.sh
+++ b/curl.sh
@@ -3,9 +3,9 @@ version: "7.70.0"
 tag: curl-7_70_0
 source: https://github.com/curl/curl.git
 build_requires:
- - "OpenSSL:(?!osx)"
- - CMake
- - alibuild-recipe-tools
+  - "OpenSSL:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 

--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -8,8 +8,8 @@ env:
   CXXFLAGS: -fPIC -g -O2 -std=c++14
 overrides:
   GCC-Toolchain:
-    tag: v12.2.0-alice1
     version: v12.2.0-alice1
+    tag: v12.2.0-alice1
   boost:
     requires:
       - GCC-Toolchain:(?!osx)

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -28,8 +28,8 @@ overrides:
       - ZeroMQ
       - JAliEn-ROOT
   GCC-Toolchain:
-    tag: v12.2.0-alice1
     version: v12.2.0-alice1
+    tag: v12.2.0-alice1
   cgal:
     version: 4.12.2
   fastjet:

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -26,8 +26,8 @@ overrides:
       - ZeroMQ
       - JAliEn-ROOT
   GCC-Toolchain:
-    tag: v12.2.0-alice1
     version: v12.2.0-alice1
+    tag: v12.2.0-alice1
   cgal:
     version: 4.12.2
   fastjet:

--- a/delphes.sh
+++ b/delphes.sh
@@ -9,9 +9,9 @@ build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
 source: https://github.com/alisw/delphes.git
-#prepend_path:
-#  LD_LIBRARY_PATH: "$O2_ROOT/lib"
-#  ROOT_INCLUDE_PATH: "$O2_ROOT/include"
+# prepend_path:
+#   LD_LIBRARY_PATH: "$DELPHES_ROOT/lib"
+#   ROOT_INCLUDE_PATH: "$DELPHES_ROOT/include"
 ---
 #!/bin/bash -ex
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \

--- a/dpmjet.sh
+++ b/dpmjet.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "v19.1.2-alice3"
 source: https://github.com/alisw/DPMJET.git
 requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
   - "Xcode:(osx.*)"

--- a/eigen3.sh
+++ b/eigen3.sh
@@ -1,8 +1,8 @@
 package: Eigen3
 version: 3.4.0
 build_requires:
-    - "GCC-Toolchain:(?!osx)"
-    - CMake
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
 source: https://gitlab.com/libeigen/eigen.git
 ---
 #!/bin/bash -ex

--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -3,10 +3,10 @@ version: "%(tag_basename)s"
 tag: v1.11.1
 source: https://github.com/FairRootGroup/FairLogger
 requires:
- - fmt
+  - fmt
 build_requires:
- - CMake
- - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -13,7 +13,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 env:
   VMCWORKDIR: "$FAIRROOT_ROOT/share/fairbase/examples"
-  GEOMPATH:   "$FAIRROOT_ROOT/share/fairbase/examples/common/geometry"
+  GEOMPATH: "$FAIRROOT_ROOT/share/fairbase/examples/common/geometry"
   CONFIG_DIR: "$FAIRROOT_ROOT/share/fairbase/examples/common/gconfig"
 prepend_path:
   ROOT_INCLUDE_PATH: "$FAIRROOT_ROOT/include"

--- a/flatbuffers.sh
+++ b/flatbuffers.sh
@@ -4,8 +4,8 @@ source: https://github.com/google/flatbuffers
 requires:
   - zlib
 build_requires:
- - CMake
- - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 cmake $SOURCEDIR                          \
       -G "Unix Makefiles"                 \

--- a/gmp.sh
+++ b/gmp.sh
@@ -3,7 +3,7 @@ version: v6.2.1
 tag: v6.2.1
 source: https://github.com/alisw/GMP.git
 requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/sh
 case $ARCHITECTURE in

--- a/googlebenchmark.sh
+++ b/googlebenchmark.sh
@@ -3,10 +3,10 @@ version: "1.6.1"
 tag: v1.6.1
 source: https://github.com/google/benchmark
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
- - ninja
- - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - ninja
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 cmake $SOURCEDIR                           \

--- a/googletest.sh
+++ b/googletest.sh
@@ -3,8 +3,8 @@ version: "1.8.0"
 source: https://github.com/google/googletest
 tag: release-1.8.0
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
 ---
 #!/bin/sh
 cmake $SOURCEDIR                           \

--- a/googletest.sh
+++ b/googletest.sh
@@ -1,7 +1,7 @@
 package: googletest
 version: "1.8.0"
-source: https://github.com/google/googletest
 tag: release-1.8.0
+source: https://github.com/google/googletest
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - CMake

--- a/igprof.sh
+++ b/igprof.sh
@@ -1,7 +1,7 @@
 package: IgProf
 version: 5.9.18
-source: http://github.com/igprof/igprof.git
 tag: v5.9.18
+source: http://github.com/igprof/igprof.git
 requires:
   - libunwind
 build_requires:

--- a/jalien.sh
+++ b/jalien.sh
@@ -3,13 +3,13 @@ version: "%(tag_basename)s"
 tag: "1.7.0"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
- - JDK
- - XRootD
- - xjalienfs
- - curl
+  - JDK
+  - XRootD
+  - xjalienfs
+  - curl
 valid_defaults:
- - jalien
- - o2
+  - jalien
+  - o2
 ---
 #!/bin/bash -e
 

--- a/jemalloc.sh
+++ b/jemalloc.sh
@@ -3,8 +3,8 @@ version: "v%(commit_hash)s"
 tag: 5.1.0
 source: https://github.com/jemalloc/jemalloc
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - "autotools:(slc6|slc7)"
+  - "GCC-Toolchain:(?!osx)"
+  - "autotools:(slc6|slc7)"
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude "**/.git" $SOURCEDIR/ .

--- a/lhapdf-pdfsets.sh
+++ b/lhapdf-pdfsets.sh
@@ -1,8 +1,8 @@
 package: lhapdf-pdfsets
 version: "v%(year)s"
 build_requires:
- - lhapdf
- - curl
+  - lhapdf
+  - curl
 ---
 #!/bin/bash -ex
 

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -3,11 +3,11 @@ version: "%(tag_basename)s"
 tag: v6.2.1-alice2
 source: https://github.com/alisw/LHAPDF
 requires:
- - "Python:slc.*"
- - "Python-system:(?!slc.*)"
- - "GCC-Toolchain:(?!osx)"
+  - "Python:slc.*"
+  - "Python-system:(?!slc.*)"
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
- - "autotools:(slc6|slc7)"
+  - "autotools:(slc6|slc7)"
 prepend_path:
   PYTHONPATH: $LHAPDF_ROOT/lib/python/site-packages
 ---

--- a/libatomic_ops.sh
+++ b/libatomic_ops.sh
@@ -1,7 +1,7 @@
 package: libatomic_ops
 version: libatomic_ops-7_4_2
-source: https://github.com/ivmai/libatomic_ops/
 tag: master
+source: https://github.com/ivmai/libatomic_ops/
 build_requires:
   - "autotools:(slc6|slc7)"
   - GCC-Toolchain

--- a/libffi.sh
+++ b/libffi.sh
@@ -1,8 +1,8 @@
 package: libffi
 version: v3.2.1
 build_requires:
- - "autotools:(slc6|slc7)"
- - "GCC-Toolchain:(?!osx)"
+  - "autotools:(slc6|slc7)"
+  - "GCC-Toolchain:(?!osx)"
 source: https://github.com/libffi/libffi
 prepend_path:
   LD_LIBRARY_PATH: "$LIBFFI_ROOT/lib64"

--- a/libpng.sh
+++ b/libpng.sh
@@ -1,9 +1,9 @@
 package: libpng
 version: v1.6.34
 requires:
- - zlib
+  - zlib
 build_requires:
- - CMake
+  - CMake
 source: https://github.com/alisw/libpng
 prefer_system: (?!slc5)
 prefer_system_check: |

--- a/lz4.sh
+++ b/lz4.sh
@@ -3,9 +3,9 @@ version: "%(tag_basename)s"
 tag: v1.9.3
 source: https://github.com/lz4/lz4
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
- - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
 prefer_system: ".*"
 prefer_system_check: |
   printf "#include <lz4.h>\n" | cc -xc -I$(brew --prefix lz4)/include - -c -M 2>&1

--- a/madgraph.sh
+++ b/madgraph.sh
@@ -3,8 +3,8 @@ version: "%(tag_basename)s"
 tag: "v2.8.1"
 source: https://github.com/alisw/MadGraph
 requires:
- - "Python:slc.*"
- - "Python-system:(?!slc.*)"
+  - "Python:slc.*"
+  - "Python-system:(?!slc.*)"
 build_requires:
   - alibuild-recipe-tools
 ---

--- a/mesos-dds.sh
+++ b/mesos-dds.sh
@@ -2,14 +2,14 @@ package: mesos-dds
 version: master
 source: https://github.com/alisw/mesos-dds
 requires:
-- mesos
-- protobuf
-- boost
-- glog
-- cpprestsdk
-- DDS
+  - mesos
+  - protobuf
+  - boost
+  - glog
+  - cpprestsdk
+  - DDS
 build_requires:
-- CMake
+  - CMake
 tag: master
 ---
 #!/bin/sh

--- a/mesos-dds.sh
+++ b/mesos-dds.sh
@@ -1,5 +1,6 @@
 package: mesos-dds
 version: master
+tag: master
 source: https://github.com/alisw/mesos-dds
 requires:
   - mesos
@@ -10,7 +11,6 @@ requires:
   - DDS
 build_requires:
   - CMake
-tag: master
 ---
 #!/bin/sh
 

--- a/mesos.sh
+++ b/mesos.sh
@@ -3,23 +3,23 @@ version: v1.11.0
 tag: 1.11.0-alice1
 source: https://github.com/AliceO2Group/mesos.git
 requires:
-- zlib
-- glog
-- grpc
-- RapidJSON
-- system-apr
-- system-apr-util
-- system-cyrus-sasl
-- system-subversion
-# We specifically CANNOT build against our own curl and OpenSSL on slc8, as
-# those conflict with system-cyrus-sasl.
-# - curl
-# - OpenSSL
+  - zlib
+  - glog
+  - grpc
+  - RapidJSON
+  - system-apr
+  - system-apr-util
+  - system-cyrus-sasl
+  - system-subversion
+  # We specifically CANNOT build against our own curl and OpenSSL on slc8, as
+  # those conflict with system-cyrus-sasl.
+  # - curl
+  # - OpenSSL
 build_requires:
-- "autotools:(slc6|slc7|slc8)"
-- protobuf
-- Python-modules:(?!osx_arm64)
-- abseil
+  - "autotools:(slc6|slc7|slc8)"
+  - protobuf
+  - Python-modules:(?!osx_arm64)
+  - abseil
 prepend_path:
   PATH: "$MESOS_ROOT/sbin"
   PYTHONPATH: $MESOS_ROOT/lib/python2.7/site-packages

--- a/millepede-ii.sh
+++ b/millepede-ii.sh
@@ -3,12 +3,12 @@ version: "%(tag_basename)s"
 tag: "V04-12-01"
 source: https://gitlab.desy.de/claus.kleinwort/millepede-ii.git
 requires:
- - zlib
- - openmp
- - OpenBLAS
- - "GCC-Toolchain:(?!osx)"
+  - zlib
+  - openmp
+  - OpenBLAS
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
- - alibuild-recipe-tools
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 

--- a/mlmodels.sh
+++ b/mlmodels.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "20220530"
 source: https://github.com/alisw/MLModels.git
 build_requires:
- - alibuild-recipe-tools
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 

--- a/monalisa.sh
+++ b/monalisa.sh
@@ -1,10 +1,10 @@
 package: MonALISA
 version: "20221109"
 requires:
- - JDK
+  - JDK
 build_requires:
- - curl
- - alibuild-recipe-tools
+  - curl
+  - alibuild-recipe-tools
 ---
 curl http://alimonitor.cern.ch/download/MonaLisa/MonaLisa-${PKGVERSION}.tar.gz | tar xz --strip-components 1 -C $INSTALLROOT
 

--- a/msgpack.sh
+++ b/msgpack.sh
@@ -3,8 +3,8 @@ version: v3.1.1
 tag: cpp-3.1.1
 source: https://github.com/msgpack/msgpack-c
 build_requires:
- - CMake
- - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <msgpack/version.hpp>\n#define VERSION (MSGPACK_VERSION_MAJOR * 10000) + (MSGPACK_VERSION_MINOR * 100) + MSGPACK_VERSION_REVISION\n#if(VERSION < 20105)\n#error \"msgpack version >= 2.1.5 needed\"\n#endif\nint main(){}" | c++ -I$(brew --prefix msgpack)/include -xc++ -std=c++11 - -o /dev/null

--- a/ninja.sh
+++ b/ninja.sh
@@ -3,7 +3,7 @@ version: "fortran-%(short_hash)s"
 tag: "v1.8.2.g3bbbe.kitware.dyndep-1.jobserver-1"
 source: https://github.com/Kitware/ninja
 build_requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 ---
 python3 $SOURCEDIR/configure.py --bootstrap
 

--- a/ocdb-test.sh
+++ b/ocdb-test.sh
@@ -1,12 +1,12 @@
 package: OCDB-test
 version: "%(short_hash)s"
+tag: v5-08-19
 requires:
   - ROOT
 env:
   ALICE_ROOT: "$ALIROOT_ROOT"
 source: http://git.cern.ch/pub/AliRoot
 write_repo: https://git.cern.ch/reps/AliRoot
-tag: v5-08-19
 ---
 #!/bin/sh
 rsync -av $SOURCEDIR/OCDB/ $INSTALLROOT/

--- a/odc.sh
+++ b/odc.sh
@@ -1,4 +1,4 @@
-#Online Device Control
+# Online Device Control
 package: ODC
 version: "%(tag_basename)s"
 tag: "0.77.0"

--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -10,7 +10,7 @@ requires:
 build_requires:
   - CMake
   - alibuild-recipe-tools
-  - "Python:(slc|ubuntu)" # onnx which is builded by the package requires Python
+  - "Python:(slc|ubuntu)"  # this package builds ONNX, which requires Python
   - "Python-system:(?!slc.*|ubuntu)"
 ---
 #!/bin/bash -e

--- a/openblas.sh
+++ b/openblas.sh
@@ -3,11 +3,11 @@ version: "%(tag_basename)s"
 tag: "v0.3.13"
 source: https://github.com/xianyi/OpenBLAS.git
 requires:
- - openmp
- - "GCC-Toolchain:(?!osx)"
+  - openmp
+  - "GCC-Toolchain:(?!osx)"
 build_requires:
- - CMake
- - alibuild-recipe-tools
+  - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 

--- a/openssl.sh
+++ b/openssl.sh
@@ -6,9 +6,9 @@ prefer_system: (?!slc5|slc6)
 prefer_system_check: |
   if [ `uname` = Darwin ]; then test -d `brew --prefix openssl@1.1 || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | cc -x c - -I`brew --prefix openssl@1.1`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER < 0x1000000L\n#error \"System's OpenSSL cannot be used: we need OpenSSL >1 to build our own XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -x c - -I`brew --prefix openssl@1.1`/include -c -o /dev/null || exit 1
 build_requires:
- - zlib
- - alibuild-recipe-tools
- - "GCC-Toolchain:(?!osx)"
+  - zlib
+  - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
 

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -2,8 +2,8 @@ package: protobuf
 version: v21.9
 source: https://github.com/protocolbuffers/protobuf
 build_requires:
- - CMake
- - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - "GCC-Toolchain:(?!osx)"
 ---
 
 cmake $SOURCEDIR/cmake                  \

--- a/python.sh
+++ b/python.sh
@@ -3,15 +3,15 @@ version: "%(tag_basename)s"
 tag: v3.9.12
 source: https://github.com/python/cpython
 requires:
- - AliEn-Runtime:(?!.*ppc64)
- - FreeType
- - libpng
- - sqlite
- - "GCC-Toolchain:(?!osx)"
- - libffi
+  - AliEn-Runtime:(?!.*ppc64)
+  - FreeType
+  - libpng
+  - sqlite
+  - "GCC-Toolchain:(?!osx)"
+  - libffi
 build_requires:
- - curl
- - alibuild-recipe-tools
+  - curl
+  - alibuild-recipe-tools
 env:
   SSL_CERT_FILE: "$(export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print(certifi.where())\")"
   PYTHONHOME: "$PYTHON_ROOT"

--- a/re2.sh
+++ b/re2.sh
@@ -2,8 +2,8 @@ package: re2
 version: "2019-09-01"
 source: https://github.com/google/re2
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
 ---
 #!/bin/sh
 cmake $SOURCEDIR                           \

--- a/roounfold.sh
+++ b/roounfold.sh
@@ -3,8 +3,8 @@ version: "%(tag_basename)s"
 tag: V02-00-01-alice5
 source: https://github.com/alisw/RooUnfold
 requires:
- - ROOT
- - boost
+  - ROOT
+  - boost
 ---
 cmake $SOURCEDIR                              \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT     \

--- a/sas.sh
+++ b/sas.sh
@@ -1,7 +1,7 @@
 package: SAS
 version: "0.1.3"
-source: https://github.com/ktf/SAS.git
 tag: master
+source: https://github.com/ktf/SAS.git
 requires:
   - Clang:(?!osx*)
 ---

--- a/snappy.sh
+++ b/snappy.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: 1.1.3
 source: https://github.com/google/snappy
 build_requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 system_requirement: ".*"
 system_requirement_check: |
   printf "#include <snappy.h>\n" | c++ -xc++ -I$(brew --prefix snappy)/include - -c -M 2>&1

--- a/system-subversion.sh
+++ b/system-subversion.sh
@@ -1,7 +1,7 @@
 package: system-subversion
 version: "1.0"
 build_requires:
-- system-apr
+  - system-apr
 system_requirement_missing: |
   apr and its development package are missing from your system.
    * RHEL-compatible systems: you will probably need the "subversion" and "subversion-devel" packages.

--- a/tbb.sh
+++ b/tbb.sh
@@ -3,9 +3,9 @@ version: "v2021.5.0"
 tag: v2021.5.0
 source: https://github.com/oneapi-src/oneTBB/
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
- - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
   printf "#include <tbb/concurrent_unordered_map.h>\n static_assert(TBB_INTERFACE_VERSION >= 11009, \"min version check failed\");\n" | c++ -std=c++11 -xc++ - -c -o /dev/null

--- a/therminator2.sh
+++ b/therminator2.sh
@@ -3,9 +3,9 @@ version: "%(tag_basename)s"
 tag: "v2.0.3-alice3"
 source: https://github.com/alisw/therminator
 requires:
- - "GCC-Toolchain:(?!osx)"
- - HepMC
- - ROOT
+  - "GCC-Toolchain:(?!osx)"
+  - HepMC
+  - ROOT
 ---
 #!/bin/bash -e
 

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -2,7 +2,7 @@ package: Toolchain
 version: "%(tag_basename)s"
 tag: v1.0
 build_requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 ---
 mkdir -p $INSTALLROOT/etc/modulefiles
 cp $GCC_TOOLCHAIN_ROOT/etc/modulefiles/GCC-Toolchain $INSTALLROOT/etc/modulefiles/GCC-${GCC_TOOLCHAIN_VERSION//-*}

--- a/utf8proc.sh
+++ b/utf8proc.sh
@@ -3,9 +3,9 @@ version: "v2.6.1"
 tag: v2.6.1
 source: https://github.com/JuliaStrings/utf8proc
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - alibuild-recipe-tools
- - CMake
+  - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
+  - CMake
 prefer_system: "(?!osx)"
 prefer_system_check: |
   printf "#include <utf8proc.h>\n" | c++ -c -I$(brew --prefix utf8proc)/include -xc++ - -o /dev/null 2>&1;

--- a/valgrind.sh
+++ b/valgrind.sh
@@ -1,7 +1,7 @@
 package: valgrind
-source: git://sourceware.org/git/valgrind.git
 version: "3.18.1"
 tag: VALGRIND_3_18_1
+source: git://sourceware.org/git/valgrind.git
 build_requires:
   - autotools
   - GCC-Toolchain

--- a/valgrind.sh
+++ b/valgrind.sh
@@ -3,9 +3,9 @@ source: git://sourceware.org/git/valgrind.git
 version: "3.18.1"
 tag: VALGRIND_3_18_1
 build_requires:
-- autotools
-- GCC-Toolchain
-- alibuild-recipe-tools
+  - autotools
+  - GCC-Toolchain
+  - alibuild-recipe-tools
 ---
 
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./

--- a/xalienfs.sh
+++ b/xalienfs.sh
@@ -3,17 +3,17 @@ version: "%(tag_basename)s"
 tag: v1.0.14r1-alice3
 source: https://github.com/alisw/xalienfs.git
 requires:
- - XRootD
- - "OpenSSL:(?!osx)"
- - "osx-system-openssl:(osx.*)"
- - AliEn-Runtime
+  - XRootD
+  - "OpenSSL:(?!osx)"
+  - "osx-system-openssl:(osx.*)"
+  - AliEn-Runtime
 build_requires:
- - "autotools:(slc6|slc7)"
- - SWIG
- - UUID
- - libperl
+  - "autotools:(slc6|slc7)"
+  - SWIG
+  - UUID
+  - libperl
 prepend_path:
- PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
+  PERLLIB: "$ALIEN_RUNTIME_ROOT/lib/perl"
 env:
   GSHELL_ROOT: "$XALIENFS_ROOT"
   GSHELL_NO_GCC: "1"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -3,16 +3,16 @@ version: "%(tag_basename)s"
 tag: "v5.5.3"
 source: https://github.com/xrootd/xrootd
 requires:
- - "OpenSSL:(?!osx)"
- - Python-modules:(?!osx_arm64)
- - AliEn-Runtime
- - libxml2
+  - "OpenSSL:(?!osx)"
+  - Python-modules:(?!osx_arm64)
+  - AliEn-Runtime
+  - libxml2
 build_requires:
- - CMake
- - "osx-system-openssl:(osx.*)"
- - "GCC-Toolchain:(?!osx)"
- - UUID:(?!osx)
- - alibuild-recipe-tools
+  - CMake
+  - "osx-system-openssl:(osx.*)"
+  - "GCC-Toolchain:(?!osx)"
+  - UUID:(?!osx)
+  - alibuild-recipe-tools
 prepend_path:
   PYTHONPATH: "${XROOTD_ROOT}/lib/python/site-packages"
 ---

--- a/yoda.sh
+++ b/yoda.sh
@@ -11,7 +11,8 @@ requires:
 build_requires:
   - "autotools:(slc6|slc7)"
 prepend_path:
-  PYTHONPATH: $YODA_ROOT/lib/python/site-packages # See below at built time the management towards generic path .../lib/python/site-packages
+  # See below at build time the management towards generic path .../lib/python/site-packages
+  PYTHONPATH: $YODA_ROOT/lib/python/site-packages
 ---
 #!/bin/bash
 

--- a/zlib-cloudflare.sh
+++ b/zlib-cloudflare.sh
@@ -3,9 +3,9 @@ version: "%(tag_basename)s"
 tag: gcc.amd64
 source: https://github.com/cloudflare/zlib/
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
- - alibuild-recipe-tools
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/sh
 

--- a/zlib.sh
+++ b/zlib.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: v1.2.8
 source: https://github.com/star-externals/zlib
 build_requires:
- - "GCC-Toolchain:(?!osx)"
+  - "GCC-Toolchain:(?!osx)"
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <zlib.h>\n" | cc -xc++ - -c -M 2>&1


### PR DESCRIPTION
This fixes some notices and warnings from alidistlint. The changed packages are considered unchanged by aliBuild, so this won't cause unnecessary rebuilds.