### PR TITLE
Get ROOT to compile with new macOS / XCode

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -1,6 +1,6 @@
 package: boost
-version: v1.83.0-alice1
-tag: v1.83.0-alice1
+version: v1.83.0-alice2
+tag: v1.83.0-alice2
 source: https://github.com/alisw/boost.git
 requires:
   - "GCC-Toolchain:(?!osx)"

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-30-01-alice3"
+tag: "v6-30-01-alice4"
 source: https://github.com/alisw/root.git
 requires:
   - arrow


### PR DESCRIPTION
Get ROOT to compile with new macOS / XCode

Notice you will need both macOS 14.4 and XCode 15.3.
