### PR TITLE
Fix permissions needed for workflow

### DIFF
--- a/.github/workflows/check_untested_pkgs.yml
+++ b/.github/workflows/check_untested_pkgs.yml
@@ -9,8 +9,6 @@ name: Check untested packages
       - reopened
       - synchronize
 
-permissions: {}
-
 jobs:
   check-untested:
     uses: alisw/ali-bot/.github/workflows/check-untested-packages.yml@master


### PR DESCRIPTION
Should fail the `graphql: Resource not accessible by integration
(addComment)` error
