### PR TITLE
Compile starlight against dpmjet

### DIFF
--- a/dpmjet.sh
+++ b/dpmjet.sh
@@ -22,6 +22,9 @@ cmake  $SOURCEDIR                           \
 
 make ${JOBS+-j $JOBS} install
 
+cp -r $SOURCEDIR/include $INSTALLROOT/.
+cp -r $SOURCEDIR/dpmdata $INSTALLROOT/.
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"

--- a/starlight.sh
+++ b/starlight.sh
@@ -2,6 +2,7 @@ package: STARlight
 version: "20240617"
 tag: 196adefb9b840587d374b675e288b2a98fb5df0e
 requires:
+  - DPMJET
   - HepMC3
 build_requires:
   - CMake
@@ -15,12 +16,15 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE      \
                  -DCMAKE_SKIP_RPATH=TRUE                   \
                  -DENABLE_HEPMC3=ON                        \
+				 -DENABLE_DPMJET=ON                        \
 		 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON        \
 		 -DBUILD_SHARED_LIB=ON                     \
                  -DCMAKE_INSTALL_LIBDIR=lib                \
-                 -DHepMC3_DIR="$HEPMC3_ROOT"
+                 -DHepMC3_DIR="$HEPMC3_ROOT"		\
+				 -DDPMJET_DIR="$DPMJET_ROOT"
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
+cp libDpmJetLib.so $INSTALLROOT/lib
 cp -r $SOURCEDIR/config $INSTALLROOT/.
 cp -r $SOURCEDIR/include $INSTALLROOT/.
 


### PR DESCRIPTION
STARlight can be compiled against DPMJET, in that case a separate library is created (libDpmJetLib) that uses routines from DPMJET to simulate photo-nuclear interactions. UPC group would like to use this mode.

The libDpmJetLib is somehow not installed and remains in the build directory so I added explicit line to move it, maybe there is another solution.

There is an adjustment in STARlight itself needed to make this work. I can make the PR myself, but I will appreciate an expert opinion on issue 2.
1. The libDpmJetLib was build as static, I added option to build it as Shared. 
2. There is an issue with "FIND_LIBRARY" in the CMake module when the library path defined as a environment variable in the alidist/starlight.sh is preceded by ENV. Library is then not found when this is build via aliBuild. It definitely works in standalone installation (to see what I mean exactly have a look in the attached patch).
[STARlight.patch](https://github.com/user-attachments/files/17633765/STARlight.patch)
