### PR TITLE
Link Python to distro-independent libcrypt.so

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -83,7 +83,7 @@ pushd "$INSTALLROOT/bin"
 popd
 
 if [ "$(uname)" = Linux ]; then
-  # We want to use el7-built Pythons on el7, e.g. on the Grid. On el7,
+  # We want to use el7-built Pythons on el9, e.g. on the Grid. On el7,
   # we compile against libcrypto.so.1, which is not available on el9
   # (it's libcrypt.so.2 instead). However, Python still works when
   # loaded with libcrypt.so.2, so just replace the library reference.

--- a/python.sh
+++ b/python.sh
@@ -82,6 +82,14 @@ pushd "$INSTALLROOT/bin"
   [[ -x python3-config ]] || ln -nfs "$PYTHON_CONFIG_BIN" python3-config
 popd
 
+if [ "$(uname)" = Linux ]; then
+  # We want to use el7-built Pythons on el7, e.g. on the Grid. On el7,
+  # we compile against libcrypto.so.1, which is not available on el9
+  # (it's libcrypt.so.2 instead). However, Python still works when
+  # loaded with libcrypt.so.2, so just replace the library reference.
+  patchelf --replace-needed libcrypt.so.1 libcrypt.so "$INSTALLROOT/bin/python"
+fi
+
 # Install Python SSL certificates right away
 env PATH="$INSTALLROOT/bin:$PATH" \
     LD_LIBRARY_PATH="$INSTALLROOT/lib:$LD_LIBRARY_PATH" \


### PR DESCRIPTION
We use el7-built Python binaries on el9 as well, but there, only libcrypt.so.2 is available (as opposed to libcrypt.so.1 on el7). However, loading .so.2 runtime still works, so patchelf the python executable to refer to the generic unversioned library.

@zensanp Is there some way you could test this? You can build the package as we do in the nightly builds using `aliBuild build -a slc7_x86-64 --docker-image registry.cern.ch/alisw/slc7-builder:patchelf Python` (the regular build container doesn't yet have patchelf).