### PR TITLE
Cache Go artifacts in build directory

### DIFF
--- a/coconut.sh
+++ b/coconut.sh
@@ -12,6 +12,7 @@ source: https://github.com/AliceO2Group/Control
 export GOPATH=$PWD/go
 export PATH=$GOPATH/bin:$PATH
 export GO111MODULE=on
+export GOCACHE=$BUILDDIR/cache
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD
 rsync -a --delete $SOURCEDIR/ $BUILD/

--- a/control-core.sh
+++ b/control-core.sh
@@ -14,6 +14,7 @@ source: https://github.com/AliceO2Group/Control
 export GOPATH=$PWD/go
 export PATH=$GOPATH/bin:$PATH
 export GO111MODULE=on
+export GOCACHE=$BUILDDIR/cache
 BUILD=$GOPATH/src/github.com/AliceO2Group/Control
 mkdir -p $BUILD
 rsync -a --delete $SOURCEDIR/ $BUILD/


### PR DESCRIPTION
This avoids leaving the cache in the user's home directory, or trying to access potentially nonexistent paths in a build container.