### PR TITLE
Update Rivet (and YODA) builds with an eye toward Rivet integration into O2 pipeline 

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,56 +1,83 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "3.1.8"
-source: https://gitlab.com/hepcedar/rivet
+tag: "rivet-3.1.8"
+source: https://gitlab.com/hepcedar/rivet.git
 requires:
   - YODA
   - fastjet
-  - HepMC3
   - "Python:(?!osx)"
   - "Python-modules:(?!osx)"
   - "Python-system:(osx.*)"
 build_requires:
   - GCC-Toolchain:(?!osx)
+  - YODA
+  - Python
 prepend_path:
-  PYTHONPATH: $RIVET_ROOT/lib/python3.9/site-packages
+  PYTHONPATH: $RIVET_ROOT/lib/python/site-packages
 ---
 #!/bin/bash -e
-case $ARCHITECTURE in
-  osx*)
-    # If we preferred system tools, we need to make sure we can pick them up.
-  ;;
-  *)
-    ARCH_LDFLAGS="-Wl,--no-as-needed"
-  ;;
-esac
-
+#
+# For testing 
+#
+#   alienv enter ./module 
+#   export ALIBUILD_ARCH_PREFIX=el7-x86_64/Packages
+#   export WORK_DIR=/cvmfs/alice.cern.ch
+#   . ${PYTHONHOME}/etc/profile.d/init.sh
+#   . ${HEPMC3_ROOT}/etc/profile.d/init.sh
+#   . ${FASTJET}/etc/profile.d/init.sh
+#   export WORK_DIR=`pwd`/sw
+#   export ALIBUILD_ARCH_PREFIX=
+#   module load `pwd`/sw/slc7_x86-64/YODA/latest/etc/modulefiles/YODA 
+#   . `pwd`/sw/slc7_x86-64/YODA/latest/etc/profile.d/init.sh
+#   export WORK_DIR=
+#   aliBuild build \
+#     --disable Python-modules,boost,defaults-release,CMake,HepMC3,ROOT,YODA,cgal,fastjet \
+#     --always-prefer-system \
+#     --debug \
+#     Rivet
+# 
 rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
-
-export LDFLAGS="$ARCH_LDFLAGS"
-export LIBRARY_PATH="$LD_LIBRARY_PATH"
-
+ 
 (
 unset PYTHON_VERSION
 autoreconf -ivf
+echo =====================================
+printenv | sort -u
+echo =====================================
+CGAL_LDFLAGS="-L${CGAL_ROOT}/lib"
 case $ARCHITECTURE in
   osx*)
-      ./configure                                 \
-	  --prefix="$INSTALLROOT"                   \
-	  --disable-doxygen                         \
-	  --with-yoda="$YODA_ROOT"                  \
-	  --with-hepmc="$HEPMC_ROOT"                \
-	  --with-fastjet="$FASTJET_ROOT"
+	./configure --prefix="$INSTALLROOT"    \
+	    --disable-doxygen                  \
+	    --with-yoda="$YODA_ROOT"           \
+	    --with-hepmc3="$HEPMC3_ROOT"       \
+	    --with-fastjet="$FASTJET_ROOT"     \
+	    LDFLAGS="${CGAL_LDFLAGS}"
   ;;
-  *)
-      ./configure                                 \
-	  --prefix="$INSTALLROOT"                   \
-	  --disable-doxygen                         \
-	  --with-yoda="$YODA_ROOT"                  \
-	  --with-hepmc="$HEPMC_ROOT"                \
-	  --with-fastjet="$FASTJET_ROOT"            \
-	  CYTHON="$PYTHON_MODULES_ROOT/share/python-modules/bin/cython"
+  *) 
+	./configure --prefix="$INSTALLROOT"    			\
+	    --disable-doxygen                  			\
+	    --with-yoda="$YODA_ROOT"           			\
+	    --with-hepmc3="$HEPMC3_ROOT"       			\
+	    --with-fastjet="$FASTJET_ROOT"     			\
+	    LDFLAGS="${CGAL_LDFLAGS} -Wl,--no-as-needed"        \
+	    CYTHON="$PYTHON_MODULES_ROOT/share/python-modules/bin/cython"
   ;;
 esac
+
+# Fix-up rivet-build to include LDFLAGS - needed _before_ bulding 
+# After 3.1.9 this will not be needed. 
+SED_EXPR="s|^myldflags=\"\(.*\)\"|myldflags=\"\1 ${CGAL_LDFLAGS}\"|"
+cat bin/rivet-build | sed -e "${SED_EXPR}" > bin/rivet-build.0
+mv bin/rivet-build bin/rivet-build.orig
+mv bin/rivet-build.0 bin/rivet-build
+chmod 0755 bin/rivet-build
+# Remove -L/usr/lib from pyext/build.py 
+cat pyext/build.py | sed -e 's,-L/usr/lib[^ /"]*,,g' > pyext/build.py.0
+mv pyext/build.py pyext/build.py.orig
+mv pyext/build.py.0 pyext/build.py
+chmod 0755 pyext/build.py
+# Now build 
 make -j$JOBS
 make install
 )
@@ -68,17 +95,47 @@ for P in $REQUIRES $BUILD_REQUIRES; do
   [[ $EXPAND ]] || continue
   SED_EXPR="$SED_EXPR; s!$EXPAND!\$${UPPER}_ROOT!g"
 done
+
+# Modify rivet-config script to use environment 
 cat $INSTALLROOT/bin/rivet-config | sed -e "$SED_EXPR" > $INSTALLROOT/bin/rivet-config.0
 mv $INSTALLROOT/bin/rivet-config.0 $INSTALLROOT/bin/rivet-config
 chmod 0755 $INSTALLROOT/bin/rivet-config
-PYVER="$(basename $(find $INSTALLROOT/lib -type d -name 'python*'))"
 
-# We do a similar thing for the `rivet-build` script so that we again
-# refer to specific installations by environment variable.  We also
+# Modify rivet-build script to use environment.  We also
 # add in the LDFLAGS set at compile time so that when building Rivet
 # plugins we use the same flags as when Rivet is built.
-cat $INSTALLROOT/bin/rivet-build | sed -e 's,^myldflags="\([^"]*\)",myldflags="\1 $LDFLAGS",' -e "$SED_EXPR" > $INSTALLROOT/bin/rivet-build.0
+# Modify rivet-build script to use environment  
+cat $INSTALLROOT/bin/rivet-build | sed -e  "$SED_EXPR" > $INSTALLROOT/bin/rivet-build.0
 mv $INSTALLROOT/bin/rivet-build.0 $INSTALLROOT/bin/rivet-build
+chmod 0755 $INSTALLROOT/bin/rivet-build
+
+# Make symlink in library dir for Python
+PYVER="$(basename $(find $INSTALLROOT/lib -type d -name 'python*'))"
+
+pushd $INSTALLROOT/lib
+ln -s ${PYVER} python
+popd
+
+# Make sure we get the YODA version we need 
+if test "x$YODA_VERSION" != "x" && test "x$YODA_REVISION" != "x" ; then 
+    YODA_NEEDED=${YODA_VERSION}-${YODA_REVISION}
+else 
+    YODA_NEEDED=`basename $YODA_ROOT` 
+fi 
+
+# Make sure we get the FASTJET version we need 
+if test "x$FASTJET_VERSION" != "x" && test "x$FASTJET_REVISION" != "x" ; then 
+    FASTJET_NEEDED=${FASTJET_VERSION}-${FASTJET_REVISION}
+else 
+    FASTJET_NEEDED=`basename $FASTJET_ROOT` 
+fi 
+
+# Make sure we get the HEPMC3 version we need 
+if test "x$HEPMC3_VERSION" != "x" && test "x$HEPMC3_REVISION" != "x" ; then 
+    HEPMC3_NEEDED=${HEPMC3_VERSION}-${HEPMC3_REVISION}
+else 
+    HEPMC3_NEEDED=`basename $HEPMC3_ROOT` 
+fi 
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
@@ -93,8 +150,8 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 ${CGAL_REVISION:+cgal/$CGAL_VERSION-$CGAL_REVISION} ${GMP_REVISION:+GMP/$GMP_VERSION-$GMP_REVISION} YODA/$YODA_VERSION-$YODA_REVISION fastjet/$FASTJET_VERSION-$FASTJET_REVISION HepMC/$HEPMC_VERSION-$HEPMC_REVISION
-# Our environment
+module load BASE/1.0 YODA/$YODA_NEEDED fastjet/$FASTJET_NEEDED HepMC3/$HEPMC3_NEEDED
+# Our environment 
 set RIVET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv RIVET_ROOT \$RIVET_ROOT
 prepend-path PYTHONPATH \$RIVET_ROOT/lib/$PYVER/site-packages

--- a/rivet.sh
+++ b/rivet.sh
@@ -3,6 +3,7 @@ version: "%(tag_basename)s"
 tag: "rivet-3.1.8"
 source: https://gitlab.com/hepcedar/rivet.git
 requires:
+  - HepMC3
   - YODA
   - fastjet
   - "Python:(?!osx)"

--- a/rivet.sh
+++ b/rivet.sh
@@ -46,7 +46,7 @@ autoreconf -ivf
 
 CGAL_LDFLAGS="-L${CGAL_ROOT}/lib"
 GMP_LDFLAGS="-L${GMP_ROOT}/lib"
-LOCAL_LDFLAGS="${CGAL_LDFAGS} ${GMP_LDFLAGS}"
+LOCAL_LDFLAGS="${CGAL_LDFLAGS} ${GMP_LDFLAGS}"
 case $ARCHITECTURE in
     osx*)
 	./configure --prefix="$INSTALLROOT"            \

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,11 +1,11 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "3.1.6-alice1"
-source: https://github.com/alisw/rivet
+tag: "3.1.8"
+source: https://gitlab.com/hepcedar/rivet
 requires:
   - YODA
   - fastjet
-  - HepMC
+  - HepMC3
   - "Python:(?!osx)"
   - "Python-modules:(?!osx)"
   - "Python-system:(osx.*)"
@@ -58,7 +58,9 @@ make install
 # Remove libRivet.la
 rm $INSTALLROOT/lib/libRivet.la
 
-# Dependencies relocation: rely on runtime environment
+# Dependencies relocation: rely on runtime environment.  That is,
+# specific paths in the generated script are replaced by expansions of
+# the relevant environment variables.
 SED_EXPR="s!x!x!"  # noop
 for P in $REQUIRES $BUILD_REQUIRES; do
   UPPER=$(echo $P | tr '[:lower:]' '[:upper:]' | tr '-' '_')
@@ -70,6 +72,13 @@ cat $INSTALLROOT/bin/rivet-config | sed -e "$SED_EXPR" > $INSTALLROOT/bin/rivet-
 mv $INSTALLROOT/bin/rivet-config.0 $INSTALLROOT/bin/rivet-config
 chmod 0755 $INSTALLROOT/bin/rivet-config
 PYVER="$(basename $(find $INSTALLROOT/lib -type d -name 'python*'))"
+
+# We do a similar thing for the `rivet-build` script so that we again
+# refer to specific installations by environment variable.  We also
+# add in the LDFLAGS set at compile time so that when building Rivet
+# plugins we use the same flags as when Rivet is built.
+cat $INSTALLROOT/bin/rivet-build | sed -e 's,^myldflags="\([^"]*\)",myldflags="\1 $LDFLAGS",' -e "$SED_EXPR" > $INSTALLROOT/bin/rivet-build.0
+mv $INSTALLROOT/bin/rivet-build.0 $INSTALLROOT/bin/rivet-build
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"

--- a/rivet.sh
+++ b/rivet.sh
@@ -41,9 +41,7 @@ rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
 (
 unset PYTHON_VERSION
 autoreconf -ivf
-echo =====================================
-printenv | sort -u
-echo =====================================
+
 CGAL_LDFLAGS="-L${CGAL_ROOT}/lib"
 case $ARCHITECTURE in
   osx*)

--- a/rivet.sh
+++ b/rivet.sh
@@ -46,7 +46,7 @@ autoreconf -ivf
 
 CGAL_LDFLAGS="-L${CGAL_ROOT}/lib"
 GMP_LDFLAGS="-L${GMP_ROOT}/lib"
-LOCAL_LDFLAGS="${GCAL_LDFAGS} ${GMP_LDFLAGS}"
+LOCAL_LDFLAGS="${CGAL_LDFAGS} ${GMP_LDFLAGS}"
 case $ARCHITECTURE in
     osx*)
 	./configure --prefix="$INSTALLROOT"            \

--- a/rivet.sh
+++ b/rivet.sh
@@ -6,6 +6,7 @@ requires:
   - HepMC3
   - YODA
   - fastjet
+  - GMP
   - "Python:(?!osx)"
   - "Python-modules:(?!osx)"
   - "Python-system:(osx.*)"
@@ -44,29 +45,34 @@ unset PYTHON_VERSION
 autoreconf -ivf
 
 CGAL_LDFLAGS="-L${CGAL_ROOT}/lib"
+GMP_LDFLAGS="-L${GMP_ROOT}/lib"
+LOCAL_LDFLAGS="${GCAL_LDFAGS} ${GMP_LDFLAGS}"
 case $ARCHITECTURE in
-  osx*)
-	./configure --prefix="$INSTALLROOT"    \
-	    --disable-doxygen                  \
-	    --with-yoda="$YODA_ROOT"           \
-	    --with-hepmc3="$HEPMC3_ROOT"       \
-	    --with-fastjet="$FASTJET_ROOT"     \
-	    LDFLAGS="${CGAL_LDFLAGS}"
-  ;;
-  *) 
-	./configure --prefix="$INSTALLROOT"    			\
-	    --disable-doxygen                  			\
-	    --with-yoda="$YODA_ROOT"           			\
-	    --with-hepmc3="$HEPMC3_ROOT"       			\
-	    --with-fastjet="$FASTJET_ROOT"     			\
-	    LDFLAGS="${CGAL_LDFLAGS} -Wl,--no-as-needed"        \
-	    CYTHON="$PYTHON_MODULES_ROOT/share/python-modules/bin/cython"
+    osx*)
+	./configure --prefix="$INSTALLROOT"            \
+		    --disable-silent-rules             \
+		    --disable-doxygen                  \
+		    --with-yoda="$YODA_ROOT"           \
+		    --with-hepmc3="$HEPMC3_ROOT"       \
+		    --with-fastjet="$FASTJET_ROOT"     \
+		    LDFLAGS="${LOCAL_LDFLAGS}"
+	;;
+    *)
+	LOCAL_LDFLAGS="${LOCAL_LDFLAGS} -Wl,--no-as-needed"
+	./configure --prefix="$INSTALLROOT"    	                        \
+		    --disable-silent-rules                              \
+		    --disable-doxygen                  			\
+		    --with-yoda="$YODA_ROOT"           			\
+		    --with-hepmc3="$HEPMC3_ROOT"       			\
+		    --with-fastjet="$FASTJET_ROOT"     			\
+		    LDFLAGS="${LOCAL_LDFLAGS}"                          \
+		    CYTHON="$PYTHON_MODULES_ROOT/share/python-modules/bin/cython"
   ;;
 esac
 
 # Fix-up rivet-build to include LDFLAGS - needed _before_ bulding 
 # After 3.1.9 this will not be needed. 
-SED_EXPR="s|^myldflags=\"\(.*\)\"|myldflags=\"\1 ${CGAL_LDFLAGS}\"|"
+SED_EXPR="s|^myldflags=\"\(.*\)\"|myldflags=\"\1 ${LOCAL_LDFLAGS}\"|"
 cat bin/rivet-build | sed -e "${SED_EXPR}" > bin/rivet-build.0
 mv bin/rivet-build bin/rivet-build.orig
 mv bin/rivet-build.0 bin/rivet-build

--- a/yoda.sh
+++ b/yoda.sh
@@ -100,10 +100,6 @@ else
     PYTHON_FULL_VERSION=$( echo $PYTHON_EXECUTABLE | sed -e 's|.*/Python/||' -e 's|/bin/.*||') 
 fi
 
-echo "=================================================" 
-printenv | sort -u
-echo "=================================================" 
-
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
@@ -113,9 +109,6 @@ mkdir -p "$MODULEDIR"
 # cat >> "$MODULEFILE"0 <<EoF
 # prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
 # EoF
-
-# Temporary hack, just to see that things work
-TGTDIR=${WORK_DIR}/${PKGPATH}
 
 cat > "$MODULEFILE" <<EoF
 #%Module1.0
@@ -132,7 +125,6 @@ module load BASE/1.0					\\
 
 # Our environment
 set YODA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-set YODA_ROOT ${TGTDIR}
 
 prepend-path PATH \$YODA_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,7 +1,7 @@
 package: YODA
 version: "%(tag_basename)s"
-tag: "v1.9.5"
-source: https://github.com/alisw/yoda
+tag: "yoda-1.9.7"
+source: https://gitlab.com/hepcedar/yoda
 requires:
   - boost
   - "Python:(?!osx)"
@@ -22,52 +22,10 @@ rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
 
 (
 
-PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)') 
-    # python3 here should come from our own Python package ("requires"), see alidist/python.sh
-    # The command will return sthg like "python3.9"
-PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
-    # The command will return sthg like "3.9"
+PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
 
 
 unset PYTHON_VERSION
-    # _Question 2_ :
-    # YODA configure needs at least 2 python-related environment variables :
-    #   From YODA/configure -help :
-    #   PYTHON_VERSION
-    #          The installed Python version to use, for example '2.3'. This
-    #          string will be appended to the Python interpreter canonical
-    #          name.
-    #   PYTHON      the Python interpreter
-
-
-    # After requirement of python module, python installation should point to our custom python (see alidist/python.sh)
-    # from there, it seems to lead to PYTHON_VERSION="v3.9.12",
-    # However it needs here to become PYTHON_VERSION="3.9" for yoda configure, i.e. PYTHON_VERSION is an env variable used by the configure file
-    # See yoda/configure.ac
-
-    # The surprise is that everything seems to be managed automagically when simply having here in the recipe "unset PYTHON_VERSION"
-
-    # 1. Log with require python + _NO_ "unset PYTHON_VERSION" :
-    #   ...
-    #   2022-08-19@18:34:36:DEBUG:YODA:YODA:v1.9.5: checking for pythonv3.9.12... no
-    #   2022-08-19@18:34:36:DEBUG:YODA:YODA:v1.9.5: configure: error: Cannot find pythonv3.9.12 in your system path
-    #   ...
-    # The command to be tested for YODA stems from YODA/configure file (https://github.com/alisw/yoda/blob/v1.9.5/configure) :
-    # l.17138   set dummy python$PYTHON_VERSION; ac_word=$2
-
-    # 2. Log with require python + "unset PYTHON_VERSION" :
-    #   ...
-    #   2022-08-19@18:24:50:DEBUG:YODA:YODA:v1.9.5: checking for python version... 3.9
-    #   ...
-    # i.e. smooth and properly set up
-    #       The key seems to be about the "python" command ($PYTHON) to be looked up,
-    #       if we point towards the right python binary - our python installation - from there the configure seems to find its way on its own
-    # i.e. there is apparently _N0_ explicit need to do the following chain :
-    #     PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)') # python3 here should come from our own Python package, see alidist/python.sh
-    #     PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
-    #     PYTHON="python${PYTHON_VER}" # PYTHON var is needed for the YODA configure
-    #    # PYTHON_VERSION=$PYTHON_VER # PYTHON_VERSION var is needed for the YODA configure; for some reason (?), the needed variable seems to be properly set up finally without doing anything further here.
-
 
 case $ARCHITECTURE in
   osx*)
@@ -75,10 +33,6 @@ case $ARCHITECTURE in
   ;;
   *)
       ./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT" CYTHON="$PYTHON_MODULES_ROOT/share/python-modules/bin/cython"
-      # --enable-root is needed to build/access e.g. yoda2root and root2yoda conversion scripts between YODA and ROOT formats (e.g. ROOT::TH1D <-> YODA::Histo1D)
-      # PyROOT compatibility is enabled by default in YODA (v1.9.5), PyROOT is built by default in our ROOT version.
-      # root-config is needed behind the scene here to configure properly the ROOT environment.
-
   ;;
 esac
 make -j$JOBS
@@ -92,11 +46,14 @@ make install
 #   the prepend_path occurs _after_ the built is completed.)
 
 pushd ${INSTALLROOT}/lib
-# Hypothesis : path towards lib is expected as $YODA_ROOT/lib/ (and nothing like $YODA_ROOT/lib64 or $YODA_ROOT/local/lib/ ...)
-# NOTE : there could be cases where python bindings are installed as relative to INSTALLROOT : case not met so far for YODA (slc, ubuntu) ...
+# Hypothesis : path towards lib is expected as $YODA_ROOT/lib/ (and
+# nothing like $YODA_ROOT/lib64 or $YODA_ROOT/local/lib/ ...)  NOTE :
+# there could be cases where python bindings are installed as relative
+# to INSTALLROOT : case not met so far for YODA (slc, ubuntu) ...
 
 if [[ -d python${PYTHON_VER} ]]; then
-    ln -s python${PYTHON_VER} python # symlink from ${INSTALLROOT}/lib/python3.9 to ${INSTALLROOT}/lib/python
+    # symlink from ${INSTALLROOT}/lib/python3.9 to ${INSTALLROOT}/lib/python
+    ln -s python${PYTHON_VER} python 
 fi
 
 if [[ ! -e python ]] && echo "YODA env pb: NO PYTHON SYMLINK CREATED for python${PYTHON_VER} in: $(pwd -P)"; then 

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,7 +1,7 @@
 package: YODA
 version: "%(tag_basename)s"
 tag: "yoda-1.9.7"
-source: https://gitlab.com/hepcedar/yoda
+source: https://gitlab.com/hepcedar/yoda.git
 requires:
   - boost
   - "Python:(?!osx)"

--- a/yoda.sh
+++ b/yoda.sh
@@ -22,8 +22,10 @@ rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
 
 (
 
-PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
-
+PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
+PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
+echo "PYTHON_EXECUTABLE='$PYTHON_EXECUTABLE'"
+echo "PYTHON_VER='$PYTHON_VER'" 
 
 unset PYTHON_VERSION
 

--- a/yoda.sh
+++ b/yoda.sh
@@ -3,64 +3,84 @@ version: "%(tag_basename)s"
 tag: "yoda-1.9.7"
 source: https://gitlab.com/hepcedar/yoda.git
 requires:
-  - boost
   - "Python:(?!osx)"
   - "Python-modules:(?!osx)"
   - "Python-system:(osx.*)"
   - ROOT
 build_requires:
   - "autotools:(slc6|slc7)"
+  - HepMC3
+  - Python
 prepend_path:
-  # See below at build time the management towards generic path .../lib/python/site-packages
   PYTHONPATH: $YODA_ROOT/lib/python/site-packages
 ---
 #!/bin/bash
-
+#
+# HepMC3 in build-requirements so that same ROOT as used 
+# for HepMC3 is picked up.  This is to avoid 
+# incompatibilities between different ROOT version
+#
+# Test building with 
+#
+#   alienv enter ./module 
+#   export ALIBUILD_ARCH_PREFIX=el7-x86_64/Packages
+#   export WORK_DIR=/cvmfs/alice.cern.ch
+#   . ${PYTHONHOME}/etc/profile.d/init.sh
+#   . ${HEPMC3_ROOT}/etc/profile.d/init.sh
+#   aliBuild build \
+#     --disable Python-modules,boost,defaults-release,CMake,HepMC3,ROOT \
+#     --always-prefer-system \
+#     --debug \
+#     YODA 
+# 
+# Note that the '--disable' option prevents 
+#
+# - aliBuild from trying to build what we already have albeit not under
+#   WORK_DIR/sw
+# - aliBuild from importing depency package settings to be loaded and 
+#   written to 'YODA/version/etc/profile.d/init.sh'
+# - Variables to be set when making the module file
+#
+# I've not figured out a way to not build all dependencies, and there is 
+# a lot, while still loading in the correct settings for build requirements
+# and so on. As far as I can tell, it's not really supported by aliBuild - 
+# surprise!
+# 
 rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ ./
 
 [[ -e .missing_timestamps ]] && ./missing-timestamps.sh --apply || autoreconf -ivf
 
 (
-
 PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
-PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
-echo "PYTHON_EXECUTABLE='$PYTHON_EXECUTABLE'"
-echo "PYTHON_VER='$PYTHON_VER'" 
-
-unset PYTHON_VERSION
+PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'from sys import version_info as vi; print(f"{vi.major}.{vi.minor}")' )
+if test "x$PYTHON_MODULES_ROOT" = "x" ; then 
+    PMBIN=`echo $PATH | tr ':' '\n' | grep Python-modules | head -n 1` 
+    if test x$PMBIN != x ; then 
+        CYTHON=$PMBIN/cython
+    else 
+        CYTHON=`which cython`
+    fi
+else
+    CYTHON=$PYTHON_MODULES_ROOT/share/python-modules/bin/cython
+fi
 
 case $ARCHITECTURE in
   osx*)
       ./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT"
   ;;
   *)
-      ./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT" CYTHON="$PYTHON_MODULES_ROOT/share/python-modules/bin/cython"
+      ./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT" CYTHON="$CYTHON"
   ;;
 esac
 make -j$JOBS
 make install
 
+pushd $INSTALLROOT/lib
 
-# Manage after compilation+install the path towards python site-package 
-#   i.e. we aim at adapting from hardcoded "$YODA_ROOT/lib/python3.9/site-packages" to a generic symlink "$YODA_ROOT/lib/python/site-packages"
-#   inspired from recipe alidist/xrootd.sh
-#   (What we do here, at built time, is needed for "prepend_path PYTHONPATH" above in the recipe header;
-#   the prepend_path occurs _after_ the built is completed.)
-
-pushd ${INSTALLROOT}/lib
-# Hypothesis : path towards lib is expected as $YODA_ROOT/lib/ (and
-# nothing like $YODA_ROOT/lib64 or $YODA_ROOT/local/lib/ ...)  NOTE :
-# there could be cases where python bindings are installed as relative
-# to INSTALLROOT : case not met so far for YODA (slc, ubuntu) ...
-
-if [[ -d python${PYTHON_VER} ]]; then
-    # symlink from ${INSTALLROOT}/lib/python3.9 to ${INSTALLROOT}/lib/python
-    ln -s python${PYTHON_VER} python 
-fi
-
-if [[ ! -e python ]] && echo "YODA env pb: NO PYTHON SYMLINK CREATED for python${PYTHON_VER} in: $(pwd -P)"; then 
+[[ -d python${PYTHON_VER} ]] && ln -s python${PYTHON_VER} python 
+[[ ! -e python ]] && \
+    echo "YODA env pb: NO PYTHON SYMLINK CREATED for python${PYTHON_VER} in: $(pwd -P)" && \
     exit 
-fi    
 
 popd  # get back from INSTALLROOT/lib
 
@@ -70,19 +90,33 @@ case $ARCHITECTURE in
         find $INSTALLROOT/lib/ -name "*.dylib" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
     ;;
 esac
-
-
 )
 
+PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
+if test "x$PYTHON_VERSION" != "x" && \
+   test "x$PYTHON_REVISION" != "x" ; then 
+    PYTHON_FULL_VERSION=${PYTHON_VERSION}-${PYTHON_REVISION}
+else
+    PYTHON_FULL_VERSION=$( echo $PYTHON_EXECUTABLE | sed -e 's|.*/Python/||' -e 's|/bin/.*||') 
+fi
 
-
-
-
+echo "=================================================" 
+printenv | sort -u
+echo "=================================================" 
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
+
+# alibuild-generate-module --bin --lib > "$MODULEFILE"0
+# cat >> "$MODULEFILE"0 <<EoF
+# prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+# EoF
+
+# Temporary hack, just to see that things work
+TGTDIR=${WORK_DIR}/${PKGPATH}
+
 cat > "$MODULEFILE" <<EoF
 #%Module1.0
 proc ModulesHelp { } {
@@ -92,17 +126,18 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0                                                    \\
-            boost/$BOOST_VERSION-$BOOST_REVISION                        \\
-            ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION} \\
-            ROOT/$ROOT_VERSION-$ROOT_REVISION
+module load BASE/1.0					\\
+            ${PYTHON_FULL_VERSION:+Python/$PYTHON_FULL_VERSION}	\\
+            ROOT/$ROOT_RELEASE
 
 # Our environment
 set YODA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+set YODA_ROOT ${TGTDIR}
 
 prepend-path PATH \$YODA_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib
 prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib64
 set pythonpath [exec yoda-config --pythonpath]
 prepend-path PYTHONPATH \$pythonpath
+prepend-path PYTHONPATH \$YODA_ROOT/lib/python/site-packages
 EoF


### PR DESCRIPTION
This will do the following updates 
- YODA and Rivet taken directly from upstream repositories.   The older `alisw` repositories are terribly out of date, and the local fixes are no longer needed. 
- YODA depends on HepMC3 to make sure we pull in the right ROOT version (HepMC3 depends on ROOT) when making Rivet 
- Rivet built against HepMC3 as needed for Rivet integration into O2 (see also https://gitlab.com/cholmcc/O2Rivet)

The changes have been checked and validated on `lxplus` albeit in a slightly funny way (because `aliBuild` doesn't play nice with CVMFS).  However, the tests are entirely equivalent to how `aliBuild` would do it from scratch. 

Yours,
_Christian_