### PR TITLE
STARlight introduction in AliGenerators

### DIFF
--- a/aligenerators.sh
+++ b/aligenerators.sh
@@ -23,6 +23,7 @@ requires:
   - lhapdf-pdfsets
   - JETSCAPE
   - EPOS4
+  - STARlight
 build_requires:
   - EPOS-test:(?!osx)
   - alibuild-recipe-tools

--- a/starlight.sh
+++ b/starlight.sh
@@ -1,6 +1,6 @@
 package: STARlight
-version: "%(tag_basename)s"
-tag: main
+version: "20240714"
+tag: 9980f5d
 requires:
   - HepMC3
 build_requires:

--- a/starlight.sh
+++ b/starlight.sh
@@ -14,7 +14,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
                  -DCMAKE_SKIP_RPATH=TRUE                   \
                  -DENABLE_HEPMC3=ON                        \
-                 -DHepMC2_DIR=$HEPMC3_ROOT
+                 -DHepMC3_DIR="$HEPMC3_ROOT"
 cmake --build . -- ${JOBS:+-j$JOBS}
 mkdir -p $INSTALLROOT/bin
 cp ./starlight $INSTALLROOT/bin/.

--- a/starlight.sh
+++ b/starlight.sh
@@ -1,16 +1,20 @@
 package: STARlight
 version: "%(tag_basename)s"
-tag: r313-c
+tag: main
+requires:
+  - HepMC3
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
-source: https://github.com/alisw/STARlight.git
+source: https://github.com/STARlightsim/STARlight.git
 ---
 #!/bin/bash -ex
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
-                 -DCMAKE_SKIP_RPATH=TRUE
+                 -DCMAKE_SKIP_RPATH=TRUE                   \
+                 -DENABLE_HEPMC3=ON                        \
+                 -DHepMC2_DIR=$HEPMC3_ROOT
 cmake --build . -- ${JOBS:+-j$JOBS}
 mkdir -p $INSTALLROOT/bin
 cp ./starlight $INSTALLROOT/bin/.
@@ -18,7 +22,6 @@ mkdir -p $INSTALLROOT/lib
 cp ./libStarlib.a $INSTALLROOT/lib/.
 cp -r $SOURCEDIR/config $INSTALLROOT/.
 cp -r $SOURCEDIR/include $INSTALLROOT/.
-cp -r $SOURCEDIR/HepMC $INSTALLROOT/.
 
 #ConfigFile
 cat << EOF > $INSTALLROOT/bin/starlight-config


### PR DESCRIPTION
Added STARlight dependency to AliGenerators. STARlight recipe has been edited to pull directly the main branch from the official STARlight repository. In addition the HepMC3 package has been set as a dependency and STARlight is now built with it, so that it could also be useful for RIVET analyses. Tests performed locally are encouraging.