### PR TITLE
xjalienfs/alienpy 1.6.4

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -1,6 +1,6 @@
 package: xjalienfs
 version: "%(tag_basename)s"
-tag: "1.6.3"
+tag: "1.6.4"
 source: https://gitlab.cern.ch/jalien/xjalienfs.git
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
* fix the usage of JALIEN_HOST/JALIEN_WSPORT :: use env vars before loading jalien_client_ file
* improve handling of certificate files (discovery and passing between modules)
* improve user agent to have full architecture details about the client
* logging fixes
* add `run_tests_venv` script to run tests in freshly created venv