### PR TITLE
Bump tag/commit for jq

### DIFF
--- a/jq.sh
+++ b/jq.sh
@@ -1,5 +1,5 @@
 package: jq
-version: v1.6
+version: v1.6-alice1
 tag: 52d5988
 source: https://github.com/stedolan/jq.git
 build_requires:

--- a/jq.sh
+++ b/jq.sh
@@ -1,6 +1,6 @@
 package: jq
 version: v1.6
-tag: jq-1.6
+tag: 52d5988
 source: https://github.com/stedolan/jq.git
 build_requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
jq - official tag 1.6 - does not compile on the latest MacOS.

In absence of a newer release, we use commit hash 52d5988, which was tested to compile fine with alibuild on linux + Mac.

@co-author: Peter Hristov