### PR TITLE
Add abseil as o2 build dependency

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -29,6 +29,7 @@ requires:
   - KFParticle
   - RapidJSON
 build_requires:
+  - abseil
   - GMP
   - MPFR
   - googlebenchmark


### PR DESCRIPTION
librans needs abseil as a build dependency as it relies on its fast hash-map implementation.