### PR TITLE
Fix looptools compile problem on AARCH64

### DIFF
--- a/looptools.sh
+++ b/looptools.sh
@@ -10,7 +10,16 @@ build_requires:
 #!/bin/bash -e
 rsync -a "$SOURCEDIR/" ./
 
-./configure --prefix="$INSTALLROOT" --64
+export LOGFILE=${PWD}/configure.log
+
+# adjust some config options based on architecture
+# (--64 does not work on aarch64)
+ARCHFLAG="--64"
+case $ARCHITECTURE in
+  *_aarch64) ARCHFLAG="" ;;
+esac
+
+./configure --prefix="$INSTALLROOT" ${ARCHFLAG}
 
 make ${JOBS+-j $JOBS}
 make install


### PR DESCRIPTION
LoopTools fails to compile on Ubuntu22 with ARM archicture. The flag -m64 caused by the `--64` to `./configure`
is not recognized by the Fortran compiler. 

Simply not passing this flag fixes the issue on ARM. This brings us one step closer to be able to compile and deploy
AliGenO2 also on this platform.