### PR TITLE
Don't fix an old GCC version since meanwhile we have generally bumped GCC

### DIFF
--- a/defaults-ali.sh
+++ b/defaults-ali.sh
@@ -26,9 +26,6 @@ overrides:
       - JAliEn-ROOT
   vgm:
     tag: "v5-2"
-  GCC-Toolchain:
-    version: v12.2.0-alice1
-    tag: v12.2.0-alice1
   cgal:
     version: 4.12.2
   fastjet:

--- a/defaults-generators.sh
+++ b/defaults-generators.sh
@@ -7,9 +7,6 @@ env:
   CMAKE_BUILD_TYPE: RELWITHDEBINFO
   CXXFLAGS: -fPIC -g -O2 -std=c++17
 overrides:
-  GCC-Toolchain:
-    version: v12.2.0-alice1
-    tag: v12.2.0-alice1
   boost:
     requires:
       - GCC-Toolchain:(?!osx)

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -35,9 +35,6 @@ disable:
   - OpenSSL
   - curl:(?!osx.*)
 overrides:
-  GCC-Toolchain:
-    version: "v12.2.0-alice1"
-    tag: "v12.2.0-alice1"
   O2-customization:
     env:
       ENABLE_UPGRADES: "OFF"  # Disable detector upgrades in O2


### PR DESCRIPTION
@ktf @singiamtel : I assume these were leftovers, from when the default GCC was 8.x?