### PR TITLE
Make sure builds find our protobuf headers

### DIFF
--- a/protobuf.sh
+++ b/protobuf.sh
@@ -4,6 +4,10 @@ source: https://github.com/protocolbuffers/protobuf
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
+prepend_path:
+  # The protobuf headers must match the protoc binary version, so prevent the
+  # use of system headers by putting ours first in the path.
+  PKG_CONFIG_PATH: "$PROTOBUF_ROOT/lib/pkgconfig"
 ---
 
 cmake $SOURCEDIR/cmake                  \

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -4,38 +4,24 @@ source: https://github.com/protocolbuffers/protobuf
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 prepend_path:
   # The protobuf headers must match the protoc binary version, so prevent the
   # use of system headers by putting ours first in the path.
   PKG_CONFIG_PATH: "$PROTOBUF_ROOT/lib/pkgconfig"
 ---
-
-cmake $SOURCEDIR/cmake                  \
-    -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
-    -Dprotobuf_BUILD_TESTS=NO           \
-    -Dprotobuf_MODULE_COMPATIBLE=YES    \
-    -Dprotobuf_BUILD_SHARED_LIBS=OFF    \
+#!/bin/bash -e
+cmake "$SOURCEDIR/cmake"                  \
+    -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
+    -Dprotobuf_BUILD_TESTS=NO             \
+    -Dprotobuf_MODULE_COMPATIBLE=YES      \
+    -Dprotobuf_BUILD_SHARED_LIBS=OFF      \
     -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j $JOBS}
 make install
 
-#ModuleFile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set PROTOBUF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PROTOBUF_ROOT \$PROTOBUF_ROOT
-prepend-path LD_LIBRARY_PATH \$PROTOBUF_ROOT/lib
-prepend-path PATH \$PROTOBUF_ROOT/bin
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv PROTOBUF_ROOT \$PKG_ROOT
 EoF

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -22,6 +22,3 @@ make install
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
-cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
-setenv PROTOBUF_ROOT \$PKG_ROOT
-EoF


### PR DESCRIPTION
The header version must match the version of the protoc binary, which we put in PATH already. Protobuf's installed pkgconfig file contains the right information.

This should solve a build failure observed by a user that had a mismatching version of protobuf installed system-wide.

@ktf, if you prefer only the first commit, I can force-push to remove the cleanup one.