### PR TITLE
Load grid-base-packages/default in toolchain module

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -181,6 +181,13 @@ if { "\$mod_name" == "GCC-Toolchain" } {
   set base_path [string map "/Modules/modulefiles/ /" \$base_path]
   regexp -- "^(.*)/.*/.*\$" \$base_path dummy base_path
   set base_path \$base_path/Packages
+  # Load any fundamental packages we need in the runtime environment, if
+  # loading off CVMFS (because there we have a grid-base-packages/default
+  # symlink). Don't depend on that package directly here, so that we don't
+  # rebuild our entire stack when changing what we use in grid-base-packages.
+  if { [regexp {^/cvmfs.*} \$ModulesCurrentModulefile dummy1 dummy2] } {
+    module load grid-base-packages/default
+  }
 }
 # Our environment
 set GCC_TOOLCHAIN_ROOT \$base_path/GCC-Toolchain/\$version


### PR DESCRIPTION
For use on the Grid and e.g. in Hyperloop, some packages need to be available (currently just jq). Package these as "grid-base-packages", which has a "default" symlink available.

Then, we can add more packages in future that should be loaded as part of the toolchain, without incurring costly rebuilds of the full software stack.

Draft PR to avoid long-running rebuilds in CI for now.