### PR TITLE
Add O2Physics-code-check

### DIFF
--- a/o2physics-code-check.sh
+++ b/o2physics-code-check.sh
@@ -1,0 +1,74 @@
+package: O2Physics-code-check
+version: "1.0"
+requires:
+  - O2Physics
+  - Clang:(?!osx*)
+license: GPL-3.0
+force_rebuild: true
+---
+#!/bin/bash -e
+
+# Runs checks on the O2Physics codebase.
+
+set -euo pipefail
+
+# Verify Clang.
+[[ -d "$CLANG_ROOT" ]]
+
+# Get the compilation database from the O2Physics build dir.
+O2PHYSICS_BUILDDIR="$(realpath ${BUILDDIR}/../../O2Physics-latest/O2Physics)"
+cp "${O2PHYSICS_BUILDDIR}/compile_commands.json" .
+
+# Guess the source directory as the common path of .cxx files in the compilation database.
+O2PHYSICS_SRC=$(python3 -c 'import json, os; print(os.path.commonpath([x["file"] for x in json.loads(open("compile_commands.json").read()) if "sw/BUILD" not in x["file"] and "G__" not in x["file"] and x["file"].endswith(".cxx")]))')
+pushd "$O2PHYSICS_SRC"
+[[ -e "CMakeLists.txt" ]]
+[[ -d ".git" ]]
+
+# If a base Git commit is provided, get a list of existing C++ files changed since.
+# If base Git commit is not provided, get all tracked C++ files.
+if [[ -n "${ALIBUILD_BASE_HASH:-}" ]]; then
+  FILES=$(git diff --diff-filter=d --name-only "$ALIBUILD_BASE_HASH${ALIBUILD_HEAD_HASH:+...$ALIBUILD_HEAD_HASH}")
+else
+  FILES=$(git ls-files)
+fi
+# Keep only existing C++ files.
+FILES_TO_CHECK=()
+while IFS= read -r FILE; do
+  case "$FILE" in
+    *.cxx|*.h|*.C)
+      [[ -e "$FILE" ]] && FILES_TO_CHECK+=("$FILE")
+      ;;
+  esac
+done <<< "$FILES"
+# Abort if no files to check.
+if [[ ${#FILES_TO_CHECK[@]} -eq 0 ]]; then
+  echo "Nothing to check."
+  exit 0
+fi
+
+# Run checks on selected files.
+# Run clang-tidy and parallelise with xargs.
+# We cannot use run-clang-tidy, because it ignores anything missing in the compilation database (headers, macros).
+LOGFILE="${BUILDDIR}/error-log.txt"
+CLANG_TIDY="${CLANG_ROOT}/bin-safe/clang-tidy"
+[[ -e .clang-tidy ]] && echo "Found configuration file: $O2PHYSICS_SRC/.clang-tidy"
+echo "Additional checks on command line: \"${O2PHYSICS_CHECKER_CHECKS=""}\""
+"$CLANG_TIDY" --list-checks --checks="$O2PHYSICS_CHECKER_CHECKS"
+printf "%s\n" "${FILES_TO_CHECK[@]}" | xargs -r ${JOBS+-P $JOBS} -I{} \
+  "$CLANG_TIDY" --checks="$O2PHYSICS_CHECKER_CHECKS" ${O2PHYSICS_CHECKER_FIX:+-fix} "{}" 2>&1 | tee "$LOGFILE" || true
+[[ -f "$LOGFILE" ]]
+
+# If issues were found, report them and abort.
+# Consider only issues in the O2Physics files.
+echo -e "\n\n========== List of errors found =========="
+if grep -qE "^${O2PHYSICS_SRC}/.+: (warning|error): " "$LOGFILE"; then
+  grep -E "^${O2PHYSICS_SRC}/.+: (warning|error): " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq
+  exit 1
+fi
+
+popd
+
+# Dummy modulefile
+mkdir -p $INSTALLROOT/etc/modulefiles
+alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME

--- a/o2physics-code-check.sh
+++ b/o2physics-code-check.sh
@@ -63,10 +63,10 @@ printf "%s\n" "${FILES_TO_CHECK[@]}" | xargs -r ${JOBS+-P $JOBS} -I{} \
 # If errors were found, abort.
 # Consider only issues in the O2Physics files.
 echo -e "\n\n========== List of issues found =========="
-grep -E "^${O2PHYSICS_SRC}/.+: warning: " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq > "${BUILDDIR}/warnings.txt" || true
 grep -E "^${O2PHYSICS_SRC}/.+: error: " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq > "${BUILDDIR}/errors.txt" || true
-N_WARNING=$(wc -l < "${BUILDDIR}/warnings.txt")
+grep -E "^${O2PHYSICS_SRC}/.+: warning: " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq > "${BUILDDIR}/warnings.txt" || true
 N_ERROR=$(wc -l < "${BUILDDIR}/errors.txt")
+N_WARNING=$(wc -l < "${BUILDDIR}/warnings.txt")
 echo "Found $N_ERROR errors and $N_WARNING warnings."
 [[ $N_ERROR -gt 0 ]] && cat "${BUILDDIR}/errors.txt"
 [[ $N_WARNING -gt 0 ]] && cat "${BUILDDIR}/warnings.txt"

--- a/o2physics-code-check.sh
+++ b/o2physics-code-check.sh
@@ -59,12 +59,15 @@ printf "%s\n" "${FILES_TO_CHECK[@]}" | xargs -r ${JOBS+-P $JOBS} -I{} \
   "$CLANG_TIDY" --checks="$O2PHYSICS_CHECKER_CHECKS" ${O2PHYSICS_CHECKER_FIX:+-fix} "{}" 2>&1 | tee "$LOGFILE" || true
 [[ -f "$LOGFILE" ]]
 
-# If issues were found, report them and abort.
+# If issues were found, report them.
+# If errors were found, abort.
 # Consider only issues in the O2Physics files.
-echo -e "\n\n========== List of errors found =========="
+echo -e "\n\n========== List of issues found =========="
 if grep -qE "^${O2PHYSICS_SRC}/.+: (warning|error): " "$LOGFILE"; then
   grep -E "^${O2PHYSICS_SRC}/.+: (warning|error): " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq
-  exit 1
+  if grep -qE "^${O2PHYSICS_SRC}/.+: error: " "$LOGFILE"; then
+    exit 1
+  fi
 fi
 
 popd

--- a/o2physics-code-check.sh
+++ b/o2physics-code-check.sh
@@ -63,12 +63,14 @@ printf "%s\n" "${FILES_TO_CHECK[@]}" | xargs -r ${JOBS+-P $JOBS} -I{} \
 # If errors were found, abort.
 # Consider only issues in the O2Physics files.
 echo -e "\n\n========== List of issues found =========="
-if grep -qE "^${O2PHYSICS_SRC}/.+: (warning|error): " "$LOGFILE"; then
-  grep -E "^${O2PHYSICS_SRC}/.+: (warning|error): " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq
-  if grep -qE "^${O2PHYSICS_SRC}/.+: error: " "$LOGFILE"; then
-    exit 1
-  fi
-fi
+grep -E "^${O2PHYSICS_SRC}/.+: warning: " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq > "${BUILDDIR}/warnings.txt" || true
+grep -E "^${O2PHYSICS_SRC}/.+: error: " "$LOGFILE" | sed -e "s,${O2PHYSICS_SRC}/,,g" | sort -V | uniq > "${BUILDDIR}/errors.txt" || true
+N_WARNING=$(wc -l < "${BUILDDIR}/warnings.txt")
+N_ERROR=$(wc -l < "${BUILDDIR}/errors.txt")
+echo "Found $N_ERROR errors and $N_WARNING warnings."
+[[ $N_ERROR -gt 0 ]] && cat "${BUILDDIR}/errors.txt"
+[[ $N_WARNING -gt 0 ]] && cat "${BUILDDIR}/warnings.txt"
+[[ $N_ERROR -gt 0 ]] && exit 1
 
 popd
 


### PR DESCRIPTION
Runs Clang-Tidy on the O2Physics codebase.

- Uses Clang installed by aliBuild.
- If a base Git commit is provided, analyses C++ files changed since.
- If base Git commit is not provided, analyses all tracked C++ files.
- Analyses `.cxx`, `.h`, `.C` files.
- Auto-detects configuration in `.clang-tidy`.
- Additional checks can be appended with `O2PHYSICS_CHECKER_CHECKS`.
- Fixes can be enabled with `O2PHYSICS_CHECKER_FIX`.
- Only issues in the O2Physics files are reported.
- Found issues are sorted and deduplicated.
- Errors and warnings are counted and reported separately.
- Errors are reported before warnings.
- If errors were found, aborts and exits with 1.