### PR TITLE
Create a new "grid-base-packages" modulefile

### DIFF
--- a/grid-base-packages.sh
+++ b/grid-base-packages.sh
@@ -1,0 +1,8 @@
+package: grid-base-packages
+version: v1
+requires:
+  - jq
+---
+#!/bin/bash -e
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION
This will be loaded by the toolchain on CVMFS, so that we have a common set of required packages for Grid use available. Currently, only jq is needed.

A separate PR will be needed to load this package from GCC-Toolchain's modulefile.

A "default" symlink must also be created for the modulefiles of this package on CVMFS.