### PR TITLE
arrow: use clang from llvm installation to avoid stack probing issue with llvm@18

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -62,18 +62,18 @@ rsync -a --exclude='**/.git' --delete --delete-excluded "$SOURCEDIR/" ./src_tmp/
 case $ARCHITECTURE in
   osx*)
    # use default llvm from homebrew if available
-   if [ -d `brew --prefix llvm` ]; then
-     CLANG_EXECUTABLE=`brew --prefix llvm`/bin/clang
+   if [ -d "$(brew --prefix llvm)" ]; then
+     CLANG_EXECUTABLE="`brew --prefix llvm`/bin/clang"
    else
      # fall back to llvm@17
-     if [ -d `brew --prefix llvm`@17 ]; then
-       CLANG_EXECUTABLE=`brew --prefix llvm`@17/bin/clang
+     if [ -d "$(brew --prefix llvm)@17" ]; then
+       CLANG_EXECUTABLE="`brew --prefix llvm`@17/bin/clang"
      fi
 
    fi
    ;;
   *)
-   CLANG_EXECUTABLE=${CLANG_ROOT}/bin-safe/clang
+   CLANG_EXECUTABLE="${CLANG_ROOT}/bin-safe/clang ${GCC_TOOLCHAIN_REVISION:+--gcc-install-dir=$GCC_TOOLCHAIN_ROOT}"
    # this patches version script to hide llvm symbols in gandiva library
    sed -i.deleteme '/^[[:space:]]*extern/ a \ \ \ \ \ \ llvm*; LLVM*;' "./src_tmp/cpp/src/gandiva/symbols.map"
    ;;

--- a/arrow.sh
+++ b/arrow.sh
@@ -63,11 +63,11 @@ case $ARCHITECTURE in
   osx*)
    # use default llvm from homebrew if available
    if [ -d "$(brew --prefix llvm)" ]; then
-     CLANG_EXECUTABLE="`brew --prefix llvm`/bin/clang"
+     CLANG_EXECUTABLE="$(brew --prefix llvm)/bin/clang"
    else
      # fall back to llvm@17
      if [ -d "$(brew --prefix llvm)@17" ]; then
-       CLANG_EXECUTABLE="`brew --prefix llvm`@17/bin/clang"
+       CLANG_EXECUTABLE="$(brew --prefix llvm)@17/bin/clang"
      fi
 
    fi

--- a/arrow.sh
+++ b/arrow.sh
@@ -123,7 +123,7 @@ cmake ./src_tmp/cpp                                                             
       -DARROW_BUILD_STATIC=OFF                                                                      \
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON                                                        \
       -DCLANG_EXECUTABLE="$CLANG_EXECUTABLE"                                                        \
-      ${GCC_TOOLCHAIN_REVISION:+-DGCC_TOOLCHAIN_ROOT=$(find $GCC_TOOLCHAIN_ROOT/lib -name crtbegin.o -exec dirname {} \;)}
+      ${GCC_TOOLCHAIN_REVISION:+-DGCC_TOOLCHAIN_ROOT=`find "$GCC_TOOLCHAIN_ROOT/lib" -name crtbegin.o -exec dirname {} \;`}
 
 make ${JOBS:+-j $JOBS}
 make install

--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v17.0.0-alice4"
-tag: apache-arrow-17.0.0-alice4
+version: "v17.0.0-alice5"
+tag: apache-arrow-17.0.0-alice5
 source: https://github.com/alisw/arrow.git
 requires:
   - boost

--- a/arrow.sh
+++ b/arrow.sh
@@ -69,7 +69,6 @@ case $ARCHITECTURE in
      if [ -d "$(brew --prefix llvm)@17" ]; then
        CLANG_EXECUTABLE="$(brew --prefix llvm)@17/bin/clang"
      fi
-
    fi
    ;;
   *)

--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v17.0.0-alice1"
-tag: apache-arrow-17.0.0-alice1
+version: "v17.0.0-alice4"
+tag: apache-arrow-17.0.0-alice4
 source: https://github.com/alisw/arrow.git
 requires:
   - boost
@@ -73,7 +73,7 @@ case $ARCHITECTURE in
    fi
    ;;
   *)
-   CLANG_EXECUTABLE="${CLANG_ROOT}/bin-safe/clang ${GCC_TOOLCHAIN_REVISION:+--gcc-install-dir=$GCC_TOOLCHAIN_ROOT}"
+   CLANG_EXECUTABLE="${CLANG_ROOT}/bin-safe/clang"
    # this patches version script to hide llvm symbols in gandiva library
    sed -i.deleteme '/^[[:space:]]*extern/ a \ \ \ \ \ \ llvm*; LLVM*;' "./src_tmp/cpp/src/gandiva/symbols.map"
    ;;
@@ -123,7 +123,8 @@ cmake ./src_tmp/cpp                                                             
       -DARROW_FILESYSTEM=ON                                                                         \
       -DARROW_BUILD_STATIC=OFF                                                                      \
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON                                                        \
-      -DCLANG_EXECUTABLE="$CLANG_EXECUTABLE"
+      -DCLANG_EXECUTABLE="$CLANG_EXECUTABLE"                                                        \
+      ${GCC_TOOLCHAIN_REVISION:+-DGCC_TOOLCHAIN_ROOT=$GCC_TOOLCHAIN_ROOT}
 
 make ${JOBS:+-j $JOBS}
 make install

--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v17.0.0-alice5"
-tag: apache-arrow-17.0.0-alice5
+version: "v17.0.0-alice6"
+tag: apache-arrow-17.0.0-alice6
 source: https://github.com/alisw/arrow.git
 requires:
   - boost

--- a/arrow.sh
+++ b/arrow.sh
@@ -61,7 +61,16 @@ rsync -a --exclude='**/.git' --delete --delete-excluded "$SOURCEDIR/" ./src_tmp/
 
 case $ARCHITECTURE in
   osx*)
-   CLANG_EXECUTABLE=/usr/bin/clang
+   # use default llvm from homebrew if available
+   if [ -d `brew --prefix llvm` ]; then
+     CLANG_EXECUTABLE=`brew --prefix llvm`/bin/clang
+   else
+     # fall back to llvm@17
+     if [ -d `brew --prefix llvm`@17 ]; then
+       CLANG_EXECUTABLE=`brew --prefix llvm`@17/bin/clang
+     fi
+
+   fi
    ;;
   *)
    CLANG_EXECUTABLE=${CLANG_ROOT}/bin-safe/clang

--- a/arrow.sh
+++ b/arrow.sh
@@ -123,7 +123,7 @@ cmake ./src_tmp/cpp                                                             
       -DARROW_BUILD_STATIC=OFF                                                                      \
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON                                                        \
       -DCLANG_EXECUTABLE="$CLANG_EXECUTABLE"                                                        \
-      ${GCC_TOOLCHAIN_REVISION:+-DGCC_TOOLCHAIN_ROOT=$GCC_TOOLCHAIN_ROOT}
+      ${GCC_TOOLCHAIN_REVISION:+-DGCC_TOOLCHAIN_ROOT=$(find $GCC_TOOLCHAIN_ROOT/lib -name crtbegin.o -exec dirname {} \;)}
 
 make ${JOBS:+-j $JOBS}
 make install


### PR DESCRIPTION
@ktf @davidrohr @singiamtel 
The issue with arrow breaking at runtime is solved by pointing it to the clang from brew-provided llvm, rather than apple clang. I've tested this on my mac with llvm 18.1.8. 

The version check can be probably improved, if you have any suggestions. 