### PR TITLE
Prefer using system or CVMFS CA certs

### DIFF
--- a/alien-cas.sh
+++ b/alien-cas.sh
@@ -2,9 +2,17 @@ package: AliEn-CAs
 version: v1
 tag: f62625ede780d455b3b7878064bcfee6bd9a4f53
 source: https://github.com/alisw/alien-cas.git
+prefer_system: .*
+prefer_system_check: |
+  # If we can verify the user's cert, the CERN CA must be installed
+  # system-wide. In that case, don't install our certs.
+  openssl verify ~/.globus/usercert.pem > /dev/null 2> /dev/null
 build_requires:
   - alibuild-recipe-tools
 env:
+  # This is only used for O2/O2Physics unit tests. These are run
+  # locally (in which case these CAs are fine and assumed to be
+  # up-to-date) or in CI (ditto).
   X509_CERT_DIR: "$ALIEN_CAS_ROOT/globus/share/certificates"
 ---
 #!/bin/bash -e
@@ -18,5 +26,19 @@ MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
 alibuild-generate-module > "$MODULEFILE"
 cat >> "$MODULEFILE" <<EOF
-setenv X509_CERT_DIR \$::env(BASEDIR)/AliEn-CAs/\$version/globus/share/certificates
+try {
+  exec openssl verify \$::env(HOME)/.globus/usercert.pem > /dev/null 2> /dev/null
+} trap CHILDSTATUS {} {
+  # If we couldn't validate the user's cert, either it doesn't exist
+  # or the CERN CA isn't installed as a system cert. In the latter
+  # case, we should redirect to CVMFS or to our certs.
+  if [file isdirectory /cvmfs/alice.cern.ch/etc/grid-security/certificates] {
+    # Prefer current certs from CVMFS, if available. This avoids
+    # failures due to expired certs.
+    setenv X509_CERT_DIR /cvmfs/alice.cern.ch/etc/grid-security/certificates
+  } else {
+    # As a fallback, use the certs we installed. Fine for local dev and CI.
+    setenv X509_CERT_DIR \$::env(BASEDIR)/AliEn-CAs/\$version/globus/share/certificates
+  }
+}
 EOF


### PR DESCRIPTION
Try to detect when we can use system certificates or those from CVMFS, and prefer them if possible. This should avoid situations where old O2 tags have expired certs pinned.

Still fallback to the old behaviour, which is fine for CI and local development.

Cc: @ktf @adriansev 