### PR TITLE
Try to use original TPC fec utils repository

### DIFF
--- a/tpcfecutils.sh
+++ b/tpcfecutils.sh
@@ -10,7 +10,7 @@ requires:
   - LLA
 build_requires:
   - CMake
-source: https://gitlab.cern.ch/ALICEPrivateExternals/alice-tpc-fec-utils.git
+source: https://gitlab.cern.ch/alice-tpc-upgrade/alice-tpc-fec-utils
 incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles


### PR DESCRIPTION
Testing to see if the CI can access this repository too. This way we could get rid of maintaining the mirror
