### PR TITLE
build librdkafka without ssl,sasl,curl

### DIFF
--- a/librdkafka.sh
+++ b/librdkafka.sh
@@ -8,19 +8,18 @@ build_requires:
   - CMake
 source: https://github.com/edenhill/librdkafka
 ---
-#!/bin/bash -ex
-cmake -H"$SOURCEDIR"                        \
-      -B"$SOURCEDIR/_cmake_build"           \
-      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
-      -DCMAKE_INSTALL_LIBDIR=lib            \
-      -DENABLE_LZ4_EXT=OFF                  \
-      -DRDKAFKA_BUILD_TESTS=OFF             \
-      -DRDKAFKA_BUILD_EXAMPLES=OFF
-cmake --build "$SOURCEDIR/_cmake_build" --target install
+
+rsync -a --delete --exclude "**/.git" "$SOURCEDIR/" .
+
+# cmake in rdfkafka links against ssl even when disabled, so we need to use configure, which is also recommended by librdkafka devs.
+./configure --prefix="$INSTALLROOT" --disable-ssl --disable-gssapi --disable-curl
+
+make
+make install
 
 #ModuleFile
 mkdir -p etc/modulefiles
-alibuild-generate-module --lib > etc/modulefiles/$PKGNAME
-cat >> etc/modulefiles/$PKGNAME <<EoF
+alibuild-generate-module --lib > "etc/modulefiles/$PKGNAME"
+cat >> "etc/modulefiles/$PKGNAME" <<EoF
 EoF
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+mkdir -p "$INSTALLROOT/etc/modulefiles" && rsync -a --delete etc/modulefiles/ "$INSTALLROOT/etc/modulefiles"

--- a/qualitycontrol.sh
+++ b/qualitycontrol.sh
@@ -81,6 +81,7 @@ cmake $SOURCEDIR                                                                
       -DO2_ROOT=$O2_ROOT                                                                                        \
       -DMS_GSL_INCLUDE_DIR=$MS_GSL_ROOT/include                                                                 \
       -DMODERNCPPKAFKA_ROOT=${MODERNCPPKAFKA_ROOT}/include                                                      \
+      -DRDKAFKA_ROOT=${LIBRDKAFKA_ROOT}                                                                         \
       ${ARROW_ROOT:+-DGandiva_DIR=$ARROW_ROOT/lib/cmake/Gandiva}                                                \
       ${ARROW_ROOT:+-DArrow_DIR=$ARROW_ROOT/lib/cmake/Arrow}                                                    \
       ${ARROW_ROOT:+${CLANG_ROOT:+-DLLVM_ROOT=$CLANG_ROOT}}                                                     \


### PR DESCRIPTION
there were linking issues with QC caused by using librdkafka. I changed the recipe that librdkafka does not use ssl,sasl and curl as we don't need it now and QC is the only one who uses the library