### PR TITLE
Do not check for member names

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -44,7 +44,6 @@ cp thinned_compile_commands.json compile_commands.json
 
 # List of explicitely enabled C++ checks (make sure they are all green)
 CHECKS="${O2_CHECKER_CHECKS:--*\
-,aliceO2-member-name\
 ,aliceO2-namespace-naming\
 ,modernize-avoid-bind\
 ,modernize-deprecated-headers\


### PR DESCRIPTION
Do not check for member names

Somehow this check was not fully working before and it's now complaining
about actual violation.

It is deemed however too complicated to fix them at this point in time.
