### PR TITLE
Force python rebuilds when patch level changes

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -31,7 +31,8 @@ prefer_system_check: |
     else
         case $ALIBUILD_ARCHITECTURE in
             osx*)
-                python3 -c 'from sys import version_info; print(f"alibuild_system_replace: python-brew{version_info.major}.{version_info.minor}")' ;;
+                # We need to include the python patch number because brew has it in the path
+                python3 -c 'from sys import version_info; print(f"alibuild_system_replace: python-brew{version_info.major}.{version_info.minor}.{version_info.micro}")' ;;
             *)
                 python3 -c 'from sys import version_info; print(f"alibuild_system_replace: python{version_info.major}.{version_info.minor}")'
             ;;
@@ -42,10 +43,12 @@ prefer_system_check: |
     python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3, 9) or sys.version_info > (3, 14) else 0)' && python3 -m pip --help > /dev/null && printf '#include "pyconfig.h"' | cc -c $(python3-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
 prefer_system_replacement_specs:
   "python-brew3.*":
+    version: "%(key)s"
     env:
         PYTHON_ROOT: $(brew --prefix python3)
         PYTHON_REVISION: ""
   "python3.*":
+    version: "%(key)s"
     env:
         # Python is in path, so we need a dummy placeholder for PYTHON_ROOT
         # to avoid having /bin in the middle of the path.
@@ -54,10 +57,12 @@ prefer_system_replacement_specs:
 
   # Workaround to support old alibuild versions that don't regex match alibuild_system_replace
   "python-brew3":
+    version: "%(key)s"
     env:
         PYTHON_ROOT: $(brew --prefix python3)
         PYTHON_REVISION: ""
   "python3":
+    version: "%(key)s"
     env:
         # Python is in path, so we need a dummy placeholder for PYTHON_ROOT
         # to avoid having /bin in the middle of the path.


### PR DESCRIPTION

This is needed because homebrew now has the full version in the path to
the various python executables which can then be cached by CMake.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/alidist/pull/5798).
* #5793 (7 commits)
* __->__ #5798