### PR TITLE
Find XercesC via CMAKE_PREFIX_PATH

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -52,6 +52,10 @@ cmake $SOURCEDIR                                                \
 make ${JOBS+-j $JOBS}
 make install
 
+# we should not use cached package links
+packagecachefile=$(find ${INSTALLROOT} -name "Geant4PackageCache.cmake")
+echo "#" > $packagecachefile
+
 # Install data sets
 # Can be done after Geant4 installation, if installed with -DGEANT4_INSTALL_DATA=OFF
 # ./geant4-config --install-datasets

--- a/o2.sh
+++ b/o2.sh
@@ -198,10 +198,8 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
       ${ARROW_ROOT:+-DGandiva_DIR=$ARROW_ROOT/lib/cmake/Gandiva}                                          \
       ${ARROW_ROOT:+-DArrow_DIR=$ARROW_ROOT/lib/cmake/Arrow}                                              \
       ${ARROW_ROOT:+${CLANG_ROOT:+-DLLVM_ROOT=$CLANG_ROOT}}                                               \
-      ${ITSRESPONSE_ROOT:+-DITSRESPONSE=${ITSRESPONSE_ROOT}}                                              \
-      -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=True
+      ${ITSRESPONSE_ROOT:+-DITSRESPONSE=${ITSRESPONSE_ROOT}}
 # LLVM_ROOT is required for Gandiva
-# FIND_PACKAGE_PREFER_CONFIG used so that Geant4 finds XercesC better internally
 
 cmake --build . -- ${JOBS+-j $JOBS} install
 

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -11,6 +11,8 @@ prefer_system_check: |
 prepend_path:
   ROOT_INCLUDE_PATH: "$XERCESC_ROOT/include"
   LD_LIBRARY_PATH: "$XERCESC_ROOT/lib"
+env:
+  CMAKE_PREFIX_PATH: "$CMAKE_PREFIX_PATH:$XERCESC_ROOT"
 ---
 
 cmake $SOURCEDIR                                         \

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -10,9 +10,7 @@ prefer_system_check: |
   pkg-config --atleast-version=3.2.0 xerces-c 2>&1 && printf "#include \"<xercesc/util/PlatformUtils.hpp>\"\nint main(){}" | c++ -xc - -o /dev/null
 prepend_path:
   ROOT_INCLUDE_PATH: "$XERCESC_ROOT/include"
-  LD_LIBRARY_PATH: "$XERCESC_ROOT/lib"
-env:
-  CMAKE_PREFIX_PATH: "$CMAKE_PREFIX_PATH:$XERCESC_ROOT"
+  CMAKE_PREFIX_PATH: "$XERCESC_ROOT"
 ---
 
 cmake $SOURCEDIR                                         \


### PR DESCRIPTION
* do not use cached information about packages in Geant4 installation
* help finding XercesC via CMAKE_PREFIX_PATH