### PR TITLE
Add recipe for O2 GPU CI tests

### DIFF
--- a/o2-gpu-deterministic-test.sh
+++ b/o2-gpu-deterministic-test.sh
@@ -70,30 +70,7 @@ cmake -DCMAKE_INSTALL_PREFIX=../install "$O2_SOURCEDIR/GPU/GPUTracking/Standalon
 cmake --build . --target install -- ${JOBS:+-j $JOBS}
 
 for BACKEND in "${GPU_BACKENDS[@]}"; do
-  case ${BACKEND^^} in
-    CUDA)
-      LIB=../install/libGPUTrackingCUDA.so
-      GPU_TYPE=CUDA
-      ;;
-    HIP|ROCM)
-      LIB=../install/libGPUTrackingHIP.so
-      GPU_TYPE=HIP
-      ;;
-    OCL|OPENCL)
-      LIB=../install/libGPUTrackingOCL.so
-      GPU_TYPE=OCL
-      ;;
-    *)
-      echo "O2-GPU-deterministic-test: unsupported backend '$BACKEND'. Use CUDA, HIP, or OCL." >&2
-      exit 1
-      ;;
-  esac
-
-  if [[ ! -e $LIB ]]; then
-    echo "O2-GPU-deterministic-test: missing $LIB" >&2
-    exit 1
-  fi
-  ../install/ca --noEvents -g --gpuType "$GPU_TYPE"
+  ../install/ca --noEvents -g --gpuType "${BACKEND^^}"
 done
 
 popd

--- a/o2-gpu-deterministic-test.sh
+++ b/o2-gpu-deterministic-test.sh
@@ -1,0 +1,120 @@
+package: O2-GPU-deterministic-test
+version: "1.0"
+requires:
+  - Vc
+  - boost
+  - fmt
+  - ms_gsl
+  - TBB
+  - ROOT
+  - ONNXRuntime
+  - GLFW
+  - gpu-system
+build_requires:
+  - CMake
+  - Clang
+  - ninja
+license: GPL-3.0
+force_rebuild: true
+---
+#!/bin/bash -e
+
+if [[ -n ${GPU_SYSTEM_ROOT:-} && -f $GPU_SYSTEM_ROOT/etc/gpu-features-available.sh ]]; then
+  source $GPU_SYSTEM_ROOT/etc/gpu-features-available.sh
+fi
+
+if [[ -n ${O2GPUCI_BACKENDS:-} ]]; then
+  read -r -a GPU_BACKENDS <<< "${O2GPUCI_BACKENDS//,/ }"
+else
+  GPU_BACKENDS=()
+  [[ ${O2_GPU_CUDA_AVAILABLE:-0} == 1 ]] && GPU_BACKENDS+=(CUDA)
+  [[ ${O2_GPU_ROCM_AVAILABLE:-0} == 1 ]] && GPU_BACKENDS+=(HIP)
+fi
+
+if [[ ${#GPU_BACKENDS[@]} == 0 ]]; then
+  echo "O2-GPU-deterministic-test: no GPU backend selected or detected." >&2
+  echo "Set O2GPUCI_BACKENDS='CUDA,HIP' in CI to require both production GPU backends." >&2
+  exit 1
+fi
+
+# HACK to find O2 sources without depending on O2 as a dependency (and potentially building all of it as a consequence)
+O2_SOURCEDIR=${O2GPUCI_O2_SOURCEDIR:-}
+for SOURCE_CANDIDATE in "$WORK_DIR/../O2" "$ALIBUILD_CONFIG_DIR/../AliceO2"; do
+  if [[ -z $O2_SOURCEDIR && -f $SOURCE_CANDIDATE/GPU/GPUTracking/Standalone/CMakeLists.txt ]]; then
+    O2_SOURCEDIR=$SOURCE_CANDIDATE
+  fi
+done
+if [[ -z $O2_SOURCEDIR && -d $WORK_DIR/SOURCES/O2 ]]; then
+  O2_SOURCEDIR=$(find "$WORK_DIR/SOURCES/O2" -mindepth 2 -maxdepth 2 -type d \
+    -exec test -f '{}/GPU/GPUTracking/Standalone/CMakeLists.txt' \; -print -quit 2>/dev/null || true)
+fi
+if [[ ! -f $O2_SOURCEDIR/GPU/GPUTracking/Standalone/CMakeLists.txt ]]; then
+  echo "O2-GPU-deterministic-test: could not find the O2 source tree." >&2
+  echo "Set O2GPUCI_O2_SOURCEDIR to the AliceO2 checkout used for this build." >&2
+  exit 1
+fi
+
+rm -Rf "$BUILDDIR/gpu-standalone-test"
+mkdir -p "$BUILDDIR/gpu-standalone-test/build" "$BUILDDIR/gpu-standalone-test/install"
+pushd "$BUILDDIR/gpu-standalone-test/build"
+
+cp "$O2_SOURCEDIR/GPU/GPUTracking/Standalone/cmake/config.cmake" .
+cat >> config.cmake <<'EoF'
+set(GPUCA_DETERMINISTIC_MODE GPU)
+set(GPUCA_BUILD_EVENT_DISPLAY 0)
+EoF
+
+cmake -DCMAKE_INSTALL_PREFIX=../install "$O2_SOURCEDIR/GPU/GPUTracking/Standalone"
+cmake --build . --target install -- ${JOBS:+-j $JOBS}
+
+for BACKEND in "${GPU_BACKENDS[@]}"; do
+  case ${BACKEND^^} in
+    CUDA)
+      LIB=../install/libGPUTrackingCUDA.so
+      GPU_TYPE=CUDA
+      ;;
+    HIP|ROCM)
+      LIB=../install/libGPUTrackingHIP.so
+      GPU_TYPE=HIP
+      ;;
+    OCL|OPENCL)
+      LIB=../install/libGPUTrackingOCL.so
+      GPU_TYPE=OCL
+      ;;
+    *)
+      echo "O2-GPU-deterministic-test: unsupported backend '$BACKEND'. Use CUDA, HIP, or OCL." >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ ! -e $LIB ]]; then
+    echo "O2-GPU-deterministic-test: missing $LIB" >&2
+    exit 1
+  fi
+  ../install/ca --noEvents -g --gpuType "$GPU_TYPE"
+done
+
+popd
+rm -Rf "$BUILDDIR/gpu-standalone-test"
+
+# Dummy modulefile
+MODULEFILE_DEPS=
+for RPKG in $REQUIRES; do
+  RPKG_UP=$(echo "$RPKG" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
+  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
+  MODULEFILE_DEPS+=" $RPKG/$RPKG_VERSION-$RPKG_REVISION"
+done
+
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+cat > "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0$MODULEFILE_DEPS
+EoF

--- a/o2-gpu-deterministic-test.sh
+++ b/o2-gpu-deterministic-test.sh
@@ -14,6 +14,7 @@ build_requires:
   - CMake
   - Clang
   - ninja
+  - alibuild-recipe-tools
 license: GPL-3.0
 force_rebuild: true
 ---
@@ -98,23 +99,5 @@ popd
 rm -Rf "$BUILDDIR/gpu-standalone-test"
 
 # Dummy modulefile
-MODULEFILE_DEPS=
-for RPKG in $REQUIRES; do
-  RPKG_UP=$(echo "$RPKG" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
-  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
-  MODULEFILE_DEPS+=" $RPKG/$RPKG_VERSION-$RPKG_REVISION"
-done
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
-cat > "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0$MODULEFILE_DEPS
-EoF
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/o2-gpu-deterministic-test.sh
+++ b/o2-gpu-deterministic-test.sh
@@ -61,8 +61,9 @@ pushd "$BUILDDIR/gpu-standalone-test/build"
 
 cp "$O2_SOURCEDIR/GPU/GPUTracking/Standalone/cmake/config.cmake" .
 cat >> config.cmake <<'EoF'
-set(GPUCA_DETERMINISTIC_MODE GPU)
 set(GPUCA_BUILD_EVENT_DISPLAY 0)
+set(GPUCA_DETERMINISTIC_MODE GPU)
+set(GPUCA_DETERMINISTIC_NO_FTZ 1)
 EoF
 
 cmake -DCMAKE_INSTALL_PREFIX=../install "$O2_SOURCEDIR/GPU/GPUTracking/Standalone"

--- a/o2-gpu-test.sh
+++ b/o2-gpu-test.sh
@@ -3,6 +3,8 @@ version: "1.0"
 requires:
   - O2
   - gpu-system
+build_requires:
+  - alibuild-recipe-tools
 license: GPL-3.0
 force_rebuild: true
 ---
@@ -38,14 +40,4 @@ rm -Rf $BUILDDIR/gpu-test
 
 # Dummy modulefile
 mkdir -p $INSTALLROOT/etc/modulefiles
-cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 O2/$O2_VERSION-$O2_REVISION
-EoF
+alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME

--- a/o2-gpu-test.sh
+++ b/o2-gpu-test.sh
@@ -1,0 +1,51 @@
+package: O2-GPU-test
+version: "1.0"
+requires:
+  - O2
+  - gpu-system
+license: GPL-3.0
+force_rebuild: true
+---
+#!/bin/bash -e
+
+if [[ -n ${GPU_SYSTEM_ROOT:-} && -f $GPU_SYSTEM_ROOT/etc/gpu-features-available.sh ]]; then
+  source $GPU_SYSTEM_ROOT/etc/gpu-features-available.sh
+fi
+
+rm -Rf $BUILDDIR/gpu-test
+mkdir $BUILDDIR/gpu-test
+pushd $BUILDDIR/gpu-test
+
+if [[ -n ${O2GPUCI_BACKENDS:-} ]]; then
+  read -r -a GPU_BACKENDS <<< "${O2GPUCI_BACKENDS//,/ }"
+else
+  GPU_BACKENDS=()
+  [[ ${O2_GPU_CUDA_AVAILABLE:-0} == 1 ]] && GPU_BACKENDS+=(CUDA)
+  [[ ${O2_GPU_ROCM_AVAILABLE:-0} == 1 ]] && GPU_BACKENDS+=(HIP)
+fi
+
+if [[ ${#GPU_BACKENDS[@]} == 0 ]]; then
+  echo "O2-GPU-test: no GPU backend selected or detected." >&2
+  exit 1
+fi
+
+for BACKEND in "${GPU_BACKENDS[@]}"; do
+  o2-gpu-standalone-benchmark --noEvents -g --gpuType "${BACKEND^^}"
+done
+
+popd
+rm -Rf $BUILDDIR/gpu-test
+
+# Dummy modulefile
+mkdir -p $INSTALLROOT/etc/modulefiles
+cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 O2/$O2_VERSION-$O2_REVISION
+EoF

--- a/o2gpuci.sh
+++ b/o2gpuci.sh
@@ -1,0 +1,38 @@
+package: O2GPUCI
+version: "1.0.0"
+tag: "O2GPUCI-1.0.0"
+requires:
+  - O2
+  - O2-GPU-test:(.*x86-64)
+license: GPL-3.0
+valid_defaults:
+  - o2
+  - o2-epn
+  - ali
+---
+#!/bin/bash -ex
+
+MODULEFILE_DEPS=
+for RPKG in $REQUIRES; do
+  [[ $RPKG != defaults* ]] || continue
+  RPKG_UP=$(echo $RPKG|tr '[:lower:]' '[:upper:]'|tr '-' '_')
+  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
+  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
+  MODULEFILE_DEPS="${MODULEFILE_DEPS} ${RPKG}/${RPKG_VERSION}-${RPKG_REVISION}"
+done
+MODULEFILE_DEPS=$(echo $MODULEFILE_DEPS)
+
+# Modulefile
+mkdir -p $INSTALLROOT/etc/modulefiles
+cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+
+# Dependencies
+module load BASE/1.0 ${MODULEFILE_DEPS}
+EoF

--- a/o2gpuci.sh
+++ b/o2gpuci.sh
@@ -4,6 +4,7 @@ tag: "O2GPUCI-1.0.0"
 requires:
   - O2
   - O2-GPU-test:(.*x86-64)
+  - O2-GPU-deterministic-test:(.*x86-64)
 license: GPL-3.0
 valid_defaults:
   - o2

--- a/o2gpuci.sh
+++ b/o2gpuci.sh
@@ -5,6 +5,8 @@ requires:
   - O2
   - O2-GPU-test:(.*x86-64)
   - O2-GPU-deterministic-test:(.*x86-64)
+build_requires:
+  - alibuild-recipe-tools
 license: GPL-3.0
 valid_defaults:
   - o2
@@ -13,27 +15,6 @@ valid_defaults:
 ---
 #!/bin/bash -ex
 
-MODULEFILE_DEPS=
-for RPKG in $REQUIRES; do
-  [[ $RPKG != defaults* ]] || continue
-  RPKG_UP=$(echo $RPKG|tr '[:lower:]' '[:upper:]'|tr '-' '_')
-  RPKG_VERSION=$(eval echo "\$${RPKG_UP}_VERSION")
-  RPKG_REVISION=$(eval echo "\$${RPKG_UP}_REVISION")
-  MODULEFILE_DEPS="${MODULEFILE_DEPS} ${RPKG}/${RPKG_VERSION}-${RPKG_REVISION}"
-done
-MODULEFILE_DEPS=$(echo $MODULEFILE_DEPS)
-
 # Modulefile
 mkdir -p $INSTALLROOT/etc/modulefiles
-cat > $INSTALLROOT/etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-
-# Dependencies
-module load BASE/1.0 ${MODULEFILE_DEPS}
-EoF
+alibuild-generate-module > $INSTALLROOT/etc/modulefiles/$PKGNAME


### PR DESCRIPTION
Add new recipes for O2 GPU CI tests.

Structure follows the full CI recipe:
- Added a meta recipe for GPU tests
- Added a test recipe that runs `o2-gpu-standalone-benchmark`

Test script currently only runs `o2-gpu-standalone-benchmark --noEvents` for available architectures to test that GPUs are present in container.