### PR TITLE
Remove setuptools pinning in XRootD

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -60,10 +60,8 @@ python3 -m venv $PYTHON_MODULES_INSTALLROOT
 . $PYTHON_MODULES_INSTALLROOT/bin/activate
 
 # Upgrade pip
-python3 -m pip install -IU pip
 # Install setuptools upfront, since this seems to create issues now...
-python3 -m pip install -IU "setuptools<=60.8.2"
-python3 -m pip install -IU wheel
+python3 -m pip install -IU pip setuptools wheel
 
 # FIXME: required because of the newly introduced dependency on scikit-garden requires
 # a numpy to be installed separately

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -43,10 +43,6 @@ case $ARCHITECTURE in
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
     unset UUID_ROOT
-    if [ "$(python3 -c 'import setuptools; print(setuptools.__version__)')" != "60.8.2" ]; then
-      echo 'Please install setuptools==60.8.2'
-      exit 1
-    fi
   ;;
 esac
 


### PR DESCRIPTION
This pinning was added in fa73bfc806f3e4012b68b2c1e018a5ae79f05f59 due to an issue when setting up the M1 Macs, but it works with the latest setuptools on the new M2 Macs.

Cc: @pzhristov @adriansev @ktf 