### PR TITLE
Allow using system ninja

### DIFF
--- a/ninja-fortran.sh
+++ b/ninja-fortran.sh
@@ -1,4 +1,4 @@
-package: ninja
+package: ninja-fortran
 version: "fortran-%(short_hash)s"
 tag: "v1.11.1.g95dee.kitware.jobserver-1"
 source: https://github.com/Kitware/ninja
@@ -6,15 +6,12 @@ build_requires:
   - "GCC-Toolchain:(?!osx)"
   - "CMake"
   - alibuild-recipe-tools
-prefer_system: .*
-prefer_system_check: |
-  type ninja
 ---
 #!/bin/bash
-cmake -Bbuild-cmake "$SOURCEDIR"
-cmake --build build-cmake ${JOBS:+-j$JOBS}
+cmake -Bbuild-cmake $SOURCEDIR
+cmake --build build-cmake
 
-mkdir -p "$INSTALLROOT"/bin
+mkdir -p $INSTALLROOT/bin
 cp build-cmake/ninja "$INSTALLROOT/bin"
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION

- Packages which build fortran parts, should use ninja-fortran
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/alidist/pull/5786).
* #5793
* #5797 (6 commits)
* __->__ #5786