### PR TITLE
Bump Fluka to 4-5.1-vmc1

### DIFF
--- a/fluka.sh
+++ b/fluka.sh
@@ -1,10 +1,9 @@
 package: FLUKA
 version: "%(tag_basename)s"
-tag: "4-1.1-vmc5"
+tag: "4-5.1-vmc1"
 source: https://gitlab.cern.ch/ALICEDevOps/FLUKA.git
 requires:
   - "GCC-Toolchain:(?!osx)"
-license: Proprietary
 build_requires:
   - alibuild-recipe-tools
 env:
@@ -15,6 +14,8 @@ prepend_path:
 ---
 export FLUPRO=$PWD
 export FC=gfortran
+export CC=gcc
+export CXX=g++
 
 rsync -a --exclude='**/.git' --delete --delete-excluded $SOURCEDIR/ "$BUILDDIR"
 
@@ -24,10 +25,10 @@ if [ $FVERSION -ge 10 ]; then
     # Redefine FC to contain the compiler, -fallow-argument-mismatch and the additional FFLAGS from FLUKA/src/config.mk
     case $ARCHITECTURE in
 	osx_arm64)
-	    make FC="gfortran -fallow-argument-mismatch -Wall -Waggregate-return -Wcast-align -Wline-truncation -Wno-conversion -Wno-integer-division -Wno-tabs -Wno-unused-dummy-argument -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable -Wsystem-headers -Wuninitialized -Wunused-label -mtune=generic -fPIC -fexpensive-optimizations -funroll-loops -fstrength-reduce -fno-automatic -finit-local-zero -ffixed-form -fbackslash -funderscoring -fd-lines-as-code -frecord-marker=4 -fbacktrace -frange-check -fbounds-check -fdump-core -ftrapping-math -ffpe-trap=invalid,zero,overflow" ${JOBS:+-j$JOBS}
+	    make FC="gfortran -DFLUKALICE -fallow-argument-mismatch -Wall -Waggregate-return -Wcast-align -Wline-truncation -Wno-conversion -Wno-integer-division -Wno-tabs -Wno-unused-dummy-argument -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable -Wsystem-headers -Wuninitialized -Wunused-label -mtune=generic -fPIC -fexpensive-optimizations -funroll-loops -fstrength-reduce -fno-automatic -finit-local-zero -ffixed-line-length-132 -fbackslash -funderscoring -fd-lines-as-code -frecord-marker=4 -fbacktrace -frange-check -fbounds-check -fdump-core -ftrapping-math -ffpe-trap=invalid,zero,overflow" ${JOBS:+-j$JOBS}
 	    ;;
 	*)
-	    make FC="gfortran -fallow-argument-mismatch -Wall -Waggregate-return -Wcast-align -Wline-truncation -Wno-conversion -Wno-integer-division -Wno-tabs -Wno-unused-dummy-argument -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable -Wsystem-headers -Wuninitialized -Wunused-label -mtune=generic -msse2 -mfpmath=sse -fPIC -fexpensive-optimizations -funroll-loops -fstrength-reduce -fno-automatic -finit-local-zero -ffixed-form -fbackslash -funderscoring -fd-lines-as-code -frecord-marker=4 -fbacktrace -frange-check -fbounds-check -fdump-core -ftrapping-math -ffpe-trap=invalid,zero,overflow" ${JOBS:+-j$JOBS}
+	    make FC="gfortran -DFLUKALICE -g -fallow-argument-mismatch -Wall -Waggregate-return -Wcast-align -Wline-truncation -Wno-conversion -Wno-integer-division -Wno-tabs -Wno-unused-dummy-argument -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable -Wsystem-headers -Wuninitialized -Wunused-label -mtune=generic -msse2 -mfpmath=sse -fPIC -O0 -fno-expensive-optimizations -funroll-loops -fstrength-reduce -fno-automatic -finit-local-zero -ffixed-form -ffixed-line-length-132 -fbackslash -funderscoring -fd-lines-as-code -frecord-marker=4 -fbacktrace -frange-check -fbounds-check -fdump-core -ftrapping-math -ffpe-trap=invalid,zero,overflow" ${JOBS:+-j$JOBS}
 	    ;;
     esac
 else

--- a/fluka_vmc.sh
+++ b/fluka_vmc.sh
@@ -1,6 +1,6 @@
 package: FLUKA_VMC
 version: "%(tag_basename)s"
-tag: "4-1.1-vmc5"
+tag: "4-5.1-vmc1"
 source: https://gitlab.cern.ch/ALICEPrivateExternals/FLUKA_VMC.git
 requires:
   - "GCC-Toolchain:(?!osx)"
@@ -23,7 +23,8 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT      \
                  ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}  \
                  -DCMAKE_SKIP_RPATH=TRUE                  \
                  -DFLUKA_ROOT=$FLUKA_ROOT                 \
-                 -DFLUKAWITHDPMJET=TRUE
+                 -DFLUKAWITHDPMJET=TRUE                   \
+                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 make ${JOBS:+-j $JOBS} install
 
 [[ ! -d $INSTALLROOT/lib64 ]] && ln -sf lib $INSTALLROOT/lib64


### PR DESCRIPTION
Both FLUKA and FLUKA_VMC are updated to the most recent tag 4-5.1-vmc1.