### PR TITLE
Bump JAliEn-ROOT to 0.7.8

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -1,6 +1,6 @@
 package: JAliEn-ROOT
 version: "%(tag_basename)s"
-tag: "0.7.7"
+tag: "0.7.8"
 source: https://gitlab.cern.ch/jalien/jalien-root.git
 requires:
   - ROOT


### PR DESCRIPTION
Bugfixes for OpenCollectionQuery and loading of the tokencert.