### PR TITLE
XRootD update to 5.6.0

### DIFF
--- a/uuid.sh
+++ b/uuid.sh
@@ -21,12 +21,14 @@ case $ARCHITECTURE in
 esac
 
 autoreconf -ivf
+# --disable-nls so we don't depend on gettext/libintl at runtime on Intel Macs.
 ./configure ${disable_shared:+--disable-shared}   \
             "--libdir=$INSTALLROOT/lib"           \
             "--prefix=$INSTALLROOT"               \
             --disable-all-programs                \
             --disable-silent-rules                \
             --disable-tls                         \
+            --disable-nls                         \
             --disable-rpath                       \
             --without-ncurses                     \
             --enable-libuuid

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -80,6 +80,9 @@ cmake "${BUILDDIR}"                                                   \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIRS=$UUID_ROOT/include}            \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIR=$UUID_ROOT/include}             \
       -DENABLE_KRB5=OFF                                               \
+      -DENABLE_FUSE=OFF                                               \
+      -DENABLE_VOMS=OFF                                               \
+      -DENABLE_XRDCLHTTP=OFF                                          \
       -DENABLE_READLINE=OFF                                           \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}               \

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -90,7 +90,7 @@ cmake "${BUILDDIR}"                                                   \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
       ${XROOTD_PYTHON:+-DPython_EXECUTABLE=$PYTHON_EXECUTABLE}        \
       ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed --verbose'}   \
-      -DCMAKE_CXX_FLAGS="-Wno-error"
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 popd

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.5.3"
+tag: "v5.6.0"
 source: https://github.com/xrootd/xrootd
 requires:
   - "OpenSSL:(?!osx)"
@@ -77,9 +77,6 @@ cmake "${BUILDDIR}"                                                   \
       ${CMAKE_FRAMEWORK_PATH+-DCMAKE_FRAMEWORK_PATH=$CMAKE_FRAMEWORK_PATH} \
       -DCMAKE_INSTALL_LIBDIR=lib                                      \
       -DXRDCL_ONLY=ON                                                 \
-      -DENABLE_CRYPTO=ON                                              \
-      -DENABLE_PERL=OFF                                               \
-      -DVOMSXRD_SUBMODULE=OFF                                         \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \
       ${UUID_ROOT:+-DUUID_LIBRARY=$UUID_ROOT/lib/libuuid.so}          \
       ${UUID_ROOT:+-DUUID_INCLUDE_DIRS=$UUID_ROOT/include}            \
@@ -90,10 +87,9 @@ cmake "${BUILDDIR}"                                                   \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}               \
       ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT}                            \
       ${XROOTD_PYTHON:+-DENABLE_PYTHON=ON}                            \
-      ${XROOTD_PYTHON:+-DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE}        \
-      ${XROOTD_PYTHON:+-DXROOTD_PYBUILD_ENV='CC=c++ CFLAGS=\"-std=c++17\"'}       \
-      ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed --verbose --no-use-pep517'}   \
-      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-Wno-error"
+      ${XROOTD_PYTHON:+-DPython_EXECUTABLE=$PYTHON_EXECUTABLE}        \
+      ${XROOTD_PYTHON:+-DPIP_OPTIONS='--force-reinstall --ignore-installed --verbose'}   \
+      -DCMAKE_CXX_FLAGS="-Wno-error"
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 popd

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -11,7 +11,7 @@ build_requires:
   - CMake
   - "osx-system-openssl:(osx.*)"
   - "GCC-Toolchain:(?!osx)"
-  - UUID:(?!osx)
+  - UUID
   - alibuild-recipe-tools
 prepend_path:
   PYTHONPATH: "${XROOTD_ROOT}/lib/python/site-packages"
@@ -44,7 +44,6 @@ case $ARCHITECTURE in
     # This seems to be a robust way to discover a working SDK path and present it to Python setuptools.
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
-    unset UUID_ROOT
     COMPILER_CC=clang
     COMPILER_CXX=clang++
     COMPILER_LD=clang
@@ -57,7 +56,6 @@ case $ARCHITECTURE in
     # This seems to be a robust way to discover a working SDK path and present it to Python setuptools.
     # This fix is needed only on MacOS when building XRootD Python bindings.
     export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
-    unset UUID_ROOT
     COMPILER_CC=clang
     COMPILER_CXX=clang++
     COMPILER_LD=clang


### PR DESCRIPTION
Notes:
- Option ENABLE_CRYPTO has been removed. It is always enabled/required.
- Options ENABLE_PERL and VOMSXRD_SUBMODULE do not exist since a while.
- CMake now uses the new FindPython.cmake module, so need to update PYTHON_EXECUTABLE to Python_EXECUTABLE.
- Python bindings build system has been completely rewritten, now follows PEP517.

This still likely won't solve the problem with uuid, but should be worth picking up before updating that. Please check build options [here](https://github.com/xrootd/xrootd/blob/master/docs/INSTALL.md#building-from-source-code-with-cmake), there may be things like erasure coding support which you may want to enable (dependencies requires are listed in the same file).