### PR TITLE
Bump JDK to 17.0.4

### DIFF
--- a/jdk.sh
+++ b/jdk.sh
@@ -1,5 +1,5 @@
 package: JDK
-version: "12.0.1"
+version: "17.0.14"
 build_requires:
   - curl
 prefer_system: .*
@@ -16,9 +16,9 @@ JDK_PLATFORM=linux
 [[ $ARCHITECTURE != osx* ]] || JDK_PLATFORM=osx
 
 if [[ $JDK_PLATFORM == osx ]]; then
-  URL="https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz"
+  URL="https://cdn.azul.com/zulu/bin/zulu17.56.15-ca-jdk17.0.14-macosx_x64.tar.gz"
 else
-  URL="https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz"  
+  URL="https://cdn.azul.com/zulu/bin/zulu17.56.15-ca-jdk17.0.14-linux_x64.tar.gz"  
 fi
 
 mkdir -p "$INSTALLROOT"


### PR DESCRIPTION
Bumps the JDK to v17 (LTS), which will be needed for JAliEn in upcoming tags (compile target changed from 11 --> 15).