### PR TITLE
MILLEPEDE: Allow pede to compile on macos (m2)

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -26,6 +26,7 @@ requires:
   - "VecGeom:(?!osx.*)"
   - FFTW3
   - ONNXRuntime
+  - nlohmann_json
   - MLModels
   - KFParticle
   - RapidJSON


### PR DESCRIPTION
On macOS fortran files need to be compiled with gfortran, this MR overrides the compiler set by the Millepede Makefile from gcc to gfortran, which then works correctly. 

I am not sure if dropping the requirement in case of osx is the right way to go, while I have libomp installed the check in openmp.sh does not pick it up correctly. 
Maybe one can also to do something like this:
``` diff
@@ -6,5 +6,13 @@ system_requirement_missing: |
     * On Linux it comes with the compiler
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <omp.h>\n" | cc -xc - -fopenmp -c -o /dev/null
+  set -e
+  case ${ALIBUILD_ARCHITECTURE} in
+    osx*)
+      printf "#include <omp.h>\n" | cc -Xpreprocessor -fopenmp -lomp -I"$(brew --prefix libomp)/include" -L"$(brew --prefix libomp)/lib" -c -o /dev/null
+      ;;
+    *)
+      printf "#include <omp.h>\n" | cc -xc - -fopenmp -c -o /dev/null
+      ;;
+  esac
 ---
```

I do not know the impact of this change on the macOS builds. But from #1922 I inferred that the openmp check was added for macOS builds since the linux compilers ship with it. But looking at o2 this is not a requirement of o2.sh, but of openblas (only a requirement for millepede) and somehow an implicit requirement of upcgen.sh with -DBUILD_WITH_OPENMP=ON. I checked on a linux machine and macOS, it appears to do what I want. But I do not know if this is the correct way to do it.