### PR TITLE
Bump json-c to v17.0

### DIFF
--- a/json-c.sh
+++ b/json-c.sh
@@ -8,7 +8,10 @@ build_requires:
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
-./cmake-configure --disable-shared --enable-static --prefix="$INSTALLROOT"
+
+mkdir build
+cd build
+../cmake-configure --disable-shared --enable-static --prefix="$INSTALLROOT"
 make ${JOBS+-j $JOBS} install
 
 # Modulefile

--- a/json-c.sh
+++ b/json-c.sh
@@ -1,15 +1,14 @@
 package: json-c
-version: "v0.13.1"
-tag: "json-c-0.13.1-20180305"
+version: "v0.17.0"
+tag: "json-c-0.17-20230812"
 source: https://github.com/json-c/json-c
 build_requires:
-  - "autotools:(slc6|slc7)"
+  - CMake
   - "GCC-Toolchain:(?!osx)"
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
-autoreconf -ivf
-./configure --disable-shared --enable-static --prefix="$INSTALLROOT"
+./cmake-configure --disable-shared --enable-static --prefix="$INSTALLROOT"
 make ${JOBS+-j $JOBS} install
 
 # Modulefile

--- a/json-c.sh
+++ b/json-c.sh
@@ -10,7 +10,7 @@ build_requires:
 #!/bin/bash -e
 
 cmake "$SOURCEDIR"                                               \
-      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                        \
+      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"                      \
       -DBUILD_SHARED_LIBS=OFF                                    \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}
 

--- a/json-c.sh
+++ b/json-c.sh
@@ -8,12 +8,13 @@ build_requires:
   - alibuild-recipe-tools
 ---
 #!/bin/bash -e
-rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
 
-mkdir build
-cd build
-../cmake-configure --disable-shared --enable-static --prefix="$INSTALLROOT"
-make ${JOBS+-j $JOBS} install
+cmake "$SOURCEDIR"                                               \
+      -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                        \
+      -DBUILD_SHARED_LIBS=OFF                                    \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}
+
+cmake --build . --target install ${JOBS:+-- -j$JOBS}
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin --lib --cmake > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/json-c.sh
+++ b/json-c.sh
@@ -5,6 +5,7 @@ source: https://github.com/json-c/json-c
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
@@ -14,22 +15,5 @@ cd build
 ../cmake-configure --disable-shared --enable-static --prefix="$INSTALLROOT"
 make ${JOBS+-j $JOBS} install
 
-# Modulefile
-mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set JSON_C_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv JSON_C_ROOT \$JSON_C_ROOT
-prepend-path PATH \$JSON_C_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$JSON_C_ROOT/lib
-EoF
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib --cmake > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION
As suggested by @davidrohr, this should bypass the reversed calloc arguments error
