### PR TITLE
Bump FairMQ: new shmem feature

### DIFF
--- a/fairmq.sh
+++ b/fairmq.sh
@@ -1,6 +1,6 @@
 package: FairMQ
 version: "%(tag_basename)s"
-tag: "v1.10.1"
+tag: "v1.11.0"
 license: LGPLv3
 source: https://github.com/FairRootGroup/FairMQ
 requires:


### PR DESCRIPTION
Bump to new FairMQ tag, containing exposed shmem API to be used for CCDB tables.