### PR TITLE
Drop SHERPA for now

### DIFF
--- a/aligeno2.sh
+++ b/aligeno2.sh
@@ -4,7 +4,6 @@ requires:
   - DPMJET
   - POWHEG
   - pythia
-  - SHERPA
   - ThePEG
   - Rivet
   - lhapdf-pdfsets


### PR DESCRIPTION
Something changed on the system, preventing SHERPA from compilation. Dropping while we understand what is going on.