### PR TITLE
Re-enable simulation in O2 builds; find geant4 + xercesc

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -198,8 +198,10 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${ARROW_ROOT:+-DGandiva_DIR=$ARROW_ROOT/lib/cmake/Gandiva}                                          \
       ${ARROW_ROOT:+-DArrow_DIR=$ARROW_ROOT/lib/cmake/Arrow}                                              \
       ${ARROW_ROOT:+${CLANG_ROOT:+-DLLVM_ROOT=$CLANG_ROOT}}                                               \
-      ${ITSRESPONSE_ROOT:+-DITSRESPONSE=${ITSRESPONSE_ROOT}}
-# LLVM_ROOT is required for Gandiva.
+      ${ITSRESPONSE_ROOT:+-DITSRESPONSE=${ITSRESPONSE_ROOT}}                                              \
+      -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=True
+# LLVM_ROOT is required for Gandiva
+# FIND_PACKAGE_PREFER_CONFIG used so that Geant4 finds XercesC better internally
 
 cmake --build . -- ${JOBS+-j $JOBS} install
 


### PR DESCRIPTION
Since the introduction of GDML support in Geant4,
some builds of O2 failed to include simulation. This lead to failure of the fullCI and absence of o2-sim on the GRID.

The problem is that finding Geant4 during O2-cmake triggers again a search for XercesC, which seems to fail.

This commit fixes the issue by asking cmake to prefer CONFIG package searches which guides it better to pickup XercesC from the alibuild software stack.

This appears to be the shortest possible (hot)fix for the issue.