### PR TITLE
ACTS: build analysis apps, correct version

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,5 +1,5 @@
 package: ACTS
-version: "main"
+version: "v23.5.0-alice"
 requires:
   - ROOT
   - pythia

--- a/acts.sh
+++ b/acts.sh
@@ -1,5 +1,5 @@
 package: ACTS
-version: v23.4.0
+version: "main"
 requires:
   - ROOT
   - pythia
@@ -18,8 +18,9 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  -DACTS_BUILD_FATRAS=ON                    \
                  -DACTS_BUILD_EXAMPLES=ON                  \
                  -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON  \
+		 -DACTS_BUILD_ANALYSIS_APPS=ON             \
                  -DACTS_BUILD_EXAMPLES_PYTHIA8=ON          \
-                 -DCMAKE_PREFIX_PATH=${PYTHIA_ROOT}
+                 -DCMAKE_PREFIX_PATH=${PYTHIA_ROOT}        
 
 
 cmake --build . -- ${JOBS:+-j$JOBS} install


### PR DESCRIPTION
This PR allows to build the analysis apps and corrects the version to "main" as the AliceO2Group fork doesn't have any version.
Tagging @mconcas, @sawenzel for approval.