### PR TITLE
Run xjalienfs's self-tests after installation

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -43,9 +43,11 @@ rm -fv "$INSTALLROOT"/bin/*.bak
 
 # Now that alien.py is installed, we can run its tests. They need a JAliEn
 # token though, so skip them if we have none.
+set +x   # avoid echoing tokens
 if [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]; then
   PATH="$INSTALLROOT/bin:$PATH" "$SOURCEDIR/tests/run_tests" ci-tests
 fi
+set -x
 
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -44,7 +44,7 @@ rm -fv "$INSTALLROOT"/bin/*.bak
 # Now that alien.py is installed, we can run its tests. They need a JAliEn
 # token though, so skip them if we have none.
 if [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]; then
-  PATH="$INSTALLROOT/bin:$PATH" "$SOURCEDIR/tests/run_tests"
+  PATH="$INSTALLROOT/bin:$PATH" "$SOURCEDIR/tests/run_tests" ci-tests
 fi
 
 # Modulefile

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.5.8"
+tag: "1.5.9"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -41,10 +41,13 @@ for binfile in "$INSTALLROOT"/bin/*; do
 done
 rm -fv "$INSTALLROOT"/bin/*.bak
 
-# Now that alien.py is installed, we can run its tests. They need a JAliEn
-# token though, so skip them if we have none.
+# Now that alien.py is installed, we can run its tests.
 set +x   # avoid echoing tokens
-if [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]; then
+# Make sure we don't accidentally run read-write tests with users' JAliEn keys.
+if [ -n "$ALIBUILD_XJALIENFS_TESTS" ] &&
+     # Tests need a JAliEn token, so skip them if we have none.
+     [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]
+then
   PATH="$INSTALLROOT/bin:$PATH" \
   PYTHONPATH="$INSTALLROOT/lib/python/site-packages:$PYTHONPATH" \
   "$SOURCEDIR/tests/run_tests" ci-tests

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -41,6 +41,12 @@ for binfile in "$INSTALLROOT"/bin/*; do
 done
 rm -fv "$INSTALLROOT"/bin/*.bak
 
+# Now that alien.py is installed, we can run its tests. They need a JAliEn
+# token though, so skip them if we have none.
+if [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]; then
+  PATH="$INSTALLROOT/bin:$PATH" "$SOURCEDIR/tests/run_tests"
+fi
+
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -45,7 +45,9 @@ rm -fv "$INSTALLROOT"/bin/*.bak
 # token though, so skip them if we have none.
 set +x   # avoid echoing tokens
 if [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]; then
-  PATH="$INSTALLROOT/bin:$PATH" "$SOURCEDIR/tests/run_tests" ci-tests
+  PATH="$INSTALLROOT/bin:$PATH" \
+  PYTHONPATH="$INSTALLROOT/lib/python/site-packages:$PYTHONPATH" \
+  "$SOURCEDIR/tests/run_tests" ci-tests
 fi
 set -x
 


### PR DESCRIPTION
In CI, we have the `JALIEN_TOKEN_{CERT,KEY}` variables, so we could use them to run `alien.py`'s self-tests. These are quick and would only be run when xjalienfs is rebuit, i.e. when it is updated.

We should probably add another CI variable (analogous to `ALIBUILD_O2_TESTS` to enable this, instead of detecting the `JALIEN_TOKEN_*` variables, since users might set those. We don't want to accidentally run these tests with users' tokens, since the self-tests create and delete various test files and directories in AliEn.