### PR TITLE
Create default dummy conf file

### DIFF
--- a/madgraph.sh
+++ b/madgraph.sh
@@ -88,6 +88,7 @@ rm vendor/*tar.gz
 sed -i.deleteme -e "s|$BUILDDIR|/TEMP_PATH/|" input/mg5_configuration.txt
 rm -f input/mg5_configuration.deleteme
 mv input/mg5_configuration.txt input/mg5_configuration.txt.buildtime
+echo "# Dummy configuration file" > input/mg5_configuration.txt
 rsync -a "$BUILDDIR/" "$INSTALLROOT/"
 
 #ModuleFile


### PR DESCRIPTION
madgraph/__init__.py checks for the existence of the mg5_configuration.txt file in the MADGRAPH_ROOT folder when the executable is launched. If this is not found it creates a default one, however CVMFS is a read-only file system, so mg5_aMC was crashing. This PR creates the dummy file at build time bypassing the problem.  