### PR TITLE
Bump boost to 1.83.0-alice1

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -1,6 +1,6 @@
 package: boost
-version: v1.75.0
-tag: v1.75.0
+version: v1.83.0-alice1
+tag: v1.83.0-alice1
 source: https://github.com/alisw/boost.git
 requires:
   - "GCC-Toolchain:(?!osx)"
@@ -54,7 +54,7 @@ fi
 
 TMPB2=$BUILDDIR/tmp-boost-build
 case $ARCHITECTURE in
-  osx*) TOOLSET=clang-darwin ;;
+  osx*) TOOLSET=clang ;;
   *) TOOLSET=gcc ;;
 esac
 
@@ -84,10 +84,8 @@ b2 -q                                            \
    --without-graph                               \
    --without-graph_parallel                      \
    --without-locale                              \
-   --without-math                                \
    --without-mpi                                 \
    ${BOOST_NO_PYTHON:+--without-python}          \
-   --without-wave                                \
    --debug-configuration                         \
    -sNO_ZSTD=1                                   \
    ${BZ2_ROOT:+-sBZIP2_INCLUDE="$BZ2_ROOT/include"}  \

--- a/jetscape.sh
+++ b/jetscape.sh
@@ -1,6 +1,6 @@
 package: JETSCAPE
 version: "%(tag_basename)s"
-tag: "v3.1.1-alice4"
+tag: "v3.1.1-alice5"
 source: https://github.com/alisw/JETSCAPE
 requires:
   - boost


### PR DESCRIPTION
Bump boost to 1.83.0-alice1

Custom tag needed due to change in behaviour of boost::interprocess.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/alidist/pull/5242).
* #5240 (2 commits)
* __->__ #5242 (2 commits)