### PR TITLE
Next attempt to enable GDML for Geant4

### DIFF
--- a/xercesc.sh
+++ b/xercesc.sh
@@ -1,9 +1,10 @@
 package: xercesc
 version: Xerces-C_3_2_2
-tag: Xerces-C_3_2_2
+tag: v3.2.2
 source: https://github.com/apache/xerces-c
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prefer_system: ".*"
 prefer_system_check: |
   pkg-config --atleast-version=3.2.0 xerces-c 2>&1 && printf "#include \"<xercesc/util/PlatformUtils.hpp>\"\nint main(){}" | c++ -xc - -o /dev/null
@@ -27,17 +28,8 @@ make install
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
+alibuild-generate-module --lib > $MODULEFILE
+cat >> "$MODULEFILE" <<EOF
+# extra environment
 set XERCESC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$XERCESC_ROOT/lib
-EoF
+EOF


### PR DESCRIPTION
* build G4 with GDML support
* update recipe for XercesC with correct tag
* use tools to generate modulefiles for XercesC + Geant4 (code reduction)

Note that in the past we had problems in relocating XercesC + Geant4. Let's hope that this has been fixed meanwhile.