### PR TITLE
xjalienfs :: 1.6.1 prevent potential abort in pthread_cancel

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "preload_gcc"
+tag: "1.6.1"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"

--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.6.0"
+tag: "preload_gcc"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
There are cases when the following message appear at the exit of alien.py:
```
libgcc_s.so.1 must be installed for pthread_cancel to work
Aborted
```

I encountered this when two versions of openssl were present in system and when trying
`/cvmfs/alice.cern.ch/bin/alienv enter O2sim::async-2023-pp-apass3-20240320.1-1,xjalienfs`

Let's try to prevent this and see if macos is happy with this.
If it works then i will tag 1.6.1