### PR TITLE
Arrow: bump to 25.0.0; thrift: bump to 0.22; xsimd: bump to 14.2

### DIFF
--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v23.0.1-alice"
-tag: apache-arrow-23.0.1-alice1
+version: "v24.0.0-alice"
+tag: apache-arrow-24.0.0-alice1
 source: https://github.com/alisw/arrow.git
 requires:
   - boost

--- a/arrow.sh
+++ b/arrow.sh
@@ -10,7 +10,6 @@ requires:
   - utf8proc
   - OpenSSL:(?!osx)
   - xsimd
-  - thrift
 license: Apache-2.0
 build_requires:
   - zlib

--- a/arrow.sh
+++ b/arrow.sh
@@ -10,6 +10,7 @@ requires:
   - utf8proc
   - OpenSSL:(?!osx)
   - xsimd
+  - thrift
 license: Apache-2.0
 build_requires:
   - zlib

--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v20.0.0-alice1"
-tag: apache-arrow-20.0.0-alice1
+version: "v23.0.1-alice"
+tag: apache-arrow-23.0.1-alice1
 source: https://github.com/alisw/arrow.git
 requires:
   - boost

--- a/arrow.sh
+++ b/arrow.sh
@@ -1,6 +1,6 @@
 package: arrow
-version: "v20.0.0-alice1"
-tag: apache-arrow-20.0.0-alice1
+version: "v25.0.0-alice"
+tag: apache-arrow-25.0.0-alice1
 source: https://github.com/alisw/arrow.git
 requires:
   - boost

--- a/thrift.sh
+++ b/thrift.sh
@@ -1,6 +1,6 @@
 package: thrift
 version: "%(tag_basename)s"
-tag: 0.12.0
+tag: 0.22.0
 source: https://github.com/apache/thrift
 requires:
   - boost
@@ -32,6 +32,8 @@ rsync -a --delete --exclude="**/.git" $SOURCEDIR/ ./
             --without-php               \
             --without-php_extension     \
             --without-ruby              \
+            --without-rs                \
+            --without-swift             \
             --without-qt                \
             --enable-libs               \
             --disable-tests             \

--- a/thrift.sh
+++ b/thrift.sh
@@ -4,10 +4,10 @@ tag: v0.22.0
 source: https://github.com/apache/thrift
 requires:
   - boost
-  - ninja
 license: Apache-2.0
 build_requires:
   - "GCC-Toolchain:(?!osx)"
+  - ninja
   - "OpenSSL:(?!osx)"
   - yacc-like
 prefer_system: ".*"

--- a/thrift.sh
+++ b/thrift.sh
@@ -4,6 +4,7 @@ tag: v0.22.0
 source: https://github.com/apache/thrift
 requires:
   - boost
+  - ninja
 license: Apache-2.0
 build_requires:
   - "GCC-Toolchain:(?!osx)"

--- a/thrift.sh
+++ b/thrift.sh
@@ -47,7 +47,3 @@ MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p etc/modulefiles
 alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
-cat >> etc/modulefiles/$PKGNAME <<EoF
-prepend-path PATH \$BASEDIR/$PKGNAME/\$version/bin
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-EoF

--- a/thrift.sh
+++ b/thrift.sh
@@ -1,6 +1,6 @@
 package: thrift
 version: "%(tag_basename)s"
-tag: 0.22.0
+tag: v0.22.0
 source: https://github.com/apache/thrift
 requires:
   - boost
@@ -20,45 +20,34 @@ case $ARCHITECTURE in
     OPENSSL_ROOT=$(brew --prefix openssl@3)
   ;;
 esac
-rsync -a --delete --exclude="**/.git" $SOURCEDIR/ ./
-./bootstrap.sh
-./configure --prefix ${INSTALLROOT}     \
-            --with-boost=${BOOST_ROOT}  \
-            --without-erlang            \
-            --without-haskell           \
-            --without-perl              \
-            --without-python            \
-            --without-java              \
-            --without-php               \
-            --without-php_extension     \
-            --without-ruby              \
-            --without-rs                \
-            --without-swift             \
-            --without-qt                \
-            --enable-libs               \
-            --disable-tests             \
-            --disable-plugin            \
-            --disable-tutorial          \
-            ${OPENSSL_ROOT:+--with-openssl=${OPENSSL_ROOT}}
-make CPPFLAGS="-I${BOOST_ROOT}/include ${CPPFLAGS}" CXXFLAGS="-Wno-error -fPIC -O2" ${JOBS:+-j $JOBS}
-make install
+
+cmake $SOURCEDIR -GNinja                                    \
+        -DBoost_DIR="${BOOST_ROOT}"                         \
+        -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"               \
+        -DBUILD_TESTING=OFF                                 \
+        -DBUILD_TUTORIALS=OFF                               \
+        -DBUILD_COMPILER=ON                                 \
+        -DBUILD_CPP=ON                                      \
+        -DBUILD_C_GLIB=OFF                                  \
+        -DBUILD_JAVA=OFF                                    \
+        -DBUILD_JAVASCRIPT=OFF                              \
+        -DBUILD_KOTLIN=OFF                                  \
+        -DBUILD_NODEJS=OFF                                  \
+        -DBUILD_PYTHON=OFF                                  \
+        -DWITH_LIBEVENT=OFF                                 \
+        -DWITH_ZLIB=ON                                      \
+        -DWITH_OPENSSL=ON
+cmake --build . -- ${JOBS+-j $JOBS} install
+
+# install the compilation database so that we can post-check the code
+cp compile_commands.json ${INSTALLROOT}
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set BASEDIR \$::env(BASEDIR)
+mkdir -p etc/modulefiles
+alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
+cat >> etc/modulefiles/$PKGNAME <<EoF
 prepend-path PATH \$BASEDIR/$PKGNAME/\$version/bin
 prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
 EoF

--- a/xsimd.sh
+++ b/xsimd.sh
@@ -1,6 +1,6 @@
 package: xsimd
-version: "14.0.0"
-tag: 14.0.0
+version: "14.2.0"
+tag: 14.2.0
 source: https://github.com/xtensor-stack/xsimd
 requires:
   - Clang:(?!.*osx)


### PR DESCRIPTION
* Bump version of thrift to current (0.22)
* Move thrift building to cmake instead of configure
* Add thrift as a dependency to Arrow, so that Parquet is enabled 
* Bump arrow version to current (24.0.0)