### PR TITLE
Add KFParticle to O2 dependencies

### DIFF
--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -10,6 +10,7 @@ env:
   GEANT4_BUILD_MULTITHREADED: 'ON'
 disable:
   - O2Physics
+  - KFParticle
   - OpenSSL
   - curl
   - mesos

--- a/o2.sh
+++ b/o2.sh
@@ -26,6 +26,7 @@ requires:
   - FFTW3
   - ONNXRuntime
   - MLModels
+  - KFParticle
 build_requires:
   - GMP
   - MPFR


### PR DESCRIPTION
Hi @pzhristov, @ktf,

This is the modification I mentioned on Thursday.
It does not create havoc, as we already build the KFParticle package for O2Physics.

Cheers,
Max