### PR TITLE
Bump FairMQ to v1.9.2

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: "v1.9.1"
+tag: "v1.9.2"
 source: https://github.com/FairRootGroup/FairMQ
 requires:
   - boost


### PR DESCRIPTION
Required to have access to the reference counting of the shared memory messages.