### PR TITLE
Bump XRootD to v5.6.4

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.6.0"
+tag: "v5.6.4"
 source: https://github.com/xrootd/xrootd
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Bump XRootD to v5.6.4

Apparently needed by bleading edge ROOT.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/alidist/pull/5305).
* #5304 (2 commits)
* __->__ #5305