### PR TITLE
ARM: Bump hdf5 and pandas

### DIFF
--- a/hdf5.sh
+++ b/hdf5.sh
@@ -1,6 +1,6 @@
 package: hdf5
-version: "%(tag_basename)s"
-tag: hdf5-1_10_7
+version: "1.14.4"
+tag: "hdf5_1.14.4.3"
 source: https://github.com/HDFGroup/hdf5.git
 requires:
   - "GCC-Toolchain:(?!osx)"
@@ -9,6 +9,8 @@ build_requires:
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include <hdf5.h>\n" | cc -xc - -c -o /dev/null
+env:
+  HDF5_DIR: "$HDF5_ROOT"
 ---
 #!/bin/bash -e
   cmake "$SOURCEDIR"                             \

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -91,7 +91,7 @@ env:
 
     pandas == 0.24.2; python_version < '3.8'
     pandas == 1.2.3; python_version == '3.8'
-    pandas == 1.1.5; python_version >= '3.9' and python_version < '3.11'
+    pandas[performance] == 1.5.3; python_version >= '3.9' and python_version < '3.11'
     pandas == 1.5.3; python_version >= '3.11'
 
     dask[array,dataframe,distributed] == 2023.2.0; python_version < '3.11'

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -91,8 +91,7 @@ env:
 
     pandas == 0.24.2; python_version < '3.8'
     pandas == 1.2.3; python_version == '3.8'
-    pandas[performance] == 1.5.3; python_version >= '3.9' and python_version < '3.11'
-    pandas == 1.5.3; python_version >= '3.11'
+    pandas == 1.5.3; python_version >= '3.9'
 
     dask[array,dataframe,distributed] == 2023.2.0; python_version < '3.11'
     dask[array,dataframe,distributed] == 2023.12.1; python_version >= '3.11'

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -5,6 +5,7 @@ requires:
   - "Python-system:(?!slc.*|ubuntu)"
   - "FreeType:(?!osx)"
   - libpng
+  - hdf5
 build_requires:
   - Python-modules-list
   - alibuild-recipe-tools


### PR DESCRIPTION
Required for the build in slc9_aarch64

HDF5_DIR is needed for h5py to find the include libs
(https://docs.h5py.org/en/stable/build.html#custom-installation)
