### PR TITLE
Define starlight as full commit hash

### DIFF
--- a/starlight.sh
+++ b/starlight.sh
@@ -1,6 +1,6 @@
 package: STARlight
 version: "20240617"
-tag: 196adef
+tag: 196adefb9b840587d374b675e288b2a98fb5df0e
 requires:
   - HepMC3
 build_requires:


### PR DESCRIPTION
Currently [CI is failing](https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/O2DPG/1679/de61db2518ea3e775ee633a82be8963d15a11e97/build_O2DPG_O2fst_o2/pretty.html#fetch) when trying to checkout this ref, I'm not sure why. Might be a bug in git?

This is a workaround but we should figure out the root cause

Tagging @ktf 

```
# git checkout -f 196adef
error: pathspec '196adef' did not match any file(s) known to git
# git checkout -f 196adefb9b840587d374b675e288b2a98fb5df0e
remote: Enumerating objects: 1198, done.
remote: Counting objects: 100% (82/82), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 1198 (delta 41), reused 76 (delta 40), pack-reused 1116
Receiving objects: 100% (1198/1198), 169.01 KiB | 1.74 MiB/s, done.
Resolving deltas: 100% (769/769), done.
remote: Enumerating objects: 119, done.
remote: Counting objects: 100% (104/104), done.
remote: Compressing objects: 100% (102/102), done.
remote: Total 119 (delta 32), reused 19 (delta 2), pack-reused 15
Receiving objects: 100% (119/119), 1.82 MiB | 3.11 MiB/s, done.
Resolving deltas: 100% (32/32), done.
Updating files: 100% (119/119), done.
Note: switching to '196adefb9b840587d374b675e288b2a98fb5df0e'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 196adef Merge pull request #11 from sawenzel/swenzel/sharedbuild
# git rev-parse --short HEAD
196adef
```