### PR TITLE
Add GMP requirement to fastjet

### DIFF
--- a/fastjet.sh
+++ b/fastjet.sh
@@ -4,6 +4,7 @@ tag: "v3.2.1_1.024-alice3"
 source: https://github.com/alisw/fastjet
 requires:
   - cgal
+  - GMP
 env:
   FASTJET: "$FASTJET_ROOT"
 ---


### PR DESCRIPTION
Not sure if this is really correct, or if instead the `module load GMP` part should be removed in the fastjet recipe. But we should find a fix quickly so opening this now for discussion @ktf 