### PR TITLE
Add python (gnu)readline package

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -98,6 +98,9 @@ env:
     dask[array,dataframe,distributed] == 2023.12.1; python_version >= '3.11'
     dask_jobqueue == 0.8.2
 
+    # readline is needed by alien.py (xjalienfs)
+    gnureadline
+
 build_requires:
   - alibuild-recipe-tools
 ---


### PR DESCRIPTION
This install the python readline package. 

Currently readline support in alien.py, build locally with alibuild or published on cvmfs, is broken. Adding this python package to our installation fixes this problem (conveniently).

Tested on CC7 and Ubuntu 22.04 No other installation of libreadline-dev etc necessary.

Fixes problem described here https://its.cern.ch/jira/browse/O2-4927 fully consistently for everyone building alien.py with alibuild.