### PR TITLE
Fix pkg-config finding the wrong CURL

### DIFF
--- a/curl.sh
+++ b/curl.sh
@@ -3,6 +3,8 @@ version: "7.70.0"
 tag: curl-7_70_0
 license: curl
 source: https://github.com/curl/curl.git
+prepend_path:
+  PKG_CONFIG_PATH: "$CURL_ROOT/lib/pkgconfig"
 build_requires:
   - "OpenSSL:(?!osx)"
   - alibuild-recipe-tools


### PR DESCRIPTION
Fixes the following issue in some environments:

```
/sw/slc8_x86-64/GCC-Toolchain/v14.2.0-alice2-1/bin/../lib/gcc/x86_64-unknown-linux-gnu/14.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /lib64/libssh.so.4: undefined reference to `EVP_KDF_CTX_new_id@OPENSSL_1_1_1b'
```

Seeing as we have the same solution in e.g. openssl, this looks like the correct fix