### PR TITLE
Dump FairMQ from FairROOT

### DIFF
--- a/fairroot.sh
+++ b/fairroot.sh
@@ -9,7 +9,6 @@ requires:
   - boost
   - protobuf
   - FairLogger
-  - FairMQ
   - "GCC-Toolchain:(?!osx)"
 env:
   VMCWORKDIR: "$FAIRROOT_ROOT/share/fairbase/examples"


### PR DESCRIPTION
AFAICT, the dependency is not actually needed.