### PR TITLE
Unpin pip

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -44,8 +44,7 @@ overrides:
   Python-modules-list:
     env:
       PIP_BASE_REQUIREMENTS: |
-        pip == 21.3.1; python_version < '3.12'
-        pip < 26.0; python_version >= '3.12'
+        pip < 26.0
         setuptools == 65.5.1; python_version < '3.12'
         setuptools == 70.0.0; python_version >= '3.12'
         wheel == 0.37.1; python_version < '3.12'

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -2,8 +2,7 @@ package: Python-modules-list
 version: "1.0"
 env:
   PIP_BASE_REQUIREMENTS: |
-    pip == 21.3.1; python_version < '3.12'
-    pip < 26.0; python_version >= '3.12'
+    pip < 26.0
     setuptools == 59.6.0; python_version < '3.12'
     setuptools == 70.0.0; python_version >= '3.12'
     wheel == 0.37.1; python_version < '3.12'


### PR DESCRIPTION
Older versions of pip are currently failing with this error:

```
ImportError: cannot import name 'RequirementInformation' from 'pip._vendor.resolvelib.structs'
```

It seems to be a compatibility issue between pip 25 and older.

As far as I can tell, the pip package was only pinned to follow the
convention set by other packages
