### PR TITLE
Bump Pythia8 to support C++20

### DIFF
--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -17,7 +17,7 @@ overrides:
     version: v3.4.1_1.052-alice2
     tag: v3.4.1_1.052-alice2
   pythia:
-    tag: v8304
+    tag: v8304-alice1
     requires:
       - lhapdf
       - boost

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -36,7 +36,7 @@ overrides:
   fastjet:
     tag: v3.4.0_1.045-alice1
   pythia:
-    tag: v8304
+    tag: v8304-alice1
     requires:
       - lhapdf
       - boost

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -33,7 +33,7 @@ overrides:
   fastjet:
     tag: v3.4.1_1.052-alice2
   pythia:
-    tag: v8304
+    tag: v8304-alice1
     requires:
       - lhapdf
       - boost

--- a/pythia.sh
+++ b/pythia.sh
@@ -1,6 +1,6 @@
 package: pythia
 version: "%(tag_basename)s"
-tag: v8243-alice1a
+tag: v8243-alice1b
 source: https://github.com/alisw/pythia8
 requires:
   - lhapdf


### PR DESCRIPTION
Bump Pythia8 to support C++20

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/alidist/pull/5256).
* #5240 (2 commits)
* __->__ #5256