### PR TITLE
Fix build with o2 defaults on slc9

### DIFF
--- a/datadistribution.sh
+++ b/datadistribution.sh
@@ -13,7 +13,6 @@ requires:
   - protobuf
   - O2
   - fmt
-  - "ucx:(slc8|slc9)"
 build_requires:
   - CMake
 source: https://github.com/AliceO2Group/DataDistribution

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -51,6 +51,20 @@ overrides:
       BUILD_ANALYSIS: "OFF"   # Disable analysis in O2
       BUILD_EXAMPLES: "OFF"   # Disable examples in O2
       O2_BUILD_FOR_FLP: "ON"
+  DataDistribution:
+    requires:
+      - "GCC-Toolchain:(?!osx)"
+      - boost
+      - FairLogger
+      - libInfoLogger
+      - FairMQ
+      - Ppconsul
+      - grpc
+      - Monitoring
+      - protobuf
+      - O2
+      - fmt
+      - ucx   # this one added
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -40,6 +40,20 @@ overrides:
     requires:
       - lhapdf
       - boost
+  DataDistribution:
+    requires:
+      - "GCC-Toolchain:(?!osx)"
+      - boost
+      - FairLogger
+      - libInfoLogger
+      - FairMQ
+      - Ppconsul
+      - grpc
+      - Monitoring
+      - protobuf
+      - O2
+      - fmt
+      - ucx   # this one added
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the


### PR DESCRIPTION
If we're going to build analysis tags on slc9, we can't assume that building on slc9 implies o2-dataflow defaults (or an FLP/EPN environment).

Move FLP/EPN-specific requirement into defaults-o2-dataflow and defaults-o2-epn.