### PR TITLE
Bump AliECS to v1.11.0

### DIFF
--- a/coconut.sh
+++ b/coconut.sh
@@ -1,6 +1,6 @@
 package: coconut
 version: "%(tag_basename)s"
-tag: "v1.9.2"
+tag: "v1.10.0"
 build_requires:
   - golang
   - protobuf

--- a/coconut.sh
+++ b/coconut.sh
@@ -1,6 +1,6 @@
 package: coconut
 version: "%(tag_basename)s"
-tag: "v1.10.0"
+tag: "v1.11.0"
 build_requires:
   - golang
   - protobuf

--- a/control-core.sh
+++ b/control-core.sh
@@ -1,6 +1,6 @@
 package: Control-Core
 version: "%(tag_basename)s"
-tag: "v1.9.2"
+tag: "v1.10.0"
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - golang

--- a/control-core.sh
+++ b/control-core.sh
@@ -1,6 +1,6 @@
 package: Control-Core
 version: "%(tag_basename)s"
-tag: "v1.10.0"
+tag: "v1.11.0"
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - golang

--- a/control-occplugin.sh
+++ b/control-occplugin.sh
@@ -1,6 +1,6 @@
 package: Control-OCCPlugin
 version: "%(tag_basename)s"
-tag: "v1.9.2"
+tag: "v1.10.0"
 requires:
   - FairMQ
   - FairLogger

--- a/control-occplugin.sh
+++ b/control-occplugin.sh
@@ -1,6 +1,6 @@
 package: Control-OCCPlugin
 version: "%(tag_basename)s"
-tag: "v1.10.0"
+tag: "v1.11.0"
 requires:
   - FairMQ
   - FairLogger

--- a/control.sh
+++ b/control.sh
@@ -1,5 +1,5 @@
 package: Control
-version: "v1.10.0"
+version: "v1.11.0"
 requires:
   - Control-Core
   - Control-OCCPlugin

--- a/control.sh
+++ b/control.sh
@@ -1,5 +1,5 @@
 package: Control
-version: "v1.9.2"
+version: "v1.10.0"
 requires:
   - Control-Core
   - Control-OCCPlugin


### PR DESCRIPTION
Note: when upgrading to v1.10.0, the existing component configuration tree should be redeployed to Consul.