### PR TITLE
Add abseil as runtime dependency

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -2,6 +2,7 @@ package: O2
 version: "%(tag_basename)s"
 tag: "daily-20240527-0200"
 requires:
+  - abseil
   - arrow
   - FairRoot
   - Vc


### PR DESCRIPTION
Required to compile O2OpenAccess from CVMFS