### PR TITLE
Bump DDS to 3.11

### DIFF
--- a/dds.sh
+++ b/dds.sh
@@ -1,6 +1,6 @@
 package: DDS
 version: "%(tag_basename)s"
-tag: "3.10"
+tag: "3.11"
 source: https://github.com/FairRootGroup/DDS
 requires:
   - boost


### PR DESCRIPTION
@lkrcal @ktf : This is needed to run with boost 1.86.

@ktf : I see we have some custom patches on top of our current boost 1.86. Do we need to port them when bumping boost, or should we try the new version?