### PR TITLE
Bump pip

### DIFF
--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -3,7 +3,7 @@ version: "1.0"
 env:
   PIP_BASE_REQUIREMENTS: |
     pip == 21.3.1; python_version < '3.12'
-    pip == 24.0; python_version >= '3.12'
+    pip < 26.0; python_version >= '3.12'
     setuptools == 59.6.0; python_version < '3.12'
     setuptools == 70.0.0; python_version >= '3.12'
     wheel == 0.37.1; python_version < '3.12'


### PR DESCRIPTION
Fixes the following issue in the mac testers

```
ERROR: Exception:
Traceback (most recent call last):
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_internal/cli/base_command.py", line 180, in exc_logging_wrapper
    status = run_func(*args)
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_internal/cli/req_command.py", line 245, in wrapper
    return func(self, options, args)
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_internal/commands/install.py", line 362, in run
    resolver = self.make_resolver(
        preparer=preparer,
    ...<8 lines>...
        use_pep517=options.use_pep517,
    )
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_internal/cli/req_command.py", line 353, in make_resolver
    import pip._internal.resolution.resolvelib.resolver
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 8, in <module>
    from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_vendor/resolvelib/__init__.py", line 19, in <module>
    from .resolvers import (
    ...<6 lines>...
    )
  File "/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_vendor/resolvelib/resolvers/__init__.py", line 1, in <module>
    from ..structs import RequirementInformation
ImportError: cannot import name 'RequirementInformation' from 'pip._vendor.resolvelib.structs' (/System/Volumes/Data/build/alice-ci-workdir/venv/lib/python3.13/site-packages/pip/_vendor/resolvelib/structs.py)
```
