### PR TITLE
Updates for Rivet

### DIFF
--- a/fastjet.sh
+++ b/fastjet.sh
@@ -90,6 +90,7 @@ module load BASE/1.0 ${CGAL_REVISION:+cgal/$CGAL_VERSION-$CGAL_REVISION}
 # Our environment
 set FASTJET_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv FASTJET \$FASTJET_ROOT
+setenv FASTJET_ROOT \$FASTJET_ROOT
 prepend-path PATH \$FASTJET_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$FASTJET_ROOT/lib
 prepend-path ROOT_INCLUDE_PATH \$FASTJET_ROOT/include

--- a/rivet.sh
+++ b/rivet.sh
@@ -13,6 +13,7 @@ requires:
 build_requires:
   - GCC-Toolchain:(?!osx)
   - YODA
+  - cgal
   - Python
 prepend_path:
   PYTHONPATH: $RIVET_ROOT/lib/python/site-packages

--- a/yoda.sh
+++ b/yoda.sh
@@ -125,7 +125,7 @@ module load BASE/1.0					\\
 
 # Our environment
 set YODA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
- 
+setenv YODA_ROOT \$YODA_ROOT 
 prepend-path PATH \$YODA_ROOT/bin
 prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib
 prepend-path LD_LIBRARY_PATH \$YODA_ROOT/lib64


### PR DESCRIPTION
- FastJet and YODA export `FASTJET_ROOT` and `YODA_ROOT`, respectively
- Rivet build-requires `cgal` so that `CGAL_ROOT` _values_ in `rivet-config` and `rivet-build` gets properly substituted at build-time with references to environment variable `CGAL_ROOT` at run-time

See also comment at

   https://github.com/alisw/alidist/pull/5221