### PR TITLE
Update O2CodeChecker to support OpenMP

### DIFF
--- a/o2codechecker.sh
+++ b/o2codechecker.sh
@@ -1,6 +1,6 @@
 package: o2codechecker
-version: v18.1.1
-tag: v18.1.1
+version: v18.1.2
+tag: v18.1.2
 requires:
   - Clang:(?!osx*)
 build_requires:


### PR DESCRIPTION
Just a bit of explanation:
- Missing header files can lead to subsequent errors, as we had with the missing GCC headers. Currently, the missing omp.h does not seem to cause trouble but better to fix it.
- We cannot use the GCC omp.h header, since it doesn't work for clang and triggers other problems.
- LLVM and Clang do not bring omp.h themselves, for this there is a separate llvm package libomp. I tried to install that in the build container, but it would pull in outdated llvms, which I would want to avoid.
- The LLVM/libomp sources do not come with a final omp.h, but only with a template file that is completed during CMake. Thus I just copied the installed omp.h header from a libomp installation to the sources of O2CodeChecker.
- First I thought I put them to the include folder of the clang installation, but then since O2 depends on clang, the clang include folder gets precedence over the GCC default include folder, and GCC would use Clang's omp.h over its own.
- Thus, finally I just copy omp.h to the o2codechekcer include folder, so it is only used for O2CodeChecker. Well, it will cause trouble if you load O2CodeChecker in you environment and then try to compile O2, but I'd say that is a bogus corner case anyway.