### PR TITLE
Fix to run Rivet3.1.8 with HepMC3.3

### DIFF
--- a/rivet.sh
+++ b/rivet.sh
@@ -1,7 +1,7 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "rivet-3.1.8"
-source: https://gitlab.com/hepcedar/rivet.git
+tag: "3.1.8-alice1"
+source: https://github.com/alisw/rivet.git
 requires:
   - HepMC3
   - YODA


### PR DESCRIPTION
HepMC3 has been updated to the version 3.3 which is not compatible with Rivet3, but it is with Rivet4.01. Due to summer vacations Rivet developers might be able to release a Rivet3.1.11 version with the fix applied, however we are still with Rivet 3.1.8 and the possible next step will be directly Rivet4. 
This PR gets the software from our original GitHub repository, pulling a slightly modified version of Rivet which works with HepMC3.3. It has been tested both on Ubuntu and AlmaLinux9 with x86 architectures