### PR TITLE
Fix Python detection in clang recipe

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -41,7 +41,13 @@ esac
 # If we have our own python, use it
 if [ -n "$PYTHON_REVISION" ]; then
   export PYTHON_HOME="$PYTHON_ROOT"
+  which -a python
+  which -a python3
+  # if [ -n "$VIRTUAL_ENV" ]; then
+  #     deactivate
+  # fi
 fi
+
 
 # BUILD_SHARED_LIBS=ON is needed for e.g. adding dynamic plugins to clang-tidy.
 # Apache Arrow needs LLVM_ENABLE_RTTI=ON.

--- a/python.sh
+++ b/python.sh
@@ -45,24 +45,32 @@ prefer_system_replacement_specs:
     env:
         PYTHON_ROOT: $(brew --prefix python3)
         PYTHON_REVISION: ""
+        PYTHONHOME: ""
+        PYTHONPATH: ""
   "python3.*":
     env:
         # Python is in path, so we need a dummy placeholder for PYTHON_ROOT
         # to avoid having /bin in the middle of the path.
         PYTHON_ROOT: "/dummy-python-folder"
         PYTHON_REVISION: ""
+        PYTHONHOME: ""
+        PYTHONPATH: ""
 
   # Workaround to support old alibuild versions that don't regex match alibuild_system_replace
   "python-brew3":
     env:
         PYTHON_ROOT: $(brew --prefix python3)
         PYTHON_REVISION: ""
+        PYTHONHOME: ""
+        PYTHONPATH: ""
   "python3":
     env:
         # Python is in path, so we need a dummy placeholder for PYTHON_ROOT
         # to avoid having /bin in the middle of the path.
         PYTHON_ROOT: "/dummy-python-folder"
         PYTHON_REVISION: ""
+        PYTHONHOME: ""
+        PYTHONPATH: ""
 ---
 rsync -av --exclude '**/.git' $SOURCEDIR/ $BUILDDIR/
 


### PR DESCRIPTION
Should fix the issues on the daily builds

```
   Could NOT find Python3 (missing: Interpreter)

       Reason given by package:
           Interpreter: Cannot run the interpreter "/local/tmp/venv/bin/python3"
```
