### PR TITLE
Force rebuilds whenever the CMake on the system changes

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -12,6 +12,11 @@ prefer_system: .*
 prefer_system_check: |
   verge() { [[  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]]; }
   type cmake && verge 3.28.1 `cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3`
+  echo alibuild_system_replace: cmake`cmake --version | sed -e 's/.* //' | cut -d. -f1,2,3`
+prefer_system_replacement_specs:
+  "cmake.*":
+    env:
+      CMAKE_VERSION: ""
 ---
 #!/bin/bash -e
 


### PR DESCRIPTION

This is needed because CMake embeds itself in the CMakeCache.txt
with the net result that if e.g. brew gets updated, you are left
with a broken setup.
