### PR TITLE
Include version as environment variable

### DIFF
--- a/epos4.sh
+++ b/epos4.sh
@@ -7,6 +7,8 @@ requires:
   - fastjet
   - HepMC3
   - alibuild-recipe-tools
+env:
+  EPO4VSN: "4.0.3"
 ---
 #!/bin/bash -ex
 


### PR DESCRIPTION
EPO4VSN is not set automatically when O2DPG-sim-tests builds, making the CI test fail. This addition, as done in EPOS3 recipe, seems to fix the issue