### PR TITLE
Don't reset CFLAGS on python recipe

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -54,7 +54,7 @@ esac
 if [[ $OPENSSL_ROOT ]]; then
   export CPATH="$OPENSSL_ROOT/include:$OPENSSL_ROOT/include/openssl:$CPATH"
   export CPPFLAGS="-I$OPENSSL_ROOT/include -I$OPENSSL_ROOT/include/openssl $CPPFLAGS"
-  export CFLAGS="-I$OPENSSL_ROOT/include -I$OPENSSL_ROOT/include/openssl"
+  export CFLAGS="-I$OPENSSL_ROOT/include -I$OPENSSL_ROOT/include/openssl $CFLAGS"
   cat >> Modules/Setup.dist <<EOF
 
 SSL=$OPENSSL_ROOT


### PR DESCRIPTION
I think we currently build without -O2 when using our own OpenSSL, seems like an oversight
