### PR TITLE
Introduced new environment config variable

### DIFF
--- a/o2dpg.sh
+++ b/o2dpg.sh
@@ -19,6 +19,7 @@ alibuild-generate-module --bin > etc/modulefiles/$PKGNAME
 cat << EOF >> etc/modulefiles/$PKGNAME
 set O2DPG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv O2DPG_ROOT \$O2DPG_ROOT
+setenv O2DPG_MC_CFG_ROOT \$O2DPG_ROOT
 setenv O2DPG_RELEASE \$version
 setenv O2DPG_VERSION $PKGVERSION
 EOF

--- a/o2dpg.sh
+++ b/o2dpg.sh
@@ -19,7 +19,7 @@ alibuild-generate-module --bin > etc/modulefiles/$PKGNAME
 cat << EOF >> etc/modulefiles/$PKGNAME
 set O2DPG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv O2DPG_ROOT \$O2DPG_ROOT
-setenv O2DPG_MC_CFG_ROOT \$O2DPG_ROOT
+setenv O2DPG_MC_CONFIG_ROOT \$O2DPG_ROOT
 setenv O2DPG_RELEASE \$version
 setenv O2DPG_VERSION $PKGVERSION
 EOF


### PR DESCRIPTION
O2DPG_MC_CFG_ROOT is going to replace O2DPG_ROOT inside the config files. This will make the system more flexible by allowing the user to change this variable on-the-fly, and hence not be limited by the loaded version of O2DPG.