### PR TITLE
xjalienfs/alienpy 1.6.2

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.6.1"
+tag: "1.6.2"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Mostly XRootD::Cp fixes and improvements:
* document `-parent`; rewrite logic to add `-rmprefix` (removing first N components from the absolute path of the source) when copy to destination
* fileIsValid :: update the access/mod time for present and valid files also when md5 check is not requested
* XRootD::cp allow (and fix) multiple usage of `-e` `-exclude` `-exclude_re`

Also a fix for args passed to InitConnection when no token is found