### PR TITLE
GCC: avoid naming conflicts

### DIFF
--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -121,7 +121,6 @@ pushd build-gcc
                    --disable-nls
   make ${JOBS+-j $JOBS} bootstrap-lean MAKEINFO=":"
   make install MAKEINFO=":"
-  (if cd gmp || cd ../gmp; then make install MAKEINFO=":"; fi)
   hash -r
 
   # GCC creates c++, but not cc
@@ -268,6 +267,10 @@ pushd build-gdb
   rm -f "$INSTALLROOT"/lib/*.la
 popd
 
+# We remove the sim folder because it's not used and actually
+# conflicts with FairRoot when installing in a single installation
+# path.
+rm -fr "$INSTALLROOT"/include/sim
 # If fixincludes is not desired, see:
 # http://ewontfix.com/12/
 # https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/eclass/toolchain.eclass?view=markup&sortby=log#l1524


### PR DESCRIPTION

- do not install GMP used to compile GCC. Other externals depend on their own
  GMP since we do not want to bind the lifetime of GMP upgrades to the lifetime
  of GCC ones. This was done to avoid reproducibility issues in e.g. FastJet
  and CGal.
- Remove the sim folder which conflicts with FairRoot.
