### PR TITLE
Fix clang prefer_system_check

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -13,7 +13,7 @@ build_requires:
 env:
   LLVM_ROOT: "$CLANG_ROOT" # needed by LLVMAlt
 prefer_system: (osx.*)
-prefer_system_check:
+prefer_system_check: |
   brew --prefix llvm@18 && test -d $(brew --prefix llvm@18)
 ---
 #!/bin/bash -e

--- a/clang.sh
+++ b/clang.sh
@@ -14,7 +14,7 @@ env:
   LLVM_ROOT: "$CLANG_ROOT" # needed by LLVMAlt
 prefer_system: (osx.*)
 prefer_system_check:
-  test -d $(brew --prefix llvm@18)
+  brew --prefix llvm@18 && test -d $(brew --prefix llvm@18)
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION
This should make it behave correctly also on Linux with --always-prefer-system.