### PR TITLE
Bump JAliEn to 1.9.6

### DIFF
--- a/jalien.sh
+++ b/jalien.sh
@@ -1,6 +1,6 @@
 package: JAliEn
 version: "%(tag_basename)s"
-tag: "1.9.5"
+tag: "1.9.6"
 source: https://gitlab.cern.ch/jalien/jalien.git
 requires:
   - JDK


### PR DESCRIPTION
Update JAliEn (Java components only). Doesn't affect AliPhysics / O2 in any way.