### PR TITLE
xjalienfs :: tag 1.6.0 and non-failure trial of gnureadline installation [JAL-178]

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -24,7 +24,7 @@ prepend_path:
 [[ "$ARCHITECTURE" ==  osx_* ]] && { env -u VIRTUAL_ENV ALIBUILD=1 \
     python3 -m pip install --force-reinstall \
     --target="$INSTALLROOT/lib/python/site-packages" \
-    gnureadline || : }
+    gnureadline || : ; }
 
 env -u VIRTUAL_ENV ALIBUILD=1 \
     python3 -m pip install --force-reinstall \

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.5.9"
+tag: "1.6.0"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"
@@ -18,6 +18,14 @@ prepend_path:
 # Use pip's --target to install under $INSTALLROOT without weird hacks. This
 # works inside and outside a virtualenv, but unset VIRTUAL_ENV to make sure we
 # only depend on stuff we installed using our Python and Python-modules.
+
+# on macos try to install gnureadline and just skip if fails (alienpy can work without it)
+# macos python readline implementation is build on libedit which does not work
+[[ "$ARCHITECTURE" ==  osx_* ]] && { env -u VIRTUAL_ENV ALIBUILD=1 \
+    python3 -m pip install --force-reinstall \
+    --target="$INSTALLROOT/lib/python/site-packages" \
+    gnureadline || : }
+
 env -u VIRTUAL_ENV ALIBUILD=1 \
     python3 -m pip install --force-reinstall \
     --target="$INSTALLROOT/lib/python/site-packages" \


### PR DESCRIPTION
* allow to work without loadable readline
* on macos use _only_ gnureadline but work without it if not found
* examples/ add ccdb_mirror, ccdb_time2run, test_grid_conn.C
* fix jobInfo infromation of wn name running the job
 