### PR TITLE
Adapt to new syntax in GPU standalone benchmark

### DIFF
--- a/o2-rtc-test.sh
+++ b/o2-rtc-test.sh
@@ -18,8 +18,8 @@ type $O2_ROOT/lib/libO2GPUTrackingCUDA.so
 type $O2_ROOT/lib/libO2GPUTrackingHIP.so
 type $O2_ROOT/lib/libO2GPUTrackingOCL.so
 
-#o2-gpu-standalone-benchmark --noEvents -g --gpuType CUDA --RTCenable 1 --RTCcacheOutput 0 --RTCoptConstexpr 1 --RTCcompilePerKernel 1 --RTCrunTest 2
-o2-gpu-standalone-benchmark --noEvents -g --gpuType HIP --RTCenable 1 --RTCcacheOutput 0 --RTCoptConstexpr 1 --RTCcompilePerKernel 1 --RTCrunTest 2
+#o2-gpu-standalone-benchmark --noEvents -g --gpuType CUDA --RTCenable 1 --RTCcacheOutput 0 --RTCoptConstexpr 1 --RTCcompilePerKernel 1 --RTCTECHrunTest 2
+o2-gpu-standalone-benchmark --noEvents -g --gpuType HIP --RTCenable 1 --RTCcacheOutput 0 --RTCoptConstexpr 1 --RTCcompilePerKernel 1 --RTCTECHrunTest 2
 
 popd
 rm -Rf $BUILDDIR/rtc-test


### PR DESCRIPTION
https://github.com/AliceO2Group/AliceO2/pull/14120 changed the syntax, and we have to change the test in alidist in parallel.
Trivial, merging