### PR TITLE
Bump JAliEn-ROOT 0.7.7

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.7.6"
+tag: "0.7.7"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Fixes brown issue when running Centos builds on Ubuntu.