### PR TITLE
Python-modules: update package versions for python 3.12

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -2,9 +2,12 @@ package: Python-modules-list
 version: "1.0"
 env:
   PIP_BASE_REQUIREMENTS: |
-    pip==24.0
-    setuptools==69.1.0
-    wheel==0.42.0
+    pip == 21.3.1; python_version < '3.12'
+    pip == 24.0; python_version >= '3.12'
+    setuptools == 59.6.0; python_version < '3.12'
+    setuptools == 69.1.0; python_version >= '3.12'
+    wheel == 0.37.1; python_version < '3.12'
+    wheel == 0.42.0; python_version >= '3.12'
   PIP_REQUIREMENTS: |
     # This is a pip requirements file. For documentation see:
     # https://pip.pypa.io/en/stable/reference/requirements-file-format/

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -2,9 +2,9 @@ package: Python-modules-list
 version: "1.0"
 env:
   PIP_BASE_REQUIREMENTS: |
-    pip==21.3.1
-    setuptools==59.6.0
-    wheel==0.37.1
+    pip==24.0
+    setuptools==69.1.0
+    wheel==0.42.0
   PIP_REQUIREMENTS: |
     # This is a pip requirements file. For documentation see:
     # https://pip.pypa.io/en/stable/reference/requirements-file-format/
@@ -42,13 +42,15 @@ env:
     numpy == 1.19.5; python_version == '3.8'
     numpy == 1.21.4; python_version == '3.9'
     numpy == 1.23.4; python_version == '3.10'
-    numpy == 1.23.5; python_version >= '3.11'
+    numpy == 1.23.5; python_version == '3.11'
+    numpy == 1.26.4; python_version >= '3.12'
 
     scipy == 1.2.1; python_version < '3.8'
     scipy == 1.6.1; python_version == '3.8'
     scipy == 1.7.3; python_version == '3.9'
     scipy == 1.9.3; python_version == '3.10'
-    scipy == 1.10.1; python_version >= '3.11'
+    scipy == 1.10.1; python_version == '3.11'
+    scipy == 1.12.0; python_version >= '3.12'
 
     Cython == 0.29.16; python_version < '3.8'
     Cython == 0.29.21; python_version >= '3.8'


### PR DESCRIPTION
As alibuild relies on latest homebrew python on mac, which is now 3.12, python modules installation fails due to some features being deprecated in this version. This updates version requirements of packages to ensure compatibility with 3.12.

@TimoWilken 