### PR TITLE
Correct handling of RPATH for grpc and c-ares

### DIFF
--- a/c-ares.sh
+++ b/c-ares.sh
@@ -14,7 +14,15 @@ incremental_recipe: |
 cmake $SOURCEDIR -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALLROOT -DCMAKE_INSTALL_LIBDIR=lib
 make ${JOBS:+-j$JOBS} install
 
-
+case $ARCHITECTURE in
+  osx*)
+    # Add correct rpath to dylibs on Mac as long as there is no better way to
+    # control rpath in the GRPC CMake
+    # Add rpath to all libraries in lib and change their IDs to be absolute paths.
+    find "$INSTALLROOT/lib" -name '*.dylib' -not -name '*ios*.dylib' \
+         -exec install_name_tool -id '{}' '{}' \;
+  ;;
+esac
 
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/grpc.sh
+++ b/grpc.sh
@@ -61,6 +61,17 @@ cmake $SOURCEDIR                                    \
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
+case $ARCHITECTURE in
+  osx*)
+    # Add correct rpath to dylibs on Mac as long as there is no better way to
+    # control rpath in the GRPC CMake
+    # Add rpath to all libraries in lib and change their IDs to be absolute paths.
+    find "$INSTALLROOT/lib" -name '*.dylib' -not -name '*ios*.dylib' \
+         -exec install_name_tool -id '{}' '{}' \;
+  ;;
+esac
+
+
 #ModuleFile
 mkdir -p etc/modulefiles
 alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME


### PR DESCRIPTION
Correct handling of RPATH for grpc and c-ares

For some reason c-ares and grpc set their id to `@rpath/lib...` rather
than their full path. This means that if a given dependent library has
an implicit transitive dependency on it, they will not be able to find it.

This happens in particular for bookkeeping which defines grpc as a private
dependency, breaking downstream users.
