### PR TITLE
Fix ODC not picking OpenSSL on Mac

### DIFF
--- a/odc.sh
+++ b/odc.sh
@@ -24,6 +24,8 @@ case $ARCHITECTURE in
     [[ ! $PROTOBUF_ROOT ]] && PROTOBUF_ROOT=`brew --prefix protobuf`
     [[ ! $GSL_ROOT ]] && GSL_ROOT=`brew --prefix gsl`
     [[ ! $GRPC_ROOT ]] && GRPC_ROOT=`brew --prefix grpc`
+    # grpc needs OpenSSL and doesn't find it by default.
+    [[ ! $OPENSSL_ROOT ]] && OPENSSL_ROOT=$(brew --prefix openssl@1.1)
 
     SONAME=dylib
   ;;
@@ -42,6 +44,7 @@ cmake  $SOURCEDIR                                                               
        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                                                    \
        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                                   \
        -DgRPC_ROOT=$GRPC_ROOT                                                                \
+       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR="$OPENSSL_ROOT"}                                   \
        -DBUILD_INFOLOGGER=ON
 
 


### PR DESCRIPTION
The ODC build needs OPENSSL_ROOT, so that the grpc CMake files can find OpenSSL.