### PR TITLE
Introduced skimmed version of AliGenerators for O2sim integration

### DIFF
--- a/aligeno2.sh
+++ b/aligeno2.sh
@@ -9,6 +9,7 @@ requires:
   - Rivet
   - lhapdf-pdfsets
   - JETSCAPE
+  - CRMC
   - EPOS4
   - STARlight
 build_requires:

--- a/aligeno2.sh
+++ b/aligeno2.sh
@@ -1,0 +1,22 @@
+package: AliGenO2
+version: "v%(year)s%(month)s%(day)s"
+requires:
+  - DPMJET
+  - POWHEG
+  - pythia
+  - SHERPA
+  - ThePEG
+  - Rivet
+  - lhapdf-pdfsets
+  - JETSCAPE
+  - EPOS4
+  - STARlight
+build_requires:
+  - alibuild-recipe-tools
+---
+#!/bin/bash -ex
+
+# Modulefile
+moduledir="$INSTALLROOT/etc/modulefiles"
+mkdir -p "$moduledir"
+alibuild-generate-module > "$moduledir/$PKGNAME"

--- a/epos4.sh
+++ b/epos4.sh
@@ -1,6 +1,6 @@
 package: EPOS4
 version: "%(tag_basename)s"
-tag: "v4.0.0-alice3"
+tag: "v4.0.0-alice4"
 source: https://github.com/alisw/EPOS4.git
 requires:
   - ROOT

--- a/o2sim.sh
+++ b/o2sim.sh
@@ -5,6 +5,7 @@ requires:
   - O2DPG
   - QualityControl
   - AEGIS
+  - AliGenO2:(?!osx|.*aarch64)
   - EVTGEN:(?!osx)
   - STARlight:(?!osx)
   - jq

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,7 +1,7 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "rivet-3.1.8"
-source: https://gitlab.com/hepcedar/rivet.git
+tag: "3.1.8-alice1"
+source: https://github.com/alisw/rivet.git
 requires:
   - HepMC3
   - YODA


### PR DESCRIPTION
In the same PR an upgrade of EPOS4 has also been introduced in order to make it work with the current O2sim generation mechanism via cmd. AliGenO2 contains the basic packages of AliGenerators. More might be added in the future if the community requires them (Herwig7 is temporarily disabled due to MadGraph not being able to compile due to wget based issues). 