### PR TITLE
Lock ROOT and FairMQ versions for online environment (FLP builds)

### DIFF
--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -72,6 +72,10 @@ overrides:
       - libInfoLogger
       - librdkafka   # this one added
       - grpc   # this one added
+  FairMQ:
+    tag: "v1.9.2"
+  ROOT
+    tag: "v6-32-06-alice9"
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/defaults-o2-dataflow.sh
+++ b/defaults-o2-dataflow.sh
@@ -74,7 +74,7 @@ overrides:
       - grpc   # this one added
   FairMQ:
     tag: "v1.9.2"
-  ROOT
+  ROOT:
     tag: "v6-32-06-alice9"
 ---
 # This file is included in any build recipe and it's only used to set


### PR DESCRIPTION
We don't want to change the versions of FairMQ and ROOT in the online environment until the end of the 2025 run. On the other hand, bumps of those packages are needed in other setups (e.g. async). 

This change ensures that when we build the RPMs for the FLPs we keep the current versions.

@davidrohr @ehellbar I assume you want/need to do the same for the EPN RPMs. Feel free to add it to this PR or create a new one.

@ktf could you check if this is the correct syntax ?