### PR TITLE
Bump starlight.sh

### DIFF
--- a/starlight.sh
+++ b/starlight.sh
@@ -1,6 +1,6 @@
 package: STARlight
 version: "%(tag_basename)s"
-tag: r313-a
+tag: r313-b
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
bumps starlight to a tag that actually exists
and that compiles with C++17