### PR TITLE
Bump mesos to 1.11.0-alice4

### DIFF
--- a/mesos.sh
+++ b/mesos.sh
@@ -1,6 +1,6 @@
 package: mesos
 version: v1.11.0
-tag: 1.11.0-alice2
+tag: 1.11.0-alice4
 source: https://github.com/AliceO2Group/mesos.git
 requires:
   - zlib


### PR DESCRIPTION
It includes a fix for mesos-fetcher, needed due to an issue introduced by the recent protobuf bump to v29.3