### PR TITLE
Fix ROOT build on OSX with system glew

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -72,6 +72,7 @@ case $ARCHITECTURE in
   osx*)
     ENABLE_COCOA=1
     DISABLE_MYSQL=1
+    USE_BUILTIN_GLEW=1
     COMPILER_CC=clang
     COMPILER_CXX=clang++
     COMPILER_LD=clang
@@ -174,6 +175,7 @@ cmake $SOURCEDIR                                                                
       -Dbuiltin_fftw3=OFF                                                              \
       -Dtmva-sofie=ON                                                                  \
       -Ddavix=OFF                                                                      \
+      ${USE_BUILTIN_GLEW:+-Dbuiltin_glew=ON}                                           \
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
       ${ROOT_HAS_PYTHON:+-DPYTHON_PREFER_VERSION=3}                                    \
       ${PYTHON_EXECUTABLE:+-DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"}                 \


### PR DESCRIPTION
If glew is installed through brew, ROOT refuses to use it and fails unless we pass `-Dbuiltin_glew=ON`.

Also, unify the many single-use variables into a single `root_flags` array and use that to set special compilation flags. This avoids word-splitting parameters too often and makes the logic a little less complex by removing some single-use variables.