### PR TITLE
ARM: Bump hdf5, numpy, scipy, Keras/tf and pandas

### DIFF
--- a/hdf5.sh
+++ b/hdf5.sh
@@ -10,6 +10,8 @@ build_requires:
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include <hdf5.h>\n" | cc -xc - -c -o /dev/null
+  env:
+    HDF5_DIR: "$HDF5_ROOT"
 ---
 #!/bin/bash -e
   cmake "$SOURCEDIR"                             \

--- a/hdf5.sh
+++ b/hdf5.sh
@@ -16,7 +16,7 @@ prefer_system_check: |
     -DCMAKE_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
     -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"        \
     ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \
-    -DHDF_BUILD_CXX=ON
+    -DHDF5_BUILD_CPP_LIB=ON
 
 cmake --build . -- ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 

--- a/hdf5.sh
+++ b/hdf5.sh
@@ -16,7 +16,7 @@ prefer_system_check: |
     -DCMAKE_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
     -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"        \
     ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \
-	-DHDF_BUILD_CXX=ON
+    -DHDF_BUILD_CXX=ON
 
 cmake --build . -- ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 

--- a/hdf5.sh
+++ b/hdf5.sh
@@ -10,7 +10,7 @@ build_requires:
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include <hdf5.h>\n" | cc -xc - -c -o /dev/null
-  env:
+env:
     HDF5_DIR: "$HDF5_ROOT"
 ---
 #!/bin/bash -e

--- a/hdf5.sh
+++ b/hdf5.sh
@@ -1,11 +1,12 @@
 package: hdf5
-version: "%(tag_basename)s"
-tag: hdf5-1_10_7
+version: "1.10.9"
+tag: hdf5-1_10_9
 source: https://github.com/HDFGroup/hdf5.git
 requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
   printf "#include <hdf5.h>\n" | cc -xc - -c -o /dev/null
@@ -14,7 +15,8 @@ prefer_system_check: |
   cmake "$SOURCEDIR"                             \
     -DCMAKE_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
     -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"        \
-    ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}
+    ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}      \
+	-DHDF_BUILD_CXX=ON
 
 cmake --build . -- ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 
@@ -22,19 +24,4 @@ cmake --build . -- ${IGNORE_ERRORS:+-k} ${JOBS+-j $JOBS} install
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set HDF5_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv HDF5_ROOT \$HDF5_ROOT
-prepend-path PATH \$HDF5_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$HDF5_ROOT/lib
-EoF
+alibuild-generate-module --bin --lib > "$MODULEFILE"

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -43,15 +43,13 @@ env:
 
     numpy == 1.16.2; python_version < '3.8'
     numpy == 1.19.5; python_version == '3.8'
-    numpy == 1.21.4; python_version == '3.9'
-    numpy == 1.23.4; python_version == '3.10'
+    numpy == 1.23.4; python_version >= '3.9' and python_version <= '3.10'
     numpy == 1.23.5; python_version == '3.11'
     numpy == 1.26.4; python_version >= '3.12'
 
     scipy == 1.2.1; python_version < '3.8'
     scipy == 1.6.1; python_version == '3.8'
-    scipy == 1.7.3; python_version == '3.9'
-    scipy == 1.9.3; python_version == '3.10'
+    scipy == 1.9.3; python_version >= '3.9' and python_version <= '3.10'
     scipy == 1.10.1; python_version == '3.11'
     scipy == 1.12.0; python_version >= '3.12'
 
@@ -72,13 +70,12 @@ env:
 
     Keras == 2.2.4; python_version < '3.8'
     Keras == 2.4.3; python_version == '3.8'
-    Keras == 2.7.0; python_version == '3.9'
-    Keras == 2.13.1; python_version >= '3.10'
+    Keras == 2.13.1; python_version >= '3.9' and python_version <= '3.10'
 
     tensorflow == 1.13.1; python_version < '3.8'
     tensorflow == 2.4.1; python_version == '3.8'
-    tensorflow == 2.7.1; python_version == '3.9'
-    tensorflow == 2.13.1; python_version >= '3.10' and python_version <= '3.11'
+    # tensorflow == 2.7.1; python_version == '3.9'
+    tensorflow == 2.13.1; python_version >= '3.9' and python_version <= '3.11'
 
     # See version compatibility table at https://pypi.org/project/tensorflow-metal/
     tensorflow-metal == 1.0.0; sys_platform == 'darwin' and python_version == '3.11'
@@ -93,8 +90,7 @@ env:
 
     pandas == 0.24.2; python_version < '3.8'
     pandas == 1.2.3; python_version == '3.8'
-    pandas == 1.1.5; python_version >= '3.9' and python_version < '3.11'
-    pandas == 1.5.3; python_version >= '3.11'
+    pandas == 1.5.3; python_version >= '3.9'
 
     dask[array,dataframe,distributed] == 2023.2.0; python_version < '3.11'
     dask[array,dataframe,distributed] == 2023.12.1; python_version >= '3.11'

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -5,6 +5,7 @@ requires:
   - "Python-system:(?!slc.*|ubuntu)"
   - "FreeType:(?!osx)"
   - libpng
+  - hdf5
 build_requires:
   - Python-modules-list
   - alibuild-recipe-tools


### PR DESCRIPTION
The CI for ARM is complaining about tensorflow, had to bump some versions. Tested on pip 21.2.3 and Python 3.9.18

@mfasDa do you agree with the changes? (follow-up to #5539)

Closes #5524 and #5525 too

The error:
```
2024-07-09@12:48:57:DEBUG:Python-modules:Python-modules:slc9_aarch64: Collecting Keras==2.7.0
2024-07-09@12:48:57:DEBUG:Python-modules:Python-modules:slc9_aarch64:   Downloading keras-2.7.0-py2.py3-none-any.whl (1.3 MB)
2024-07-09@12:48:57:DEBUG:Python-modules:Python-modules:slc9_aarch64:      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 22.1 MB/s eta 0:00:00
2024-07-09@12:48:57:DEBUG:Python-modules:Python-modules:slc9_aarch64: ERROR: Could not find a version that satisfies the requirement tensorflow==2.7.1 (from versions: 2.10.0rc0, 2.10.0rc1, 2.10.0rc2, 2.10.0rc3, 2.10.0, 2.10.1, 2.11.0rc0, 2.11.0rc1, 2.11.0rc2, 2.11.0, 2.11.1, 2.12.0rc0, 2.12.0rc1, 2.12.0, 2.12.1, 2.13.0rc0, 2.13.0rc1, 2.13.0rc2, 2.13.0, 2.13.1, 2.14.0rc0, 2.14.0rc1, 2.14.0, 2.14.1, 2.15.0rc0, 2.15.0rc1, 2.15.0, 2.15.1, 2.16.0rc0, 2.16.1, 2.16.2, 2.17.0rc0, 2.17.0rc1)
2024-07-09@12:48:57:DEBUG:Python-modules:Python-modules:slc9_aarch64: ERROR: No matching distribution found for tensorflow==2.7.1
```
