### PR TITLE
o2dpg.sh : Be sensitive to ALIEN_JDL_O2DPG_MC_CONFIG_ROOT

### DIFF
--- a/o2dpg.sh
+++ b/o2dpg.sh
@@ -19,7 +19,11 @@ alibuild-generate-module --bin > etc/modulefiles/$PKGNAME
 cat << EOF >> etc/modulefiles/$PKGNAME
 set O2DPG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv O2DPG_ROOT \$O2DPG_ROOT
-setenv O2DPG_MC_CONFIG_ROOT \$O2DPG_ROOT
+if {[info exists env(ALIEN_JDL_O2DPG_MC_CONFIG_ROOT)] && \$::env(ALIEN_JDL_O2DPG_MC_CONFIG_ROOT) ne ""} {
+  setenv O2DPG_MC_CONFIG_ROOT \$::env(ALIEN_JDL_O2DPG_MC_CONFIG_ROOT)
+} else {
+  setenv O2DPG_MC_CONFIG_ROOT \$O2DPG_ROOT
+}
 setenv O2DPG_RELEASE \$version
 setenv O2DPG_VERSION $PKGVERSION
 EOF


### PR DESCRIPTION
Add sensitivity to a JDL configuration.

This achieves sensitivity to pickup alternative MC generator config paths via a JDL variable (ALIEN_JDL_O2DPG_MC_CONFIG_ROOT).

This is the most convenient place to do this. No script in O2DPG needs to be changed.

Relates to ticket https://its.cern.ch/jira/browse/O2-5366