### PR TITLE
Remove readline installation from xjalienfs recipe

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -19,13 +19,6 @@ prepend_path:
 # works inside and outside a virtualenv, but unset VIRTUAL_ENV to make sure we
 # only depend on stuff we installed using our Python and Python-modules.
 
-# on macos try to install gnureadline and just skip if fails (alienpy can work without it)
-# macos python readline implementation is build on libedit which does not work
-[[ "$ARCHITECTURE" ==  osx_* ]] && { env -u VIRTUAL_ENV ALIBUILD=1 \
-    python3 -m pip install --force-reinstall \
-    --target="$INSTALLROOT/lib/python/site-packages" \
-    gnureadline || : ; }
-
 env -u VIRTUAL_ENV ALIBUILD=1 \
     python3 -m pip install --force-reinstall \
     --target="$INSTALLROOT/lib/python/site-packages" \


### PR DESCRIPTION
Since https://github.com/alisw/alidist/pull/5534 we depend on gnureadline globally anyway, no point in reinstalling it in the recipe

CC @ktf @adriansev @sawenzel