### PR TITLE
Bump GEANT4_VMC version for HF MC productions

### DIFF
--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v6-6-p1"
+tag: "v6-6-p3"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT


### PR DESCRIPTION
This PR it's needed to have this fix https://github.com/vmc-project/geant4_vmc/pull/70 needed for HF MC productions