### PR TITLE
ONNXRuntime: Add explicit dependency on abseil

### DIFF
--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -6,6 +6,7 @@ requires:
   - protobuf
   - re2
   - boost
+  - abseil
 build_requires:
   - CMake
   - alibuild-recipe-tools


### PR DESCRIPTION
To prevent possible clash between ONNXRuntime build and system install of abseil library. See https://github.com/alisw/alidist/issues/5550