### PR TITLE
xjalienfs 1.5.8

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.5.7"
+tag: "1.5.8"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
[Diff 1.5.7..1.5.8](https://github.com/adriansev/jalien_py/compare/1.5.7...1.5.8)

Main changes
* act on ALIEN_SITE env var
* XRootD:: cp : always send md5 when asking for write(upload) access
* XRootD:: cp : for writing(upload) use the used md5 from access request to inform xrootd to use it as pre-computed checksum and verify the uploaded file 