### PR TITLE
Bump JAliEn to 1.8.8

### DIFF
--- a/jalien.sh
+++ b/jalien.sh
@@ -1,11 +1,10 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.8.7"
+tag: "1.8.8"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
   - JDK
   - XRootD
-  - xjalienfs
   - curl
 valid_defaults:
   - jalien


### PR DESCRIPTION
Update JAliEn (Java components only). Doesn't affect AliPhysics / O2 in any way.

Note: Also removes "xjalienfs" as a dependency to JAliEn.