### PR TITLE
Improve GCC builds

### DIFF
--- a/defaults-ali.sh
+++ b/defaults-ali.sh
@@ -25,9 +25,6 @@ overrides:
       - Vc
       - ZeroMQ
       - JAliEn-ROOT
-  GCC-Toolchain:
-    version: v12.2.0-alice1
-    tag: v12.2.0-alice1
   cgal:
     version: 4.12.2
   fastjet:

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -35,9 +35,6 @@ disable:
   - OpenSSL
   - curl:(?!osx.*)
 overrides:
-  GCC-Toolchain:
-    version: "v12.2.0-alice1"
-    tag: "v12.2.0-alice1"
   Python-modules-list:
     env:
       PIP_BASE_REQUIREMENTS: |

--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -28,9 +28,6 @@ overrides:
       - Vc
       - ZeroMQ
       - JAliEn-ROOT
-  GCC-Toolchain:
-    version: v12.2.0-alice1
-    tag: v12.2.0-alice1
   cgal:
     version: 4.12.2
   fastjet:

--- a/defaults-o2.sh
+++ b/defaults-o2.sh
@@ -25,9 +25,6 @@ overrides:
       - Vc
       - ZeroMQ
       - JAliEn-ROOT
-  GCC-Toolchain:
-    version: v12.2.0-alice1
-    tag: v12.2.0-alice1
   cgal:
     version: 4.12.2
   fastjet:

--- a/flatbuffers.sh
+++ b/flatbuffers.sh
@@ -1,5 +1,5 @@
 package: flatbuffers
-version: v1.12.0
+version: v24.3.25
 source: https://github.com/google/flatbuffers
 requires:
   - zlib
@@ -7,26 +7,20 @@ build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
   - alibuild-recipe-tools
+  - ninja
 ---
-#!/bin/bash -e
-cmake "$SOURCEDIR"                          \
-      -G 'Unix Makefiles'                   \
-      -DFLATBUFFERS_BUILD_TESTS=OFF         \
-      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
-      -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-unknown-warning -Wno-unknown-warning-option -Wno-error=unused-but-set-variable"
-# LLVM 15 requires -Wno-error=unused-but-set-variable to compile
-# flatbuffers, but GCC earlier LLVM versions don't understand this
-# option, so we need -Wno-unknown-warning (for GCC) and
-# -Wno-unknown-warning-option (for Clang) as well.
+cmake "$SOURCEDIR"                                                                                                      \
+      -G 'Ninja'                                                                                                        \
+      -DFLATBUFFERS_BUILD_TESTS=OFF                                                                                     \
+      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                                                                          
 
-make ${JOBS:+-j $JOBS}
-make install
+cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Work around potentially faulty CMake (missing `install` for binaries)
-mkdir -p "$INSTALLROOT/bin"
-for bin in flathash flatc; do
-  [ -e "$INSTALLROOT/bin/$bin" ] || cp -p "$bin" "$INSTALLROOT/bin/"
-done
+#mkdir -p "$INSTALLROOT/bin"
+#for bin in flathash flatc; do
+#  [ -e "$INSTALLROOT/bin/$bin" ] || cp -p "$bin" "$INSTALLROOT/bin/"
+#done
 
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"

--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -1,9 +1,10 @@
 package: GCC-Toolchain
 version: "%(tag_basename)s"
-tag: v7.3.0-alice2
+tag: v13.2.0-alice1
 source: https://github.com/alisw/gcc-toolchain
 prepend_path:
   "LD_LIBRARY_PATH": "$GCC_TOOLCHAIN_ROOT/lib64"
+  "PATH": "$GCC_TOOLCHAIN_ROOT/libexec/bin"
 build_requires:
   - "autotools:(slc6|slc7)"
   - yacc-like
@@ -25,9 +26,12 @@ prefer_system_check: |
   #error "System's GCC cannot be used: we need at least ($MIN_GCC_VERSION/1e4), while we intend to go for GCC $REQUESTED_VERSION. We'll compile our own version."
   #endif
   EOF
+env:
+  CCACHE_CONFIGPATH: "$GCC_TOOLCHAIN_ROOT/etc/ccache.conf"
 ---
-#!/bin/bash -e
-
+# Fix syntax highlight
+cat <<EOF
+EOF
 unset CXXFLAGS
 unset CFLAGS
 
@@ -82,18 +86,25 @@ cat > test.c <<EOF
 int main(void) { printf("The answer is 42.\n"); }
 EOF
 
+# We will need to rebuild them with the final GCC
+rsync -a gcc/mpfr/ mpfr
+rsync -a gcc/gmp/ gmp
+rsync -a gcc/isl/ isl
+rsync -a gcc/mpc/ mpc
+
 pushd gcc
-[ -e mpfr ] && (cd mpfr && autoreconf -ivf)
-[ -e mpc ] && (cd mpc && autoreconf -ivf)
-[ -e gmp ] && (cd gmp && autoreconf -ivf)
-[ -e isl ] && (cd isl && autoreconf -ivf)
-[ -e cloog ] && (cd cloog && autoreconf -ivf)
+  [ -d mpfr ] && (cd mpfr && autoreconf -ivf)
+  [ -d mpc ] && (cd mpc && autoreconf -ivf)
+  [ -d gmp ] && (cd gmp && autoreconf -ivf)
+  [ -d isl ] && (cd isl && autoreconf -ivf)
+  [ -d cloog ] && (cd cloog && autoreconf -ivf)
 popd
-[ -e mpfr ] && (cd mpfr && autoreconf -ivf)
-[ -e mpc ] && (cd mpc && autoreconf -ivf)
-[ -e gmp ] && (cd gmp && autoreconf -ivf)
-[ -e isl ] && (cd isl && autoreconf -ivf)
-[ -e cloog ] && (cd cloog && autoreconf -ivf)
+
+[ -d mpfr ] && (cd mpfr && autoreconf -ivf)
+[ -d mpc ] && (cd mpc && autoreconf -ivf)
+[ -d gmp ] && (cd gmp && autoreconf -ivf)
+[ -d isl ] && (cd isl && autoreconf -ivf)
+[ -d cloog ] && (cd cloog && autoreconf -ivf)
 
 mkdir build-gcc
 pushd build-gcc
@@ -130,17 +141,122 @@ export LD_LIBRARY_PATH="$INSTALLROOT/lib64:$INSTALLROOT/lib:$LD_LIBRARY_PATH"
 hash -r
 
 # Test own linker and own GCC
-which ld
-which g++
+type ld
+type g++
 g++ test.c
 ./a.out
 rm -f a.out
+
+# Build a very basic CMake, to compile ccache and nothing else
+# in case we manage, we build ccache
+if [ -e ccache ]; then
+  mkdir -p build-cmake
+  pushd build-cmake
+  cat > build-flags.cmake <<- EOF
+# Disable Java capabilities; we don't need it and on OS X might miss the
+# required /System/Library/Frameworks/JavaVM.framework/Headers/jni.h.
+SET(JNI_H FALSE CACHE BOOL "" FORCE)
+SET(Java_JAVA_EXECUTABLE FALSE CACHE BOOL "" FORCE)
+SET(Java_JAVAC_EXECUTABLE FALSE CACHE BOOL "" FORCE)
+
+# SL6 with GCC 4.6.1 and LTO requires -ltinfo with -lcurses for link to succeed,
+# but cmake is not smart enough to find it. We do not really need ccmake anyway,
+# so just disable it.
+SET(BUILD_CursesDialog FALSE CACHE BOOL "" FORCE)
+EOF
+    $SOURCEDIR/cmake/bootstrap --prefix=$BUILDDIR/bootstrap-cmake \
+                               --no-debugger                      \
+                               --no-qt-gui                        \
+                               --init=build-flags.cmake           \
+                               ${JOBS:+--parallel=$JOBS}
+    make ${JOBS+-j $JOBS}
+    make install/strip
+  popd
+
+  # We build ccache using our own compiler, so that we do not have issue
+  # with libstdc++ compatibility.
+  mkdir build-ccache
+  pushd build-ccache
+    $BUILDDIR/bootstrap-cmake/bin/cmake -S ../ccache \
+        -DENABLE_DOCUMENTATION=OFF                   \
+        -DENABLE_TESTING=OFF                         \
+        -DSTATIC_LINK=ON                             \
+        -DCMAKE_INSTALL_PREFIX="$INSTALLROOT/libexec/ccache"
+    make ${JOBS:+-j $JOBS} install
+    ln -sf ccache $INSTALLROOT/libexec/ccache/bin/gcc
+    ln -sf ccache $INSTALLROOT/libexec/ccache/bin/g++
+    ln -sf ccache $INSTALLROOT/libexec/ccache/bin/cc
+    ln -sf ccache $INSTALLROOT/libexec/ccache/bin/c++
+    export PATH=$INSTALLROOT/libexec/ccache/bin:$PATH
+    # Notice how we configure CCACHE to work, but then 
+    # disable so that users need to export CCACHE_DISABLE=false
+    # to actually have it working.
+    mkdir -p $INSTALLROOT/libexec/ccache/etc
+    cat > $INSTALLROOT/libexec/ccache/etc/ccache.conf <<EOF
+cache_dir=$WORK_DIR/TMP/ccache/$ARCHITECTURE
+disable=true
+EOF
+  popd
+fi
+
+# We rebuild mpfr, gmp, isl to be used with gdb. We do so because
+# we want to make sure they were actually built with the GCC we
+# use, not with the bootstrap xgcc.
+[ -d mpfr ] && (cd mpfr && autoreconf -ivf)
+[ -d gmp ] && (cd gmp && autoreconf -ivf)
+[ -d isl ] && (cd isl && autoreconf -ivf)
+[ -d mpc ] && (cd mpc && autoreconf -ivf)
+mkdir -p build-gmp
+mkdir -p build-mpfr
+mkdir -p build-isl
+mkdir -p build-mpc
+
+pushd build-gmp
+  ../gmp/configure --prefix="$INSTALLROOT/libexec/extra"  \
+                   --disable-shared                       \
+                   --enable-static                       
+  make ${JOBS:+-j$JOBS} MAKEINFO=":"
+  make install MAKEINFO=":"
+popd
+
+pushd build-mpfr
+  ../mpfr/configure --prefix="$INSTALLROOT/libexec/extra"  \
+                   --disable-shared                        \
+                   --with-gmp="$INSTALLROOT/libexec/extra" \
+                   --enable-static                       
+  make ${JOBS:+-j$JOBS} MAKEINFO=":"
+  make install MAKEINFO=":"
+popd
+
+pushd build-isl
+  ../isl/configure --prefix="$INSTALLROOT/libexec/extra"          \
+                   --with-gmp-prefix="$INSTALLROOT/libexec/extra" \
+                   --disable-shared                               \
+                   --enable-static
+  make ${JOBS:+-j$JOBS} MAKEINFO=":"
+  make install MAKEINFO=":"
+popd
+
+pushd build-mpc
+  ../mpc/configure --prefix="$INSTALLROOT/libexec/extra"    \
+                   --disable-shared                         \
+                   --with-gmp="$INSTALLROOT/libexec/extra"  \
+                   --with-mpft="$INSTALLROOT/libexec/extra" \
+                   --enable-static
+  make ${JOBS:+-j$JOBS} MAKEINFO=":"
+  make install MAKEINFO=":"
+popd
 
 # GDB
 mkdir build-gdb
 pushd build-gdb
   ../gdb/configure --prefix="$INSTALLROOT"                \
                    ${MARCH:+--build=$MARCH --host=$MARCH} \
+                   --with-gmp=$INSTALLROOT/libexec/extra  \
+                   --with-mpfr=$INSTALLROOT/libexec/extra \
+                   --with-isl=$INSTALLROOT/libexec/extra  \
+                   --with-mpc=$INSTALLROOT/libexec/extra  \
+                   --without-guile                        \
                    --without-python                       \
                    --disable-multilib
   make ${JOBS:+-j$JOBS} MAKEINFO=":"
@@ -194,4 +310,5 @@ set GCC_TOOLCHAIN_ROOT \$base_path/GCC-Toolchain/\$version
 prepend-path LD_LIBRARY_PATH \$GCC_TOOLCHAIN_ROOT/lib
 prepend-path LD_LIBRARY_PATH \$GCC_TOOLCHAIN_ROOT/lib64
 prepend-path PATH \$GCC_TOOLCHAIN_ROOT/bin
+prepend-path PATH \$GCC_TOOLCHAIN_ROOT/libexec/ccache/bin
 EoF

--- a/ucx.sh
+++ b/ucx.sh
@@ -1,6 +1,6 @@
 package: ucx
 version: "%(tag_basename)s"
-tag: v1.13.1
+tag: v1.16.0
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
@@ -8,17 +8,16 @@ build_requires:
   - alibuild-recipe-tools
   - "GCC-Toolchain:(?!osx)"
 source: https://github.com/openucx/ucx
+system_requirement_missing: |
+  rdma-core not found.
+    * On RHEL-compatible systems you probably need: rdma-core-devel
+system_requirement: ".*"
+system_requirement_check: |
+  printf "#include <rdma/rdma_cma.h>" | cc -xc - -c -o /dev/null
 ---
-#!/bin/bash -e
-
 # Unified Communication X Library (linux only)
 ## NOTE: rdma-core and rdma-core-devel (v35+) packages must be installed for O2 FLP/EPN use
-
-printf "#include <rdma/rdma_cma.h>" | cc -xc - -c -o /dev/null ||
-( printf "rdma-core not found.\n * On RHEL-compatible systems you probably need: rdma-core-devel\n"; exit 1; )
-
-rsync -a --delete --exclude "**/.git" ${SOURCEDIR}/ .
-./autogen.sh
+${SOURCEDIR}/autogen.sh
 ./contrib/configure-release-mt --prefix=${INSTALLROOT}     \
                                --with-verbs                \
                                --with-rdmacm               \


### PR DESCRIPTION
- Move to GCC 13.2.0
- Move to GDB 14.2
- Do not use GCC 7.3.0 as default, since now AliRoot it's built with its own default.
- Add support for CCACHE. While disabled by default it can be enabled by passing CCACHE_DISABLE=false as environment variable.