### PR TITLE
Need to enable TPythia8

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -21,6 +21,7 @@ requires:
   - protobuf
   - FFTW3
   - Vc
+  - pythia
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
@@ -177,6 +178,7 @@ cmake $SOURCEDIR                                                                
       -Dtmva-gpu=OFF                                                                   \
       -Ddavix=OFF                                                                      \
       -Dunfold=ON                                                                      \
+      -Dpythia8=ON
       ${USE_BUILTIN_GLEW:+-Dbuiltin_glew=ON}                                           \
       ${DISABLE_MYSQL:+-Dmysql=OFF}                                                    \
       ${ROOT_HAS_PYTHON:+-DPYTHON_PREFER_VERSION=3}                                    \


### PR DESCRIPTION
If we disable TPythia6, we need to switch to building TPythia8Decayer etc which is achieved with this commit.