### PR TITLE
bump pda + readoutcard

### DIFF
--- a/pda.sh
+++ b/pda.sh
@@ -1,6 +1,6 @@
 package: PDA
 version: "%(tag_basename)s"
-tag: 12.0.0
+tag: 12.1.0
 source: https://github.com/AliceO2Group/pda.git
 requires:
   - "GCC-Toolchain:(?!osx)"

--- a/readoutcard.sh
+++ b/readoutcard.sh
@@ -1,6 +1,6 @@
 package: ReadoutCard
 version: "%(tag_basename)s"
-tag: v0.45.4
+tag: v0.45.5
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
WIP

To be merged in sync with the deployment of the new pda-kadapter-dkms RPM, if it applies to the build/ci hosts.
cf https://its.cern.ch/jira/browse/ORC-500
