### PR TITLE
Bump Data Distribution to v1.6.0

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -1,6 +1,6 @@
 package: DataDistribution
 version: "%(tag_basename)s"
-tag: v1.5.5
+tag: v1.6.0
 requires:
   - "GCC-Toolchain:(?!osx)"
   - boost


### PR DESCRIPTION
This bumps DataDistribution to v1.6.0, which addresses a number of pending requests. TfBuilder will now terminate in case of a gRPC failure or if it cannot connect to one of the FLPs.