### PR TITLE
alienpy 1.5.2

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.5.1"
+tag: "1.5.2"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* Fast release for increasing timeout for cp operations. (this is the target of release)

* Improve mechanics for `cp -fastcheck` (now also aliased to `-skipmd5`) to check also for the age of destination file. If destination present and older than lfn then i will be re-downloaded
* ccdb command improvements (and helpers in example directory for QC shifter duties)