### PR TITLE
Bump to onnxruntime to 1.22.0

### DIFF
--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -1,6 +1,6 @@
 package: ONNXRuntime
 version: "%(tag_basename)s"
-tag: v1.21.0
+tag: v1.22.0
 source: https://github.com/microsoft/onnxruntime
 requires:
   - protobuf


### PR DESCRIPTION

Provides nicer API for amending models on the fly.
We need to mask a few more warnings.
