### PR TITLE
Bump ROOT to v6-30-01-alice5

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-30-01-alice4"
+tag: "v6-30-01-alice5"
 source: https://github.com/alisw/root.git
 requires:
   - arrow


### PR DESCRIPTION
Fixes https://its.cern.ch/jira/browse/O2-4652
by moving forward one tag in our patch branch.