### PR TITLE
Bump to ROOT v6-32-06-alice1

### DIFF
--- a/o2.sh
+++ b/o2.sh
@@ -23,7 +23,7 @@ requires:
   - libuv
   - libjalienO2
   - cgal
-  - VecGeom
+  - "VecGeom:(?!osx.*)"
   - FFTW3
   - ONNXRuntime
   - MLModels

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-32-02-alice1"
+tag: "v6-32-04-alice1"
 source: https://github.com/alisw/root.git
 requires:
   - arrow
@@ -169,7 +169,7 @@ cmake $SOURCEDIR                                                                
       -Dmathmore=ON                                                                    \
       -Droofit=ON                                                                      \
       -Dhttp=ON                                                                        \
-      -Droot7=OFF                                                                      \
+      -Droot7=ON                                                                       \
       -Dsoversion=ON                                                                   \
       -Dshadowpw=OFF                                                                   \
       -Dvdt=OFF                                                                        \

--- a/root.sh
+++ b/root.sh
@@ -125,6 +125,7 @@ fi
 
 case $PKG_VERSION in
   v6[-.]30*) EXTRA_CMAKE_OPTIONS="-Dminuit2=ON -Dpythia6=ON -Dpythia6_nolink=ON" ;;
+  v6[-.]32[-.]0[6789]*) EXTRA_CMAKE_OPTIONS="-Dminuit=ON -Dpythia6=ON -Dpythia6_nolink=ON -Dproof=ON" ;;
   *) EXTRA_CMAKE_OPTIONS="-Dminuit=ON" ;;
 esac
 

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-32-04-alice1"
+tag: "v6-32-06-alice1"
 source: https://github.com/alisw/root.git
 requires:
   - arrow


### PR DESCRIPTION
- Make sure ROOT works on macOS 15 Sequoia (requires enabling ROOT7)
- Disable VecGeom on macOS (apparently not used)
- Include improvements to geometry handling by @sawenzel 
- Include reverts necessary to have pythia6 and proof working
