### PR TITLE
Don't check namespace names

### DIFF
--- a/o2checkcode.sh
+++ b/o2checkcode.sh
@@ -44,7 +44,6 @@ cp thinned_compile_commands.json compile_commands.json
 
 # List of explicitely enabled C++ checks (make sure they are all green)
 CHECKS="${O2_CHECKER_CHECKS:--*\
-,aliceO2-namespace-naming\
 ,modernize-avoid-bind\
 ,modernize-deprecated-headers\
 ,modernize-make-shared\


### PR DESCRIPTION
Analogously to https://github.com/alisw/alidist/pull/5344. Spurious `aliceO2-namespace-naming` errors seen e.g. here: https://github.com/AliceO2Group/AliceO2/pull/12682.

Assuming the same reasoning applies as for #5344!