### PR TITLE
Disable EPOS4HQ build on ARM

### DIFF
--- a/aligeno2.sh
+++ b/aligeno2.sh
@@ -11,7 +11,7 @@ requires:
   - JETSCAPE
   - CRMC
   - EPOS4
-  - EPOS4HQ
+  - EPOS4HQ:(?!.*aarch64)
   - EVTGEN:(?!osx)
   - STARlight:(?!osx)
   - Upcgen:(?!osx)


### PR DESCRIPTION
EPOS4HQ is currently unsupported on ARM, it needs the compiler flag
`mcmodel=large`, which is incompatible with `-fPIC`

As per the IN2P3 team, they require mcmodel=large to fit all their
statically allocated arrays in Fortran common blocks

CC @ktf @jackal1-66 
