### PR TITLE
xrootd 5.6.6

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.6.0"
+tag: "v5.6.6"
 source: https://github.com/xrootd/xrootd
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
With recent 5.6.6 there was introduced an client side improvement for resiliency to replica errors. 
More info can be seen in the [release page](https://github.com/xrootd/xrootd/releases)
or in the [release notes](https://github.com/xrootd/xrootd/blob/v5.6.6/docs/ReleaseNotes.txt)