### PR TITLE
Bump geant4_vmc to v6.1.p8

### DIFF
--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v6-1-p6"
+tag: "v6-1-p8"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT


### PR DESCRIPTION
 Includes fixes in biasing (observed with O2 simulation) and in implementation of Gmtod, Gdtom (observed in productions with AliRoot)
