### PR TITLE
[O2-5506] Bump libffi and use our patched version

### DIFF
--- a/libffi.sh
+++ b/libffi.sh
@@ -1,5 +1,5 @@
 package: libffi
-version: v3.4.4-alice1
+version: v3.2.1-alice1
 build_requires:
   - "autotools:(slc6|slc7)"
   - "GCC-Toolchain:(?!osx)"
@@ -11,9 +11,11 @@ prepend_path:
 #!/bin/bash -ex
 rsync -a "$SOURCEDIR"/ .
 autoreconf -ivf .
+
 # Hack to bypass automake 1.17 creating a malformed Makefile on macOS
 # https://github.com/libffi/libffi/issues/853
-mv -f Makefile_upstream_v3.4.4.in Makefile.in
+mv -f Makefile_3.2.1_autoconf_2.69.in Makefile.in
+
 MAKEINFO=: ./configure --prefix="$INSTALLROOT" --disable-docs --disable-multi-os-directory
 make ${JOBS:+-j $JOBS} MAKEINFO=:
 make install MAKEINFO=:

--- a/libffi.sh
+++ b/libffi.sh
@@ -1,38 +1,25 @@
 package: libffi
-version: v3.2.1
+version: v3.4.4-alice1
 build_requires:
   - "autotools:(slc6|slc7)"
   - "GCC-Toolchain:(?!osx)"
-source: https://github.com/libffi/libffi
+  - alibuild-recipe-tools
+source: https://github.com/alisw/libffi
 prepend_path:
   LD_LIBRARY_PATH: "$LIBFFI_ROOT/lib64"
 ---
 #!/bin/bash -ex
-rsync -a $SOURCEDIR/ .
+rsync -a "$SOURCEDIR"/ .
 autoreconf -ivf .
-MAKEINFO=: ./configure --prefix=$INSTALLROOT --disable-docs
+# Hack to bypass automake 1.17 creating a malformed Makefile on macOS
+# https://github.com/libffi/libffi/issues/853
+mv -f Makefile_upstream_v3.4.4.in Makefile.in
+MAKEINFO=: ./configure --prefix="$INSTALLROOT" --disable-docs --disable-multi-os-directory
 make ${JOBS:+-j $JOBS} MAKEINFO=:
 make install MAKEINFO=:
 
-LIBPATH=$(find $INSTALLROOT -name libffi.so -o -name libffi.dylib -o -name libffi.a | head -n 1)
 # Do not install info documentation
 rm -fr "$INSTALLROOT/share/info"
 
-# Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-set LIBFFI_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$LIBFFI_ROOT/$(basename $(dirname $LIBPATH))
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION
Should bypass both the macOS automake 1.17 issues, and the cfi_startproc issue

Automake 1.17 workaround: https://github.com/libffi/libffi/issues/853#issuecomment-2306898507
cfi_startproc workaround: https://github.com/libffi/libffi/commit/8308bed5b2423878aa20d7884a99cf2e30b8daf7

Also taking the chance to modernize the modulefile generation

```diff
$ diff modulefile.old modulefile.new
9,12c9,15
< module load BASE/1.0
< # Our environment
< set LIBFFI_ROOT $::env(BASEDIR)/libffi/$version
< prepend-path LD_LIBRARY_PATH $LIBFFI_ROOT/lib
---
> if ![ is-loaded 'BASE/1.0' ] {
>  module load BASE/1.0
> }
>
> set PKG_ROOT $::env(BASEDIR)/libffi/$version
> prepend-path LD_LIBRARY_PATH $PKG_ROOT/lib
>
```
CC @ktf 