### PR TITLE
alidist/defaults-generators.sh - update fastjet version to match O² standards

### DIFF
--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -14,8 +14,8 @@ overrides:
     requires:
       - GCC-Toolchain:(?!osx)
   fastjet:
-    version: v3.4.0_1.045-alice1
-    tag: v3.4.0_1.045-alice1
+    version: v3.4.1_1.052-alice2
+    tag: v3.4.1_1.052-alice2
   pythia:
     tag: v8304
     requires:


### PR DESCRIPTION

You may want to stay tuned to alidist/defaults-o2.sh to make the best compatibility between Aligenerators and O², likely wise in view of convergence for [Rivet] workflow in [0²].

i.e. move FastJet `v3.4.0_1.045-alice1` to `v3.4.1_1.052-alice2`
To be tried out.