### PR TITLE
Don't run full recipe check on PRs

### DIFF
--- a/.github/workflows/recipe-checks.yml
+++ b/.github/workflows/recipe-checks.yml
@@ -5,6 +5,8 @@ name: Check recipes
 
 'on':
   push:
+    branches:
+      - master
     paths:
       - '*.sh'
   pull_request:


### PR DESCRIPTION
Currently we test the changed recipes properly with pull_request, and
all the files pushed in case the PR is done with an alisw/alidist branch
