### PR TITLE
Revert jalien-root back to v7.5

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.7.7"
+tag: "0.7.5"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Since higher versions produce lose the connection then produce seg.fault after a few 10 min of running (at least on ubuntu 22.04).