### PR TITLE
Fix XRootD compilation on Mac

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -78,7 +78,7 @@ cmake "${BUILDDIR}"                                                   \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
-      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV="CC=c++ CFLAGS=\"$CFLAGS -std=c++17\""} \
+      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV="CC=c++ CFLAGS='$CFLAGS -std=c++17'"} \
       ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed --verbose --no-use-pep517'}   \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
 

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -78,7 +78,7 @@ cmake "${BUILDDIR}"                                                   \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
-      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'}       \
+      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV="CC=c++ CFLAGS=\"$CFLAGS -std=c++17\""} \
       ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed --verbose --no-use-pep517'}   \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
 

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -31,6 +31,10 @@ setuptools version:
 $(python3 -m pip show setuptools | grep 'Version\|Location')
 ###################"
 
+COMPILER_CC=cc
+COMPILER_CXX=c++
+COMPILER_LD=c++
+
 case $ARCHITECTURE in
   osx_x86-64)
     export ARCHFLAGS="-arch x86_64"
@@ -41,6 +45,9 @@ case $ARCHITECTURE in
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
     unset UUID_ROOT
+    COMPILER_CC=clang
+    COMPILER_CXX=clang++
+    COMPILER_LD=clang
   ;;
   osx_arm64)
     [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl@1.1)
@@ -51,6 +58,9 @@ case $ARCHITECTURE in
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
     unset UUID_ROOT
+    COMPILER_CC=clang
+    COMPILER_CXX=clang++
+    COMPILER_LD=clang
   ;;
 esac
 
@@ -60,6 +70,9 @@ mkdir build
 pushd build
 cmake "${BUILDDIR}"                                                   \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                       \
+      -DCMAKE_CXX_COMPILER=$COMPILER_CXX                              \
+      -DCMAKE_C_COMPILER=$COMPILER_CC                                 \
+      -DCMAKE_LINKER=$COMPILER_LD                                     \
       -DCMAKE_INSTALL_PREFIX=${INSTALLROOT}                           \
       ${CMAKE_FRAMEWORK_PATH+-DCMAKE_FRAMEWORK_PATH=$CMAKE_FRAMEWORK_PATH} \
       -DCMAKE_INSTALL_LIBDIR=lib                                      \
@@ -78,7 +91,7 @@ cmake "${BUILDDIR}"                                                   \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
-      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV="CC=c++ CFLAGS='$CFLAGS -std=c++17'"} \
+      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'}       \
       ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed --verbose --no-use-pep517'}   \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
 


### PR DESCRIPTION
This should fix the "ld: library not found: -ldl" error seen when compiling XRootD under some Python configurations on MacOS.

@pzhristov @ktf This is the solution you found, right?