### PR TITLE
Bump bookkeeping-api to v1.9.2

### DIFF
--- a/bookkeeping-api.sh
+++ b/bookkeeping-api.sh
@@ -1,6 +1,6 @@
 package: bookkeeping-api
-version: "v1.6.0"
-tag: "@aliceo2/bookkeeping@1.6.0"
+version: "v1.9.2"
+tag: "@aliceo2/bookkeeping@1.9.2"
 requires:
   - grpc
   - protobuf


### PR DESCRIPTION
To allow for creating a BKP gRPC client with authentication tokens.