### PR TITLE
Update root.sh

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-32-02-alice1"
+tag: "v6-32-04-alice2"
 source: https://github.com/alisw/root.git
 requires:
   - arrow


### PR DESCRIPTION
Bump ROOT to ALICE specific version v6-32-04-alice2. (Needed, for instance, to get improvements in TGeoParallelWorld for ITS simulation).