### PR TITLE
Make ROOT use FFTW3 from alidist

### DIFF
--- a/fftw3.sh
+++ b/fftw3.sh
@@ -18,30 +18,23 @@ elif [[ $FFTW3_LONG_DOUBLE == "ON" ]]; then
   unset FFTW3_WITH_AVX
   FFTW3_FLOAT="OFF"
   FFTW3_DOUBLE="OFF"
-else # keep FLOAT default option as it was
-  FFTW3_FLOAT="ON"
-  FFTW3_DOUBLE="OFF"
+else
+  # Install libfftw3.so by default, not libfftw3{f,l}.so. ROOT only looks for the former.
+  FFTW3_FLOAT="OFF"
+  FFTW3_DOUBLE="ON"
   FFTW3_LONG_DOUBLE="OFF"
 fi
 
 case $ARCHITECTURE in
-    osx_arm64)
-  cmake $SOURCEDIR                                          \
-        -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}"        \
-        -DCMAKE_INSTALL_LIBDIR:PATH="lib"                   \
-        -DENABLE_LONG_DOUBLE=${FFTW3_LONG_DOUBLE-OFF}       \
-        -DENABLE_FLOAT=${FFTW3_FLOAT-OFF}
-  ;;
-    *)
-  cmake $SOURCEDIR                                          \
-        -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}"        \
-        -DCMAKE_INSTALL_LIBDIR:PATH="lib"                   \
-        -DENABLE_LONG_DOUBLE=${FFTW3_LONG_DOUBLE-OFF}       \
-        -DENABLE_FLOAT=${FFTW3_FLOAT-OFF}                   \
-        ${FFTW3_WITH_AVX:+-DENABLE_AVX=ON}
-  ;;
+  osx_arm64) unset FFTW3_WITH_AVX ;;
 esac
 
+cmake "$SOURCEDIR"                                        \
+      -DCMAKE_INSTALL_PREFIX:PATH="${INSTALLROOT}"        \
+      -DCMAKE_INSTALL_LIBDIR:PATH="lib"                   \
+      -DENABLE_LONG_DOUBLE=${FFTW3_LONG_DOUBLE-OFF}       \
+      -DENABLE_FLOAT=${FFTW3_FLOAT-OFF}                   \
+      ${FFTW3_WITH_AVX:+-DENABLE_AVX=ON}
 make ${JOBS+-j $JOBS}
 make install
 
@@ -49,4 +42,4 @@ make install
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --bin --lib > $MODULEFILE
+alibuild-generate-module --bin --lib > "$MODULEFILE"

--- a/root.sh
+++ b/root.sh
@@ -74,7 +74,6 @@ case $ARCHITECTURE in
   osx*)
     ENABLE_COCOA=1
     DISABLE_MYSQL=1
-    USE_BUILTIN_GLEW=1
     COMPILER_CC=clang
     COMPILER_CXX=clang++
     COMPILER_LD=clang
@@ -134,6 +133,8 @@ cmake $SOURCEDIR                                                                
       -Dbuiltin_gl2ps=ON                                                               \
       -Dbuiltin_cfitsio=ON                                                             \
       -Dbuiltin_ftgl=ON                                                                \
+      -Dbuiltin_zstd=ON                                                                \
+      -Dbuiltin_glew=ON                                                                \
       -Dalien=OFF                                                                      \
       ${CMAKE_CXX_STANDARD:+-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}}                \
       -Dfreetype=ON                                                                    \
@@ -182,7 +183,6 @@ cmake $SOURCEDIR                                                                
       -Dtmva-gpu=OFF                                                                   \
       -Ddavix=OFF                                                                      \
       -Dunfold=ON                                                                      \
-      ${USE_BUILTIN_GLEW:+-Dbuiltin_glew=ON}                                           \
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
       ${ROOT_HAS_PYTHON:+-DPYTHON_PREFER_VERSION=3}                                    \
       ${PYTHON_EXECUTABLE:+-DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"}                 \

--- a/root.sh
+++ b/root.sh
@@ -128,6 +128,12 @@ cmake $SOURCEDIR                                                                
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                                        \
       -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                                             \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                                              \
+      -Dfail-on-missing=ON                                                             \
+      -Dbuiltin_nlohmannjson=ON                                                        \
+      -Dbuiltin_xxhash=ON                                                              \
+      -Dbuiltin_gl2ps=ON                                                               \
+      -Dbuiltin_cfitsio=ON                                                             \
+      -Dbuiltin_ftgl=ON                                                                \
       -Dalien=OFF                                                                      \
       ${CMAKE_CXX_STANDARD:+-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}}                \
       -Dfreetype=ON                                                                    \


### PR DESCRIPTION
Install the right version of the FFTW3 library -- ROOT requires the "double", not "float" version.

Also, make sure the ROOT build can find all its dependencies for the features we enable, and fail if it doesn't.