### PR TITLE
Bump to monitoring 3.18.1

### DIFF
--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v3.17.5
+tag: v3.18.1
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Bump to monitoring 3.18.1

Required for C++20

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/alidist/pull/5262).
* #5240
* __->__ #5262