### PR TITLE
Don't hard-code the number of parallel builders for mesos

### DIFF
--- a/mesos.sh
+++ b/mesos.sh
@@ -42,7 +42,7 @@ cd build
     --with-rapidjson=${RAPIDJSON_ROOT}
 
 # We build with fewer jobs to avoid OOM errors in GCC
-make -j 6
+make -j $((JOBS / 2))
 make install
 
 


### PR DESCRIPTION
I don't think that we should hard code the number of parallel jobs for the build of mesos. 
What about `JOBS/2` ? 