### PR TITLE
move to geant4_vmc v6-6-update2-p3 and vmc v2-2

### DIFF
--- a/geant4.sh
+++ b/geant4.sh
@@ -1,6 +1,6 @@
 package: GEANT4
 version: "%(tag_basename)s"
-tag: "v11.2.0-alice1"
+tag: "v11.2.0-alice2"
 source: https://github.com/alisw/geant4.git
 # source: https://gitlab.cern.ch/geant4/geant4.git
 requires:

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -1,6 +1,6 @@
 package: GEANT4_VMC
 version: "%(tag_basename)s"
-tag: "v6-6-update1-p3"
+tag: "v6-6-update2-p3"
 source: https://github.com/vmc-project/geant4_vmc
 requires:
   - ROOT

--- a/vmc.sh
+++ b/vmc.sh
@@ -1,6 +1,6 @@
 package: VMC
 version: "%(tag_basename)s"
-tag: "v2-1"
+tag: "v2-2"
 source: https://github.com/vmc-project/vmc
 requires:
   - ROOT


### PR DESCRIPTION
Moving to these tags will allow to 
- use the geant4 user scoring weight interface
- separate between particle decays and radioactive decays