### PR TITLE
Disable ngprofng in binutils

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -73,6 +73,7 @@ pushd build-binutils
                         --enable-lto                           \
                         --enable-plugins                       \
                         --enable-threads                       \
+                        --enable-gprofng=no                    \
                         --disable-nls
   make ${JOBS:+-j$JOBS} MAKEINFO=":"
   make install MAKEINFO=":"


### PR DESCRIPTION
This is also failing sometimes with the current GCC 13.2 for me, so let's just remove it.
Then we could also use the newest binutils for GCC 14.