### PR TITLE
Bump GEANT4 to v11.2.0

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -1,6 +1,6 @@
 package: GEANT4
 version: "%(tag_basename)s"
-tag: "v11.0.4"
+tag: "v11.2.0"
 # source: https://github.com/alisw/geant4.git
 source: https://gitlab.cern.ch/geant4/geant4.git
 requires:

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v6-1-update1-p9"
+tag: "v6-5"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT

--- a/vgm.sh
+++ b/vgm.sh
@@ -1,6 +1,6 @@
 package: vgm
 version: "%(tag_basename)s"
-tag: "v5-0"
+tag: "v5-2"
 source: https://github.com/vmc-project/vgm
 requires:
   - ROOT


### PR DESCRIPTION
Compiling GEANT4 v11.0.4 with gcc 13.2 fails because of missing `cstdint` includes which is fixed in v11.2.0. 

Not sure if anything speaks agains this bump?