### PR TITLE
[WIP] add clang arch for RISCV

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -31,6 +31,7 @@ case $ARCHITECTURE in
   *_x86-64) LLVM_TARGETS_TO_BUILD=X86 ;;
   *_arm64) LLVM_TARGETS_TO_BUILD=AArch64 ;;
   *_aarch64) LLVM_TARGETS_TO_BUILD=AArch64 ;;
+  *_riscv64) LLVM_TARGETS_TO_BUILD=RISCV ;;
   *) echo 'Unknown LLVM target for architecture' >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
I got a maching at CNAF to test the build on RISC-V
This option is needed to compile clang with such an arch
Still in the process of building, I'll remove WIP as soon as I check other packages don't need any further action