### PR TITLE
Fix CMAKE_IGNORE_PATH for Intel macs

### DIFF
--- a/abseil.sh
+++ b/abseil.sh
@@ -33,13 +33,19 @@ prepend_path:
 ---
 #!/bin/bash -e
 
+case $ARCHITECTURE in
+  osx*)
+    CMAKE_IGNORE_PATH="$(brew --prefix)/include"
+  ;;
+esac
+
 mkdir -p $INSTALLROOT
 cmake $SOURCEDIR                              \
   -G Ninja                                    \
   ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}     \
   -DCMAKE_INSTALL_LIBDIR=lib                  \
   -DBUILD_TESTING=OFF                         \
-  -DCMAKE_IGNORE_PATH="/opt/homebrew/include" \
+  ${CMAKE_IGNORE_PATH:+-DCMAKE_IGNORE_PATH="$CMAKE_IGNORE_PATH"} \
   -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 cmake --build . -- ${JOBS:+-j$JOBS} install

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -22,6 +22,12 @@ else
   ALIBUILD_CMAKE_SOURCE_DIR=$SOURCEDIR
 fi
 
+case $ARCHITECTURE in
+  osx*)
+    CMAKE_IGNORE_PATH="$(brew --prefix)/include"
+  ;;
+esac
+
 cmake -S "$ALIBUILD_CMAKE_SOURCE_DIR"                  \
     -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
     -Dprotobuf_BUILD_TESTS=NO             \
@@ -29,6 +35,7 @@ cmake -S "$ALIBUILD_CMAKE_SOURCE_DIR"                  \
     -Dprotobuf_BUILD_SHARED_LIBS=OFF      \
     -Dprotobuf_ABSL_PROVIDER=package      \
     ${ABSEIL_ROOT:+-Dabsl_DIR=$ABSEIL_ROOT} \
+    ${CMAKE_IGNORE_PATH:+-DCMAKE_IGNORE_PATH="$CMAKE_IGNORE_PATH"} \
     -DCMAKE_INSTALL_LIBDIR=lib
 
 cmake --build . -- ${JOBS:+-j$JOBS} install


### PR DESCRIPTION
The homebrew directory isn't always /opt/homebrew
