### PR TITLE
Set HDF5_DIR as environment variable during YODA build

### DIFF
--- a/yoda.sh
+++ b/yoda.sh
@@ -13,6 +13,8 @@ build_requires:
   - Python
 prepend_path:
   PYTHONPATH: $YODA_ROOT/lib/python/site-packages
+env:
+  HDF5_DIR: "$HDF5_ROOT"
 ---
 #!/bin/bash -e
 rsync -a --exclude='**/.git' --delete --delete-excluded "$SOURCEDIR"/ ./


### PR DESCRIPTION
h5cc sets the include directory in yoda-config which is used later to set cppflags in Rivet. the dailytag is wrongly taken when building in docker/CI, so the folder must be correctly set at building time. 
Not clear why this was working before. An update somewhere must have had an effect here (no updates since a month on Rivet, hdf5, Yoda and GMP). 