### PR TITLE
Hide system pip when installing python

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -25,6 +25,10 @@ rsync -av --exclude '**/.git' $SOURCEDIR/ $BUILDDIR/
 # According to cmsdist, this is required to pick up our own version
 export LIBFFI_ROOT
 
+# If the python installer finds another pip, it won't install the new one
+export PATH=$(echo $PATH | awk -v RS=':' -v ORS=':' '!/python/ {print}' | sed 's/:$//')
+unset PYTHONUSERBASE
+
 # The only way to pass externals to Python
 LDFLAGS=
 CPPFLAGS=


### PR DESCRIPTION
If the python installer finds another pip, it will not install the new one and break the build. This should fix some of the most common issues (but doesn't fully guarantee there will not be a pip conflict). 
