### PR TITLE
Fix use of Python-modules binaries during subsequent builds

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -10,6 +10,8 @@ build_requires:
   - Python-modules-list
   - alibuild-recipe-tools
 prepend_path:
+  PATH: "$PYTHON_MODULES_ROOT/share/python-modules/bin"
+  LD_LIBRARY_PATH: "$PYTHON_MODULES_ROOT/share/python-modules/lib"
   # If we need tensorflow to work on Mac, we must use lib/python$pyver, not lib/python here.
   PYTHONPATH: $PYTHON_MODULES_ROOT/share/python-modules/lib/python/site-packages
 ---


### PR DESCRIPTION
On osx_arm64, we need to use the python binary from Python-modules (i.e. from Conda) in subsequent builds like ROOT.

These paths are in a non-standard place intentionally (for updatable RPM support), so aliBuild does not pick them up as it would usually.