### PR TITLE
Add Python 3.11 clause to Python modules list

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -92,6 +92,22 @@ env:
     responses==0.10.6
     pandas==1.1.5
     setuptools==65.5.1
+  PIP311_REQUIREMENTS: |
+    PyYAML==5.4
+    psutil==5.9.4
+    uproot==4.1.0
+    numpy==1.23.4
+    scipy==1.9.3
+    Cython==0.29.21
+    seaborn==0.11.0
+    scikit-learn==0.24.1
+    sklearn-evaluation==0.8.1
+    Keras==2.4.3
+    xgboost==1.2.0
+    dryable==1.0.5
+    responses==0.10.6
+    pandas==1.1.5
+    setuptools==65.5.1
 ---
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -37,7 +37,9 @@ case $ARCHITECTURE in
   echo $PIP_REQUIREMENTS | tr \  \\n > requirements.txt;;
   *)
   echo $PIP_REQUIREMENTS | tr \  \\n > requirements.txt
-  if python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3010 else 1)'; then
+  if python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3011 else 1)'; then
+    echo $PIP311_REQUIREMENTS | tr \  \\n >> requirements.txt
+  elif python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3010 else 1)'; then
     echo $PIP310_REQUIREMENTS | tr \  \\n >> requirements.txt
   elif python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3009 else 1)'; then
     echo $PIP39_REQUIREMENTS | tr \  \\n >> requirements.txt


### PR DESCRIPTION
On MacOS Ventura, our CI machines use python@3.11 from brew.

Under Python 3.11, we can install psutil==5.9.4 as a wheel, but not 5.9.0, leading to a pip failure.

Nothing else is changed from `PIP310_REQUIREMENTS`.