### PR TITLE
Bump scikit-learn on older python versions

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -62,8 +62,7 @@ env:
     seaborn == 0.11.0; python_version >= '3.9'
 
     scikit-learn == 0.20.3; python_version < '3.8'
-    scikit-learn == 0.24.1; python_version >= '3.8' and python_version < '3.11'
-    scikit-learn == 1.3.0; python_version >= '3.11'
+    scikit-learn == 1.3.0; python_version >= '3.8'
 
     sklearn-evaluation == 0.4; python_version < '3.9'
     sklearn-evaluation == 0.5.2; python_version == '3.9'


### PR DESCRIPTION
Fixes the following error (tested on python 3.10)

```
  Error compiling Cython file:
  ------------------------------------------------------------
  ...
      # Max value for our rand_r replacement (near the bottom).
      # We don't use RAND_MAX because it's different across platforms and
      # particularly tiny on Windows/MSVC.
      RAND_R_MAX = 0x7FFFFFFF

  cpdef sample_without_replacement(np.int_t n_population,
                                   ^
  ------------------------------------------------------------

  sklearn/utils/_random.pxd:18:33: 'int_t' is not a type identifier
  ```