### PR TITLE
Strip libonnxruntime by default

### DIFF
--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -22,8 +22,8 @@ case $ARCHITECTURE in
   ;;
   *) ;;
 esac
-
 mkdir -p $INSTALLROOT
+
 
 cmake $SOURCEDIR                                                 \
       ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER=$CXX_COMPILER}        \

--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -27,22 +27,22 @@ popd
 
 mkdir -p $INSTALLROOT
 
-cmake "$SOURCEDIR/cmake" \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
-      -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") \
-      -Donnxruntime_BUILD_UNIT_TESTS=OFF \
-      -Donnxruntime_PREFER_SYSTEM_LIB=ON \
-      -Donnxruntime_BUILD_SHARED_LIB=ON \
-      -DProtobuf_USE_STATIC_LIBS=ON \
-      ${PROTOBUF_ROOT:+-DProtobuf_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.a} \
+cmake "$SOURCEDIR/cmake"                                                              \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                             \
+      -DCMAKE_BUILD_TYPE=Release                                                      \
+      -DCMAKE_INSTALL_LIBDIR=lib                                                      \
+      -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)")           \
+      -Donnxruntime_BUILD_UNIT_TESTS=OFF                                              \
+      -Donnxruntime_PREFER_SYSTEM_LIB=ON                                              \
+      -Donnxruntime_BUILD_SHARED_LIB=ON                                               \
+      -DProtobuf_USE_STATIC_LIBS=ON                                                   \
+      ${PROTOBUF_ROOT:+-DProtobuf_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf.a}           \
       ${PROTOBUF_ROOT:+-DProtobuf_LITE_LIBRARY=$PROTOBUF_ROOT/lib/libprotobuf-lite.a} \
-      ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_LIBRARY=$PROTOBUF_ROOT/lib/libprotoc.a} \
-      ${PROTOBUF_ROOT:+-DProtobuf_INCLUDE_DIR=$PROTOBUF_ROOT/include} \
-      ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc} \
-      ${RE2_ROOT:+-DRE2_INCLUDE_DIR=${RE2_ROOT}/include} \
-      ${FLATBUFFERS_ROOT:+-DFLATBUFFERS_INCLUDE_DIR=${FLATBUFFERS_ROOT}/include} \
+      ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_LIBRARY=$PROTOBUF_ROOT/lib/libprotoc.a}      \
+      ${PROTOBUF_ROOT:+-DProtobuf_INCLUDE_DIR=$PROTOBUF_ROOT/include}                 \
+      ${PROTOBUF_ROOT:+-DProtobuf_PROTOC_EXECUTABLE=$PROTOBUF_ROOT/bin/protoc}        \
+      ${RE2_ROOT:+-DRE2_INCLUDE_DIR=${RE2_ROOT}/include}                              \
+      ${FLATBUFFERS_ROOT:+-DFLATBUFFERS_INCLUDE_DIR=${FLATBUFFERS_ROOT}/include}      \
       ${BOOST_ROOT:+-DBOOST_INCLUDE_DIR=${BOOST_ROOT}/include}
 
 cmake --build . -- ${JOBS:+-j$JOBS} install


### PR DESCRIPTION
Strip libonnxruntime by default

From:

-rwxr-xr-x  1 root root  602M Nov 23 02:08 libonnxruntime.so.1.12.1

to:

-rwxr-xr-x  1 root root   12M Dec 15 09:07 libonnxruntime.so.1.12.1
