### PR TITLE
Fix and update MadGraph

### DIFF
--- a/hepmc.sh
+++ b/hepmc.sh
@@ -13,6 +13,7 @@ cmake  $SOURCEDIR                           \
        -DCMAKE_POLICY_VERSION_MINIMUM=3.5   \
        -Dmomentum=GEV                       \
        -Dlength=MM                          \
+       -DBUILD_STATIC_LIBS=ON               \
        -Dbuild_docs:BOOL=OFF                \
        -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -28,19 +28,12 @@ rsync -a --chmod=ug=rwX --exclude '**/.git' $SOURCEDIR/ ./
 
 export LIBRARY_PATH="$LD_LIBRARY_PATH"
 
-if type "python" &>/dev/null; then
-  # Python2 or Python3 point to "python"
-  if python -c 'import sys; exit(0 if sys.version_info.major >=3 else 1)'; then
-    # LHAPDF not yet ready for Python3
-    DISABLE_PYTHON=1
-  fi
-else
-  # Python2 not installed and Python3 points to "python3"
-  DISABLE_PYTHON=1
-fi
-
 autoreconf -ivf
-./configure --prefix=$INSTALLROOT ${DISABLE_PYTHON:+--disable-python}
+if [[ -n $DISABLE_PYTHON ]]; then
+  ./configure --prefix=$INSTALLROOT --disable-python
+else
+  ./configure --prefix=$INSTALLROOT --enable-python PYTHON=$(which python3)
+fi
 
 make ${JOBS+-j $JOBS} all
 make install

--- a/madgraph.sh
+++ b/madgraph.sh
@@ -1,11 +1,15 @@
 package: madgraph
 version: "%(tag_basename)s"
-tag: "v3.5.2"
-source: https://github.com/alisw/MadGraph
+tag: "v3.5.13"
+source: https://github.com/mg5amcnlo/mg5amcnlo
 requires:
   - Python-modules
   - curl
   - zlib
+  - fastjet
+  - lhapdf
+  - pythia
+  - ninja
 license: GPL-3.0
 build_requires:
   - alibuild-recipe-tools
@@ -17,12 +21,15 @@ rsync -a --no-specials --no-devices  --chmod=ug=rwX --exclude '**/.git' --delete
 # install internal packages 
 cd "$BUILDDIR"
 cat << EOF >> install.dat
+set lhapdf $LHAPDF_ROOT/bin/lhapdf-config
+set fastjet $FASTJET_ROOT/bin/fastjet-config
+set pythia8_path $PYTHIA_ROOT
 install oneloop
-install ninja
 install collier
 install RunningCoupling
 install QCDLoop
-install MadAnalysis5 --with_zlib=$ZLIB_ROOT
+install MadAnalysis5 --with_zlib=$ZLIB_ROOT --with_fastjet=$FASTJET/lib
+install mg5amc_py8_interface
 EOF
 
 # MadGraph uses wget for non macOSx systems, but this might not be available.
@@ -56,15 +63,15 @@ EOF
     export PATH="$PWD/tmpwget:$PATH"
 fi
 
+# FastJet was built with CGAL support; MA5 links against -lCGAL and -lgmp but
+# only passes -L$FASTJET/lib. This ensures the linker can find CGAL and GMP.
+export LIBRARY_PATH="${CGAL_ROOT:+$CGAL_ROOT/lib:}${GMP_ROOT:+$GMP_ROOT/lib:}${LIBRARY_PATH:-}"
+
 ./bin/mg5_aMC install.dat
 
 # cleanup after build
 rm install.dat
-rm HEPTools/ninja/ninja_install.log 
-rm HEPTools/oneloop/oneloop_install.log
-rm HEPTools/collier/collier_install.log
-rm HEPTools/madanalysis5/madanalysis5_install.log
-rm -rf HEPTools/ninja/Ninja 
+find HEPTools -name "*.log" -delete
 rm -rf HEPTools/oneloop/OneLOop*
 rm -rf HEPTools/collier/COLLIER*
 find QCDLoop -mindepth 1 -maxdepth 1 -not -name include -not -name lib -not -name share -exec rm -rf {} \;


### PR DESCRIPTION
Multiple things achieved by this PR:
- Enabled static HepMC2 libraries &rarr; Pythia8 can't be linked to MadGraph otherwise
- Enable LHAPDF6 Python3 module &rarr; it was disabled 6 years ago and it is needed by MadGraph
- Update to the latest MadGraph LTS 3.5.X version found on Launchpad (3.5.14 was released, but not LTS, as well as all the 3.6.X and 3.7.0 versions)
- MadGraph is now pulled directly from the official repository
- Disable ninja install via HepTools &rarr; fetched automatically from the system
- Install of Pythia8 MadGraph interface 
- Correct setting of Fastjet, Pythia8 and LHAPDF &rarr; silent crashes otherwise during runs

I tested everything using an example madgraph card I have, but deeper tests will most likely be required