### PR TITLE
defaults-o2-epn: disable AliGenO2 for online processing

### DIFF
--- a/defaults-o2-epn.sh
+++ b/defaults-o2-epn.sh
@@ -10,6 +10,7 @@ env:
   GEANT4_BUILD_MULTITHREADED: 'OFF'
 disable:
   - AliGenerators
+  - AliGenO2
   - O2Physics
   - KFParticle
   - OpenSSL


### PR DESCRIPTION
disabling AliGenO2 for EPNs since recently, AliGenO2 requires Rivet which causes problems for P2 environment creation when using a local O2DPG repository path (in the Rivet module file, a catch statement tries to write to the local path which it is not allowed to do by default if it is a user path).

@davidrohr can you confirm that we don't use AliGenO2 on EPNs for online?