### PR TITLE
Bump JAlien-ROOT to 0.7.5

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.7.4"
+tag: "0.7.5"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Fixes issue with ROOT 6.30.XX compiled on slc7 and running on RHEL8 / ALMA9