### PR TITLE
Added cgal as rivet requirement

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -13,9 +13,6 @@ requires:
   - "Python-system:(osx.*)"
 build_requires:
   - GCC-Toolchain:(?!osx)
-  - cgal
-  - GMP
-  - YODA
   - Python
 prepend_path:
   PYTHONPATH: $RIVET_ROOT/lib/python/site-packages

--- a/rivet.sh
+++ b/rivet.sh
@@ -6,12 +6,14 @@ requires:
   - HepMC3
   - YODA
   - fastjet
+  - cgal
   - GMP
   - "Python:(?!osx)"
   - "Python-modules:(?!osx)"
   - "Python-system:(osx.*)"
 build_requires:
   - GCC-Toolchain:(?!osx)
+  - cgal
   - GMP
   - YODA
   - Python


### PR DESCRIPTION
Without this fix the CGAL_ROOT path is wrongly expanded in myldflags pushed inside rivet-build