### PR TITLE
Bump DDS to 3.7.23

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -1,6 +1,6 @@
 package: DDS
 version: "%(tag_basename)s"
-tag: "3.7.22"
+tag: "3.7.23"
 source: https://github.com/FairRootGroup/DDS
 requires:
   - boost


### PR DESCRIPTION
Bump DDS to 3.7.23

Needed by macOS Sonoma.
