### PR TITLE
alienpy 1.5.4 bugfix

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.5.3"
+tag: "1.5.4"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* Due to wrong import ordering, stdout print log messages destined to logfile
	* It could confuse tools that do a scrapping of alienpy stdout

Secondary improvements: 
* Make X509_CERT_{DIR,FILE} requirements without fallback: if they are specified then it should be the only option to be used
* Relax the validity checking of CApath location, it only requires to have at least one pem file into it
* add `-report` option to `ccdb` command