### PR TITLE
Fix o2 unittests mac

### DIFF
--- a/curl.sh
+++ b/curl.sh
@@ -10,7 +10,7 @@ build_requires:
 #!/bin/bash -e
 
 if [[ $ARCHITECTURE = osx* ]]; then
-  OPENSSL_ROOT=$(brew --prefix openssl@1.1)
+  OPENSSL_ROOT=$(brew --prefix openssl@3)
 else
   ${OPENSSL_ROOT:+env LDFLAGS=-Wl,-R$OPENSSL_ROOT/lib}
 fi

--- a/o2.sh
+++ b/o2.sh
@@ -82,6 +82,9 @@ incremental_recipe: |
     if [[ ! $BOOST_VERSION && $ARCHITECTURE == osx* ]]; then
       export ROOT_INCLUDE_PATH=$(brew --prefix boost)/include:$ROOT_INCLUDE_PATH
     fi
+    if [[ -z $OPENSSL_REVISION && $ARCHITECTURE == osx* ]]; then
+      export ROOT_INCLUDE_PATH=$(brew --prefix openssl@1.1)/include:$ROOT_INCLUDE_PATH
+    fi
     export ROOT_INCLUDE_PATH=$INSTALLROOT/include:$INSTALLROOT/include/GPU:$ROOT_INCLUDE_PATH
     # Set Geant4 data sets environment
     if [[ "$G4INSTALL" != "" ]]; then
@@ -277,6 +280,9 @@ if [[ $ALIBUILD_O2_TESTS ]]; then
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$O2_ROOT/lib
   if [[ ! $BOOST_VERSION && $ARCHITECTURE == osx* ]]; then
     export ROOT_INCLUDE_PATH=$(brew --prefix boost)/include:$ROOT_INCLUDE_PATH
+  fi
+  if [[ -z $OPENSSL_REVISION && $ARCHITECTURE == osx* ]]; then
+    export ROOT_INCLUDE_PATH=$(brew --prefix openssl@1.1)/include:$ROOT_INCLUDE_PATH
   fi
   export ROOT_INCLUDE_PATH=$INSTALLROOT/include:$INSTALLROOT/include/GPU:$ROOT_INCLUDE_PATH
   # Clean up old coverage data and tests logs


### PR DESCRIPTION
Brew's OpenSSL needs to be added to ROOT_INCLUDE_PATH manually to avoid "illegal instruction" errors at unittest-time when compiling ROOT macros.

This, together with https://github.com/alisw/alidist/pull/5158, fixes most of the unit test errors on the Intel Mac in my tests. A few errors remain, but seem unrelated to OpenSSL.

(I've cherry-picked the commit from #5158 to see if the combined fix works in CI.)