### PR TITLE
Add prefer_system to the golang recipe

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -2,6 +2,7 @@ package: golang
 version: "1.22.2"
 build_requires:
   - curl
+prefer_system: ".*"
 prefer_system_check: |
   type go && case `go version | sed -e 's/go version go//' | sed -e 's/ .*//'` in 0*|1.[0-9].*) exit 1 ;; esac
 ---


### PR DESCRIPTION
Add prefer_system to the golang recipe

prefer_system has priority over prefer_system_check and by default
it's not matching any architecture.
