### PR TITLE
ACTSO2: Restore source URL to SSH in actso2.sh

### DIFF
--- a/actso2.sh
+++ b/actso2.sh
@@ -13,7 +13,7 @@ build_requires:
   - Eigen3
   - ninja
   - alibuild-recipe-tools
-source: https://gitlab.cern.ch/alice3-trackers/wp1-simulationsandperformances/actso2
+source: ssh://git@gitlab.cern.ch:7999/alice3-trackers/wp1-simulationsandperformances/actso2.git
 ---
 #!/bin/bash -ex
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \


### PR DESCRIPTION
Updated the source URL back from HTTPS to SSH for actso2, reverting https://github.com/alisw/alidist/pull/6205
The init via ssh is seamless if the ssh key is configured in gitlab