### PR TITLE
Integrate Conda env into Python-modules

### DIFF
--- a/agile.sh
+++ b/agile.sh
@@ -7,7 +7,7 @@ requires:
   - boost
   - lhapdf5
   - HepMC
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
 build_requires:
   - "autotools:(slc6|slc7)"
   - SWIG

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -6,7 +6,7 @@ env:
   LHAPATH: "$LHAPDF5_ROOT/share/lhapdf"
 requires:
   - "GCC-Toolchain:(?!osx)"
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
 build_requires:
   - curl
 ---

--- a/mesos.sh
+++ b/mesos.sh
@@ -18,7 +18,7 @@ requires:
 build_requires:
   - "autotools:(slc6|slc7|slc8)"
   - protobuf
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
   - abseil
 prepend_path:
   PATH: "$MESOS_ROOT/sbin"

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -76,6 +76,26 @@ env:
     dryable==1.0.5
     responses==0.10.6
     pandas==1.1.5
+  # Keep the PIPxy version in sync with the Conda env we install in Python-modules!
+  # Everything but the first two lines copied from PIP39_REQUIREMENTS, but with versions
+  # adjusted such that wheels are available and for compatibility with tensorflow.
+  PIP39_REQUIREMENTS_osx_arm64: |
+    tensorflow-macos==2.12.0
+    tensorflow-metal==0.8.0
+    PyYAML==5.4.1
+    psutil==5.9.5
+    uproot==4.1.0
+    numpy==1.23.5
+    scipy==1.10.1
+    Cython==0.29.21
+    seaborn==0.11.0
+    scikit-learn==1.2.2
+    sklearn-evaluation==0.12.0
+    Keras==2.12.0
+    xgboost==1.7.5
+    dryable==1.0.5
+    responses==0.10.6
+    pandas==1.5.3
   PIP310_REQUIREMENTS: |
     PyYAML==5.4
     psutil==5.9.0
@@ -106,20 +126,9 @@ env:
     dryable==1.0.5
     responses==0.10.6
     pandas==1.1.5
+build_requires:
+  - alibuild-recipe-tools
 ---
-# Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-EoF
+#!/bin/bash -e
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -3,70 +3,66 @@ version: "1.0"
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - FreeType
+  - "FreeType:(?!osx)"
   - libpng
 build_requires:
   - curl
   - Python-modules-list
   - alibuild-recipe-tools
 prepend_path:
+  # If we need tensorflow to work on Mac, we must use lib/python$pyver, not lib/python here.
   PYTHONPATH: $PYTHON_MODULES_ROOT/share/python-modules/lib/python/site-packages
 ---
-
-# A spurios PYTHONPATH can affect later commands
-unset PYTHONPATH
-# If we are in a virtualenv, assume that what you want to do is to copy
-# the same installation in your alibuild one.
-if [ ! "X$VIRTUAL_ENV" = X ]; then
+#!/bin/bash -e
+if [ -n "$VIRTUAL_ENV" ]; then
   # Once more to get the deactivate
-  . $VIRTUAL_ENV/bin/activate
-  pip freeze > system-requirements.txt
+  . "$VIRTUAL_ENV/bin/activate"
   deactivate
 fi
+# A spurious PYTHONPATH can affect later commands
+unset PYTHONPATH
 
-# Special lists for different platforms
-PIP39_REQUIREMENTS=$(eval echo \${PIP39_REQUIREMENTS_${ARCHITECTURE/-/_}:-$PIP39_REQUIREMENTS})
-PIP310_REQUIREMENTS=$(eval echo \${PIP310_REQUIREMENTS_${ARCHITECTURE/-/_}:-$PIP310_REQUIREMENTS})
-PIP311_REQUIREMENTS=$(eval echo \${PIP311_REQUIREMENTS_${ARCHITECTURE/-/_}:-$PIP311_REQUIREMENTS})
-
-# These are the basic requirements needed for all installation and platform
-# and it should represent the common denominator (working) for all packages/platforms
-echo $PIP_BASE_REQUIREMENTS | tr \  \\n > base_requirements.txt
-
-# PIP_REQUIREMENTS, PIP36_REQUIREMENTS, PIP38_REQUIREMENTS come from python-modules-list.sh
-case $ARCHITECTURE in
-  osx_arm64)
-  touch requirements.txt
-  ;;
-  slc6*)
-  echo $PIP_REQUIREMENTS | tr \  \\n > requirements.txt
-  ;;
-  *)
-  echo $PIP_REQUIREMENTS | tr \  \\n > requirements.txt
-  if python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3011 else 1)'; then
-    echo $PIP311_REQUIREMENTS | tr \  \\n >> requirements.txt
-  elif python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3010 else 1)'; then
-    echo $PIP310_REQUIREMENTS | tr \  \\n >> requirements.txt
-  elif python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3009 else 1)'; then
-    echo $PIP39_REQUIREMENTS | tr \  \\n >> requirements.txt
-  elif python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3008 else 1)'; then
-    echo $PIP38_REQUIREMENTS | tr \  \\n >> requirements.txt
-  elif python3 -c 'import sys; exit(0 if 1000*sys.version_info.major + sys.version_info.minor >= 3006 else 1)'; then
-    echo $PIP36_REQUIREMENTS | tr \  \\n >> requirements.txt
-  fi
-  ;;
-esac
 # We use a different INSTALLROOT, so that we can build updatable RPMS which
 # do not conflict with the underlying Python installation.
 PYTHON_MODULES_INSTALLROOT=$INSTALLROOT/share/python-modules
-mkdir -p $PYTHON_MODULES_INSTALLROOT
 
-# Create the virtualenv
-python3 -m venv $PYTHON_MODULES_INSTALLROOT
-. $PYTHON_MODULES_INSTALLROOT/bin/activate
+case $ARCHITECTURE in
+  osx_arm64)
+    # On ARM Macs, we need to install Conda to get Tensorflow with hardware support.
+    # Available version list: https://repo.anaconda.com/miniconda/
+    # The Python version of this Conda env matters! Keep it in sync
+    # with the "PIPXY_REQUIREMENTS_osx_arm64" clause in Python-modules-list.
+    curl -fsSLo miniconda.sh 'https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-arm64.sh'
+    bash miniconda.sh -b -p "$PYTHON_MODULES_INSTALLROOT"
+    . "$PYTHON_MODULES_INSTALLROOT/bin/activate"
+    conda install -y -c apple tensorflow-deps ;;
+  *)
+    # On other platforms, just create a plain virtualenv.
+    python3 -m venv "$PYTHON_MODULES_INSTALLROOT"
+    . "$PYTHON_MODULES_INSTALLROOT/bin/activate" ;;
+esac
 
-## Install pinned basic requirements for python infrastructure
-python3 -m pip install -IU -r base_requirements.txt
+# Major.minor version of Python
+pyver="$(python3 -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')"
+
+# These are the basic requirements needed for all installation and platform
+# and it should represent the common denominator (working) for all packages/platforms
+echo "$PIP_BASE_REQUIREMENTS" | tr '[:space:]' '\n' > base-requirements.txt
+
+# PIP*_REQUIREMENTS variables come from python-modules-list.sh.
+case $ARCHITECTURE in
+  slc6_*) echo "$PIP_REQUIREMENTS" ;;
+  *)
+    echo "$PIP_REQUIREMENTS"
+    # Handle special lists for different platforms, e.g. $PIP39_REQUIREMENTS_osx_arm64.
+    this_pyver_requirements_var=PIP${pyver/.}_REQUIREMENTS
+    this_pyver_arch_requirements_var=PIP${pyver/.}_REQUIREMENTS_$ARCHITECTURE
+    # Use $PIPxy_REQUIREMENTS_arch if set, falling back to $PIPxy_REQUIREMENTS.
+    echo "${!this_pyver_arch_requirements_var:-${!this_pyver_requirements_var}}" ;;
+esac | tr -s '[:space:]' '\n' > requirements.txt
+
+# Install pinned basic requirements for python infrastructure
+python3 -m pip install -IU -r base-requirements.txt
 
 # FIXME: required because of the newly introduced dependency on scikit-garden requires
 # a numpy to be installed separately
@@ -75,8 +71,6 @@ python3 -m pip install -IU -r base_requirements.txt
 python3 -m pip install -IU numpy
 python3 -m pip install -IU -r requirements.txt
 
-# Major.minor version of Python
-export PYVER="$(python3 -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')"
 # Find the proper Python lib library and export it
 pushd "$PYTHON_MODULES_INSTALLROOT"
   # let's remove any pre-existent symlinks to have a clean slate
@@ -85,16 +79,9 @@ pushd "$PYTHON_MODULES_INSTALLROOT"
   if [[ -d lib64 ]]; then
     ln -nfs lib64 lib  # creates lib pointing to lib64
   elif [[ -d lib ]]; then
-       ln -nfs lib lib64 # creates lib64 pointing to lib
+    ln -nfs lib lib64  # creates lib64 pointing to lib
   fi
-  pushd lib
-    ln -nfs python$PYVER python
-  popd
-  pushd bin
-    # Fix shebangs: remove hardcoded Python path
-    find . -type f -exec sed -i.deleteme -e "s|${PYTHON_MODULES_INSTALLROOT}|/usr|;s|python3|env python3|" '{}' \;
-    find . -name "*.deleteme" -delete
-  popd
+  ln -nfs "python$pyver" lib/python
 popd
 
 # Remove useless stuff
@@ -102,6 +89,14 @@ rm -rvf "$PYTHON_MODULES_INSTALLROOT"/share "$PYTHON_MODULES_INSTALLROOT"/lib/py
 find "$PYTHON_MODULES_INSTALLROOT"/lib/python* \
      -mindepth 2 -maxdepth 2 -type d -and \( -name test -or -name tests \) \
      -exec rm -rvf '{}' \;
+
+case $ARCHITECTURE in
+  osx_arm64) ;;
+  *)
+    # Fix shebangs: remove hardcoded Python path
+    find "$PYTHON_MODULES_INSTALLROOT/bin" -type f -exec sed -i.deleteme -e "s|${PYTHON_MODULES_INSTALLROOT}|/usr|;s|python3|env python3|" '{}' \;
+    find "$PYTHON_MODULES_INSTALLROOT/bin" -name '*.deleteme' -delete ;;
+esac
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
@@ -112,5 +107,6 @@ cat >> "$MODULEDIR/$PKGNAME" <<EoF
 set PYTHON_MODULES_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$PYTHON_MODULES_ROOT/share/python-modules/bin
 prepend-path LD_LIBRARY_PATH \$PYTHON_MODULES_ROOT/share/python-modules/lib
-prepend-path PYTHONPATH \$PYTHON_MODULES_ROOT/share/python-modules/lib/python/site-packages
+# We need to use lib/python$pyver, not lib/python here so that tensorflow-metal works on Mac.
+prepend-path PYTHONPATH \$PYTHON_MODULES_ROOT/share/python-modules/lib/python$pyver/site-packages
 EoF

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -56,7 +56,7 @@ case $ARCHITECTURE in
     echo "$PIP_REQUIREMENTS"
     # Handle special lists for different platforms, e.g. $PIP39_REQUIREMENTS_osx_arm64.
     this_pyver_requirements_var=PIP${pyver/.}_REQUIREMENTS
-    this_pyver_arch_requirements_var=PIP${pyver/.}_REQUIREMENTS_$ARCHITECTURE
+    this_pyver_arch_requirements_var=PIP${pyver/.}_REQUIREMENTS_${ARCHITECTURE//-/_}
     # Use $PIPxy_REQUIREMENTS_arch if set, falling back to $PIPxy_REQUIREMENTS.
     echo "${!this_pyver_arch_requirements_var:-${!this_pyver_requirements_var}}" ;;
 esac | tr -s '[:space:]' '\n' > requirements.txt

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -11,7 +11,7 @@ requires:
   - O2
   - arrow
   - Control-OCCPlugin
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
   - libjalienO2
   - bookkeeping-api
 build_requires:

--- a/root.sh
+++ b/root.sh
@@ -9,7 +9,7 @@ requires:
   - opengl:(?!osx)
   - Xdevel:(?!osx)
   - FreeType:(?!osx)
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
   - "GCC-Toolchain:(?!osx)"
   - libpng
   - lzma

--- a/sacrifice.sh
+++ b/sacrifice.sh
@@ -7,7 +7,7 @@ requires:
   - boost
   - lhapdf
   - HepMC
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
   - pythia
 build_requires:
   - "autotools:(slc6|slc7)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -7,7 +7,7 @@ requires:
   - "osx-system-openssl:(osx.*)"
   - XRootD
   - AliEn-Runtime
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
 prepend_path:
   PYTHONPATH: ${XJALIENFS_ROOT}/lib/python/site-packages
 ---

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -4,7 +4,7 @@ tag: "v5.5.3"
 source: https://github.com/xrootd/xrootd
 requires:
   - "OpenSSL:(?!osx)"
-  - Python-modules:(?!osx_arm64)
+  - Python-modules
   - AliEn-Runtime
   - libxml2
 build_requires:


### PR DESCRIPTION
Conda is required for GPU hardware support on ARM (M1/M2) Macs, in order to use Tensorflow.

Previously, this was expected to be installed manually, as documented at https://alice.its.cern.ch/jira/browse/O2-2072, but that way packages are not automatically kept compatible with alidist packages.

This PR installs a Conda environment as the Python-modules package instead. This integration also means all packages that previously disabled Python-modules on osx_arm64 can now depend on the package normally.

Tested on an M2 Mac; I can run the tensorflow test script listed at https://developer.apple.com/metal/tensorflow-plugin/ successfully in the resulting `alienv enter Python-modules/latest` environment.

@pzhristov, if you could test this with some O2-related script that uses the GPU, that would be great!