### PR TITLE
Fix libuv load path

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -7,6 +7,7 @@ requires:
   - xjalienfs
   - XRootD
   - libwebsockets
+  - libuv
 build_requires:
   - json-c
   - CMake
@@ -57,7 +58,8 @@ module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@
 module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION} \\
                      ROOT/${ROOT_VERSION}-${ROOT_REVISION}                                                   \\
                      ${XJALIENFS_REVISION:+xjalienfs/$XJALIENFS_VERSION-$XJALIENFS_REVISION}                 \\
-                     ${LIBJALIENWS_REVISION:+libjalienws/$LIBJALIENWS_VERSION-$LIBJALIENWS_REVISION}
+                     ${LIBUV_REVISION:+libuv/$LIBUV_VERSION-$LIBUV_REVISION}                                 \\
+		     ${LIBJALIENWS_REVISION:+libjalienws/$LIBJALIENWS_VERSION-$LIBJALIENWS_REVISION}
 
 # Our environment
 set JALIEN_ROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version


### PR DESCRIPTION
libwebsockets is linked statically, however it requires libuv, which is not, therefore one needs to actually have it in the modulefile. This works just fine on O2, because other stuff brings in libuv, however it breaks when using it for AliROOT, which does not. Hot patched on CVMFS as well.