### PR TITLE
alienpy 1.5.5:: quick fix for files missing md5 hash in catalogue

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.5.4"
+tag: "1.5.5"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
@TimoWilken done :)
