### PR TITLE
ROOT: bump to 6-36-10-alice2

### DIFF
--- a/jalien-root.sh
+++ b/jalien-root.sh
@@ -36,7 +36,7 @@ ALIBUILD_CMAKE_BUILD_DIR=$SOURCEDIR
 if [ ! -f "$JALIEN_ROOT_ROOT/cmake/modules/FindAliceGridUtils.cmake" ]; then
   ALIBUILD_CMAKE_BUILD_DIR="$BUILDDIR"
   rsync -a --exclude .git --delete --delete-excluded "$SOURCEDIR/" "$BUILDDIR"
-  rsync -a "$ALICE_GRID_UTILS_ROOT/include/" "$BUILDDIR/inc"
+  rsync -a --exclude "module.modulemap" "$ALICE_GRID_UTILS_ROOT/include/" "$BUILDDIR/inc"
 fi
 
 cmake "$ALIBUILD_CMAKE_BUILD_DIR"                        \

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s"
-tag: "v6-36-10-alice1"
+tag: "v6-36-10-alice2"
 source: https://github.com/alisw/root.git
 license: LGPLv2.1
 requires:


### PR DESCRIPTION

Drops spurious messages about missing PCM.

Needed to avoid confusion once we move JAliEn to be a proper .pcm
