### PR TITLE
Always ensure CLANG_EXECUTABLE exists when building arrow

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -70,6 +70,7 @@ case $ARCHITECTURE in
        CLANG_EXECUTABLE="$(brew --prefix llvm)@17/bin/clang"
      fi
    fi
+   [[ -z $CLANG_EXECUTABLE ]] && echo "Arrow requires homebrew llvm or llvm@17 on macOS" && exit 1
    ;;
   *)
    CLANG_EXECUTABLE="${CLANG_ROOT}/bin-safe/clang"


### PR DESCRIPTION
Currently not all paths ensure this variable is defined (it will be
empty on macs with no llvm from homebrew, for example)
