### PR TITLE
Fix GDML installation for Geant4 compilation

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -48,6 +48,7 @@ cmake $SOURCEDIR                                                \
   ${XERCESC_ROOT:+-DXERCESC_ROOT_DIR=$XERCESC_ROOT}             \
   ${CXXSTD:+-DGEANT4_BUILD_CXXSTD=$CXXSTD}                      \
   -DG4_USE_GDML=ON                                              \
+  -DGEANT4_USE_GDML=ON                                          \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                            \
   -DGEANT4_USE_SYSTEM_ZLIB=ON
 


### PR DESCRIPTION
For some reason the G4_USE_GDML flag doesn't work for me. We checked the CMake file of geant and the flag seems to be called GEANT4_USE_GDML, so we added it to the recipe. It seems to be working fine now to compile and install with GDML support. 

@njacazio 