### PR TITLE
XRootD 5.7.2

### DIFF
--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.7.0"
+tag: "v5.7.2"
 source: https://github.com/xrootd/xrootd
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
XRootD 5.7.2 was released and together with 5.7.1 it has some XrdCl and Python fixes
see https://github.com/xrootd/xrootd/blob/v5.7.2/docs/ReleaseNotes.txt 