### PR TITLE
Add libuv dependency to libwebsockets

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.7.5"
+tag: "0.7.6"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT

--- a/libuv.sh
+++ b/libuv.sh
@@ -6,6 +6,8 @@ requires:
 build_requires:
   - CMake
   - alibuild-recipe-tools
+prepend_path:
+  PKG_CONFIG_PATH: "$LIBUV_ROOT/lib/pkgconfig"
 prefer_system: (?!slc5.*)
 prefer_system_check: |
   printf "#include <uv/version.h>\n#if UV_VERSION_HEX < 0x12a00\n#error libuv >=1.40.0 required\n#endif\n" | c++ -I$(brew --prefix libuv)/include -xc++ - -c -o /dev/null 2>&1

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -8,6 +8,7 @@ build_requires:
   - "OpenSSL:(?!osx)"
   - ninja
   - alibuild-recipe-tools
+  - libuv
 # On Mac, Brew's libwebsockets loads Brew's Python, which confuses ROOT.
 prefer_system: "(?!osx_)"
 prefer_system_check: |
@@ -47,6 +48,9 @@ cmake $SOURCEDIR                                                    \
       ${OPENSSL_ROOT:+-DOPENSSL_LIBRARIES=$OPENSSL_ROOT/lib/libssl.$SONAME;$OPENSSL_ROOT/lib/libcrypto.$SONAME}     \
       ${OPENSSL_ROOT:+-DLWS_OPENSSL_INCLUDE_DIRS=$OPENSSL_ROOT/include}                                             \
       ${OPENSSL_ROOT:+-DLWS_OPENSSL_LIBRARIES=$OPENSSL_ROOT/lib/libssl.$SONAME;$OPENSSL_ROOT/lib/libcrypto.$SONAME} \
+      -DLWS_WITH_LIBUV=ON                                           \
+      ${LIBUV_ROOT:+-DLIBUV_INCLUDE_DIRS=$LIBUV_ROOT/include}       \
+      ${LIBUV_ROOT:+-DLIBUV_LIBRARIES=$LIBUV_ROOT/lib}              \
       -DLWS_HAVE_OPENSSL_ECDH_H=OFF                                 \
       -DLWS_WITHOUT_TESTAPPS=ON
 cmake --build . --target install ${JOBS+-j $JOBS}

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -49,8 +49,8 @@ cmake $SOURCEDIR                                                    \
       ${OPENSSL_ROOT:+-DLWS_OPENSSL_INCLUDE_DIRS=$OPENSSL_ROOT/include}                                             \
       ${OPENSSL_ROOT:+-DLWS_OPENSSL_LIBRARIES=$OPENSSL_ROOT/lib/libssl.$SONAME;$OPENSSL_ROOT/lib/libcrypto.$SONAME} \
       -DLWS_WITH_LIBUV=ON                                           \
-      ${LIBUV_ROOT:+-DLIBUV_INCLUDE_DIRS=$LIBUV_ROOT/include}       \
-      ${LIBUV_ROOT:+-DLIBUV_LIBRARIES=$LIBUV_ROOT/lib}              \
+      ${LIBUV_REVISION:+-DLIBUV_INCLUDE_DIRS=$LIBUV_ROOT/include}   \
+      ${LIBUV_REVISION:+-DLIBUV_LIBRARIES=$LIBUV_ROOT/lib}          \
       -DLWS_HAVE_OPENSSL_ECDH_H=OFF                                 \
       -DLWS_WITHOUT_TESTAPPS=ON
 cmake --build . --target install ${JOBS+-j $JOBS}

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -50,7 +50,7 @@ cmake $SOURCEDIR                                                    \
       ${OPENSSL_ROOT:+-DLWS_OPENSSL_LIBRARIES=$OPENSSL_ROOT/lib/libssl.$SONAME;$OPENSSL_ROOT/lib/libcrypto.$SONAME} \
       -DLWS_WITH_LIBUV=ON                                           \
       ${LIBUV_REVISION:+-DLIBUV_INCLUDE_DIRS=$LIBUV_ROOT/include}   \
-      ${LIBUV_REVISION:+-DLIBUV_LIBRARIES=$LIBUV_ROOT/lib}          \
+      ${LIBUV_REVISION:+-DLIBUV_LIBRARIES=$LIBUV_ROOT/lib/libuv.$SONAME} \
       -DLWS_HAVE_OPENSSL_ECDH_H=OFF                                 \
       -DLWS_WITHOUT_TESTAPPS=ON
 cmake --build . --target install ${JOBS+-j $JOBS}


### PR DESCRIPTION
Enable libuv support in JAliEn-ROOT by adding libuv as a dependency in libwebsockets recipe.

This change doesn't turn on libuv in jalien-root immediately, but prepares the transition. It is controlled by a dedicated lws option in the code whether libwebsockets use libuv loop or the default one.