### PR TITLE
Revert to CodeChecker V18.1.2

### DIFF
--- a/o2codechecker.sh
+++ b/o2codechecker.sh
@@ -1,6 +1,6 @@
 package: o2codechecker
-version: v18.1.2.1
-tag: v18.1.2.1
+version: v18.1.2
+tag: v18.1.2
 requires:
   - Clang:(?!osx*)
 build_requires:


### PR DESCRIPTION
Picking up clang from our own build apparently silently breaks.