### PR TITLE
Bump to FairMQ v1.10.0

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: "v1.9.2"
+tag: "v1.10.0"
 source: https://github.com/FairRootGroup/FairMQ
 requires:
   - boost


### PR DESCRIPTION
This version uses std::pmr rather than boost::collections::pmr. Do not include it in FLPSuite tags until you mean to.