### PR TITLE
Include AliGenerators in O2Sim

### DIFF
--- a/o2sim.sh
+++ b/o2sim.sh
@@ -6,6 +6,7 @@ requires:
   - QualityControl
   - AEGIS
   - EVTGEN:(?!osx)
+  - AliGenerators:(?!osx|.*aarch64)
   - STARlight:(?!osx)
   - jq
 ---


### PR DESCRIPTION
AliGenerators does not build at the moment on osx and ARM based machines, so the support for those is explicitely removed in the recipe. 