### PR TITLE
Bump JETSCAPE to 3.1.1-alice3

### DIFF
--- a/jetscape.sh
+++ b/jetscape.sh
@@ -1,6 +1,6 @@
 package: JETSCAPE
 version: "%(tag_basename)s"
-tag: "v3.1.1-alice2"
+tag: "v3.1.1-alice3"
 source: https://github.com/alisw/JETSCAPE
 requires:
   - boost


### PR DESCRIPTION
Bump JETSCAPE to 3.1.1-alice3

Needed to detect the new ROOT
