### PR TITLE
xjalienfs :: re-enable tests for slc9_aarch64

### DIFF
--- a/xjalienfs.sh
+++ b/xjalienfs.sh
@@ -90,9 +90,7 @@ if [ -n "$ALIBUILD_XJALIENFS_TESTS" ] &&
      # Tests need a JAliEn token, so skip them if we have none.
      [ -n "$JALIEN_TOKEN_CERT" ] && [ -n "$JALIEN_TOKEN_KEY" ]
 then
-  # temporary measure againt breakage of alienpy tests on Alma9 aarch64 builder environment
-  # the breakage is present only in the special CI environment on that machine
-  [[ "${ARCHITECTURE}" != "slc9_aarch64" ]] && PATH="$INSTALLROOT/bin:$PATH" \
+  PATH="$INSTALLROOT/bin:$PATH" \
   PYTHONPATH="$INSTALLROOT/lib/python/site-packages:$PYTHONPATH" \
   "$SOURCEDIR/tests/run_tests" ci-tests
 fi


### PR DESCRIPTION
This should have been fixed since https://github.com/adriansev/jalien_py/commit/4b05cd35bc00f693d585024e8e076a2dea6f6574

This reverts commit ab6301ad5e84900a39c517f3491adbe831bd5e24.
