### PR TITLE
Update to Rivet4.1.0

### DIFF
--- a/hdf5.sh
+++ b/hdf5.sh
@@ -1,6 +1,6 @@
 package: hdf5
-version: "1.10.9"
-tag: hdf5-1_10_9
+version: "1.14.6"
+tag: hdf5_1.14.6
 source: https://github.com/HDFGroup/hdf5.git
 requires:
   - "GCC-Toolchain:(?!osx)"

--- a/rivet.sh
+++ b/rivet.sh
@@ -1,7 +1,7 @@
 package: Rivet
 version: "%(tag_basename)s"
-tag: "3.1.8-alice1"
-source: https://github.com/alisw/rivet.git
+tag: "rivet-4.1.0"
+source: https://gitlab.com/hepcedar/rivet.git
 requires:
   - HepMC3
   - YODA

--- a/thepeg.sh
+++ b/thepeg.sh
@@ -1,6 +1,6 @@
 package: ThePEG
 version: "%(tag_basename)s"
-tag: "v2.2.2-alice2"
+tag: "v2.3.0-alice1"
 source: https://github.com/alisw/thepeg
 requires:
   - Rivet

--- a/yoda.sh
+++ b/yoda.sh
@@ -1,11 +1,12 @@
 package: YODA
 version: "%(tag_basename)s"
-tag: "yoda-1.9.7"
+tag: "yoda-2.1.0"
 source: https://gitlab.com/hepcedar/yoda.git
 requires:
   - Python
   - Python-modules
   - ROOT
+  - hdf5
 build_requires:
   - "autotools:(slc6|slc7)"
   - HepMC3
@@ -13,115 +14,21 @@ build_requires:
 prepend_path:
   PYTHONPATH: $YODA_ROOT/lib/python/site-packages
 ---
-#!/bin/bash
-#
-# HepMC3 in build-requirements so that same ROOT as used 
-# for HepMC3 is picked up.  This is to avoid 
-# incompatibilities between different ROOT version
-#
-# Test building with 
-#
-#   alienv enter ./module 
-#   export ALIBUILD_ARCH_PREFIX=el7-x86_64/Packages
-#   export WORK_DIR=/cvmfs/alice.cern.ch
-#   . ${PYTHONHOME}/etc/profile.d/init.sh
-#   . ${HEPMC3_ROOT}/etc/profile.d/init.sh
-#   aliBuild build \
-#     --disable Python-modules,boost,defaults-release,CMake,HepMC3,ROOT \
-#     --always-prefer-system \
-#     --debug \
-#     YODA 
-# 
-# Note that the '--disable' option prevents 
-#
-# - aliBuild from trying to build what we already have albeit not under
-#   WORK_DIR/sw
-# - aliBuild from importing depency package settings to be loaded and 
-#   written to 'YODA/version/etc/profile.d/init.sh'
-# - Variables to be set when making the module file
-#
-# I've not figured out a way to not build all dependencies, and there is 
-# a lot, while still loading in the correct settings for build requirements
-# and so on. As far as I can tell, it's not really supported by aliBuild - 
-# surprise!
-# 
+#!/bin/bash -e
 rsync -a --exclude='**/.git' --delete --delete-excluded "$SOURCEDIR"/ ./
 
 [[ -e .missing_timestamps ]] && ./missing-timestamps.sh --apply || autoreconf -ivf
 
-(
-PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
-PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'from sys import version_info as vi; print(f"{vi.major}.{vi.minor}")' )
-if test "x$PYTHON_MODULES_ROOT" = "x" ; then 
-    PMBIN=$(echo "$PATH" | tr ':' '\n' | grep Python-modules | head -n 1)
-    if test x"$PMBIN" != x ; then 
-        CYTHON=$PMBIN/cython
-    else 
-        CYTHON=$(which cython)
-    fi
-else
-    CYTHON=$PYTHON_MODULES_ROOT/bin/cython
-fi
+export PYTHON=$(type -p python3)
 
-CYTHON_PATH="$(dirname -- "$CYTHON")"
-if cython; then
-    echo "Cython succesfully executed" 
-else
-    stat=$?
-    # Check if python executable is linked in cython bin folder 
-    if [ $stat == 127 ]; then
-        echo "python not found by cython, setting up link..."
-        ln -nsf "$PYTHON_EXECUTABLE" "$CYTHON_PATH/python3"
-    else 
-        echo "Issue in cython execution"
-    fi
-fi
-
-case $ARCHITECTURE in
-  osx*)
-      ./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT"
-  ;;
-  *)
-      ./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT" CYTHON="$CYTHON"
-  ;;
-esac
+./configure --disable-silent-rules --enable-root --prefix="$INSTALLROOT"
 make ${JOBS+-j $JOBS}
 make install
-
-pushd "$INSTALLROOT"/lib
-
-[[ -d python${PYTHON_VER} ]] && ln -s python"${PYTHON_VER}" python 
-[[ ! -e python ]] && \
-    echo "YODA env pb: NO PYTHON SYMLINK CREATED for python${PYTHON_VER} in: $(pwd -P)" && \
-    exit 
-
-popd  # get back from INSTALLROOT/lib
-
-case $ARCHITECTURE in
-    osx*)
-        find "$INSTALLROOT"/lib/python/ -name "*.so" -exec install_name_tool -add_rpath "${INSTALLROOT}"/lib {} \;
-        find "$INSTALLROOT"/lib/ -name "*.dylib" -exec install_name_tool -add_rpath "${INSTALLROOT}"/lib {} \;
-    ;;
-esac
-)
-
-PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
-if test "x$PYTHON_VERSION" != "x" && \
-   test "x$PYTHON_REVISION" != "x" ; then 
-    PYTHON_FULL_VERSION=${PYTHON_VERSION}-${PYTHON_REVISION}
-else
-    PYTHON_FULL_VERSION=$( echo "$PYTHON_EXECUTABLE" | sed -e 's|.*/Python/||' -e 's|/bin/.*||') 
-fi
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-
-# alibuild-generate-module --bin --lib > "$MODULEFILE"0
-# cat >> "$MODULEFILE"0 <<EoF
-# prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
-# EoF
 
 cat > "$MODULEFILE" <<EoF
 #%Module1.0


### PR DESCRIPTION
Multiple packages updated:
- Rivet: from 3.1.8 to 4.1.0 pulling source directly from the official repository
- Yoda: cleaned recipe and update to latest 2.1.0 version
- HDF5: update to last available version
- ThePEG: update to latest version + added compatibility to RIVET4, not available by default

More tests are required, especially on the GRID, but locally everything seems to work fine