### PR TITLE
Remove check for availability of both OpenCL libraries, with the removal of OpenCL 1.2 we have only 1

### DIFF
--- a/o2-rtc-test.sh
+++ b/o2-rtc-test.sh
@@ -17,7 +17,6 @@ pushd $BUILDDIR/rtc-test
 type $O2_ROOT/lib/libO2GPUTrackingCUDA.so
 type $O2_ROOT/lib/libO2GPUTrackingHIP.so
 type $O2_ROOT/lib/libO2GPUTrackingOCL.so
-type $O2_ROOT/lib/libO2GPUTrackingOCL2.so
 
 #o2-gpu-standalone-benchmark --noEvents -g --gpuType CUDA --RTCenable 1 --RTCcacheOutput 0 --RTCoptConstexpr 1 --RTCcompilePerKernel 1 --RTCrunTest 2
 o2-gpu-standalone-benchmark --noEvents -g --gpuType HIP --RTCenable 1 --RTCcacheOutput 0 --RTCoptConstexpr 1 --RTCcompilePerKernel 1 --RTCrunTest 2


### PR DESCRIPTION
trivial, merging