### PR TITLE
Bump ROOT to v6-32-06-alice8

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-32-06-alice7"
+tag: "v6-32-06-alice8"
 source: https://github.com/alisw/root.git
 requires:
   - arrow


### PR DESCRIPTION
Includes backport of fix for large zip files https://github.com/root-project/root/pull/18958.