### PR TITLE
Check for system OpenSSL 1.1.1

### DIFF
--- a/openssl.sh
+++ b/openssl.sh
@@ -4,7 +4,19 @@ tag: OpenSSL_1_1_1m
 source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl@1.1 || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | cc -x c - -I`brew --prefix openssl@1.1`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER < 0x1000000L\n#error \"System's OpenSSL cannot be used: we need OpenSSL >1 to build our own XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -x c - -I`brew --prefix openssl@1.1`/include -c -o /dev/null || exit 1
+  #!/bin/bash -e
+  case $(uname) in
+    Darwin) prefix=$(brew --prefix openssl@1.1); [ -d "$prefix" ] ;;
+    *) prefix= ;;
+  esac
+  cc -x c - ${prefix:+"-I$prefix/include"} -c -o /dev/null <<\EOF
+  #include <openssl/bio.h>
+  #include <openssl/opensslv.h>
+  #if OPENSSL_VERSION_NUMBER < 0x1010100L
+  #error "System's OpenSSL cannot be used: we need OpenSSL >= 1.1.1 for the Python ssl module. We are going to compile our own version."
+  #endif
+  int main() { }
+  EOF
 build_requires:
   - zlib
   - alibuild-recipe-tools

--- a/openssl.sh
+++ b/openssl.sh
@@ -12,7 +12,7 @@ prefer_system_check: |
   cc -x c - ${prefix:+"-I$prefix/include"} -c -o /dev/null <<\EOF
   #include <openssl/bio.h>
   #include <openssl/opensslv.h>
-  #if OPENSSL_VERSION_NUMBER < 0x1010100L
+  #if OPENSSL_VERSION_NUMBER < 0x10101000L
   #error "System's OpenSSL cannot be used: we need OpenSSL >= 1.1.1 for the Python ssl module. We are going to compile our own version."
   #endif
   int main() { }


### PR DESCRIPTION
Python requires OpenSSL 1.1.1+ to compile its ssl module, else importing "requests" will fail at runtime.

Ubuntu 18.04 still has OpenSSL 1.0 installed (at least in some cases), and we must not use the system OpenSSL there.

Draft for now to avoid lots of rebuilds and slowing down the CI.