### PR TITLE
[O2-4427] Don't use Homebrew's libwebsockets

### DIFF
--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -10,8 +10,19 @@ build_requires:
   - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
-  printf '#if !__has_include(<lws_config.h>)\n#error \"Cannot find libwebsocket\"\n#endif\n' | cc -I$(brew --prefix libwebsockets)/include -c -xc - -o /dev/null
-  printf '#include <lws_config.h>\n#if LWS_LIBRARY_VERSION_NUMBER < 4000000 \n#error \"JAliEn-ROOT requires libwebsockets >= 4.0 but lesser version was detected\"\n#endif\n' | cc -c -x c -I$(brew --prefix libwebsockets)/include - -o /dev/null || exit 1
+  #!/bin/bash -e
+  [ "$(uname)" != Darwin ]   # On Mac, Brew's libwebsockets loads Brew's Python, which confuses ROOT.
+  cc -c -xc - -o /dev/null <<\EOF
+  #if !__has_include(<lws_config.h>)
+  #error "Cannot find libwebsocket"
+  #endif
+  EOF
+  cc -c -xc - -o /dev/null <<\EOF
+  #include <lws_config.h>
+  #if LWS_LIBRARY_VERSION_NUMBER < 4000000
+  #error "JAliEn-ROOT requires libwebsockets >= 4.0 but lesser version was detected"
+  #endif
+  EOF
 ---
 #!/bin/bash -e
 SONAME=so

--- a/libwebsockets.sh
+++ b/libwebsockets.sh
@@ -8,10 +8,10 @@ build_requires:
   - "OpenSSL:(?!osx)"
   - ninja
   - alibuild-recipe-tools
-prefer_system: .*
+# On Mac, Brew's libwebsockets loads Brew's Python, which confuses ROOT.
+prefer_system: "(?!osx_)"
 prefer_system_check: |
   #!/bin/bash -e
-  [ "$(uname)" != Darwin ]   # On Mac, Brew's libwebsockets loads Brew's Python, which confuses ROOT.
   cc -c -xc - -o /dev/null <<\EOF
   #if !__has_include(<lws_config.h>)
   #error "Cannot find libwebsocket"


### PR DESCRIPTION
The version from brew loads brew's python at runtime, which leads to ROOT errors: https://alice.its.cern.ch/jira/browse/O2-4427