### PR TITLE
Roll back to QC v1.124.0

### DIFF
--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -1,6 +1,6 @@
 package: QualityControl
 version: "%(tag_basename)s"
-tag: v1.125.0
+tag: v1.124.0
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Due to problems with Check Runners hanging indefinitely and objects without checks associated not being published.