### PR TITLE
Fix the system check on safe_int and nlohmann_json

### DIFF
--- a/nlohmann_json.sh
+++ b/nlohmann_json.sh
@@ -9,7 +9,7 @@ build_requires:
   - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
-  printf "#include <nlohmann/json_fwd.hpp>\n" | cc -xc++ - -I"$(brew --prefix nlohmann-json)"-c -o/dev/null
+  printf "#include <nlohmann/json_fwd.hpp>\n" | cc -xc++ - -I"$(brew --prefix nlohmann-json)/include" -c -o /dev/null
 ---
 #!/bin/bash -e
   cmake "$SOURCEDIR"                             \

--- a/safe_int.sh
+++ b/safe_int.sh
@@ -4,7 +4,7 @@ tag: 3.0.28a
 source: https://github.com/dcleblanc/SafeInt
 prefer_system: .*
 prefer_system_check: |
-  printf "#include <SafeInt.hpp>" | cc -I$(brew --prefix safeint)/include - -xc++ -c -o/dev/null
+  printf "#include <SafeInt.hpp>\n" | cc -xc++ - -I"$(brew --prefix safeint)/include" -c -o /dev/null
 ---
 #!/bin/bash -e
 mkdir -p $INSTALLROOT/include


### PR DESCRIPTION
Updated the check for the presence of `safe_int` and `nlohmann_json` packages in the macOS