### PR TITLE
More changes in AEGIS/MCStepLogger for the ROOT 6.32 bump

### DIFF
--- a/aegis.sh
+++ b/aegis.sh
@@ -1,6 +1,6 @@
 package: AEGIS
 version: "%(tag_basename)s"
-tag: v1.5.3-alice1
+tag: v1.5.3-alice2
 requires:
   - ROOT
   - VMC
@@ -24,7 +24,8 @@ fi
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"} \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
-                 -DCMAKE_SKIP_RPATH=TRUE \
+                 -DCMAKE_SKIP_RPATH=TRUE                   \
+                 -DPYTHIA6_DIR=${PYTHIA6_ROOT}             \
 		 ${SPECIALFFLAGS:+-DCMAKE_Fortran_FLAGS="-fallow-argument-mismatch"}
 cmake --build . -- ${JOBS:+-j$JOBS} install
 

--- a/mcsteplogger.sh
+++ b/mcsteplogger.sh
@@ -1,6 +1,6 @@
 package: MCStepLogger
 version: "%(tag_basename)s"
-tag: "v0.6.0"
+tag: "v0.6.1"
 source: https://github.com/AliceO2Group/VMCStepLogger.git
 requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
this should be the final step to make simulation happy with ROOT 6.32 and TPythia6 deprecated in ROOT.