### PR TITLE
Fix MadGraph: Pythia8 shower chain and conf relocation

### DIFF
--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -45,9 +45,9 @@ pushd "$INSTALLROOT"
   elif [[ -d lib && ! -d lib64 ]]; then
     ln -nfs lib lib64
   fi
-  # Uniform Python library path
+  # Uniform Python library path (relative symlink so it survives relocation)
   pushd lib
-    find $PWD -name "python3*" -exec ln -nfs {} python \;
+    for d in python3*; do [[ -d $d ]] && ln -nfs "$d" python && break; done
   popd
 popd
 

--- a/madgraph.sh
+++ b/madgraph.sh
@@ -18,7 +18,13 @@ build_requires:
 
 rsync -a --no-specials --no-devices  --chmod=ug=rwX --exclude '**/.git' --delete --delete-excluded "$SOURCEDIR/" "$BUILDDIR/"
 
-# install internal packages 
+# Pythia8 Makefile.inc could have a space after "-rpath," which causes the linker to fail to find HepMC2. This ensures there is no space.
+sed -i -E \
+    -e "s|HEPMC2_LIB=.*|HEPMC2_LIB=-L${HEPMC_ROOT}/lib -Wl,-rpath,${HEPMC_ROOT}/lib -lHepMC|" \
+    -e "s|HEPMC2_INCLUDE=.*|HEPMC2_INCLUDE=-I${HEPMC_ROOT}/include|" \
+    "$PYTHIA_ROOT/share/Pythia8/examples/Makefile.inc"
+
+# install internal packages
 cd "$BUILDDIR"
 cat << EOF >> install.dat
 set lhapdf $LHAPDF_ROOT/bin/lhapdf-config
@@ -78,9 +84,19 @@ find QCDLoop -mindepth 1 -maxdepth 1 -not -name include -not -name lib -not -nam
 rm *.tgz
 rm vendor/*tar.gz
 
-# change paths in configuration file for package relocation
-sed -i.deleteme -e "s|$BUILDDIR|$INSTALLROOT|" input/mg5_configuration.txt
-rm -f input/mg5_configuration.deleteme
+# Make the configuration written at build time relocatable, editing it in place so
+# that anything else MG5 wrote is kept.
+# Paths inside the package are relative to the MG5 install directory
+PYTHIA_REL="../../pythia/$(basename "$PYTHIA_ROOT")"
+sed -i.deleteme \
+    -e "s|$BUILDDIR/*|./|g" \
+    -e "s|^pythia8_path *=.*|pythia8_path = $PYTHIA_REL|" \
+    -e "s|^fastjet *=.*|fastjet = fastjet-config|" \
+    -e "s|^lhapdf *=.*|lhapdf = lhapdf-config|" \
+    -e "s|^#* *automatic_html_opening *=.*|automatic_html_opening = False|" \
+    -e "s|^mg5_path *=|# mg5_path =|" \
+    input/mg5_configuration.txt
+rm -f input/mg5_configuration.txt.deleteme
 rsync -a "$BUILDDIR/" "$INSTALLROOT/"
 
 #ModuleFile

--- a/pythia.sh
+++ b/pythia.sh
@@ -6,6 +6,7 @@ requires:
   - lhapdf
   - HepMC
   - boost
+  - zlib
 license: GPL-2.0
 env:
   PYTHIA8DATA: "$PYTHIA_ROOT/share/Pythia8/xmldoc"
@@ -24,7 +25,8 @@ esac
             --enable-shared \
             ${HEPMC_ROOT:+--with-hepmc2="$HEPMC_ROOT"} \
             ${LHAPDF_ROOT:+--with-lhapdf6="$LHAPDF_ROOT"} \
-            ${BOOST_ROOT:+--with-boost="$BOOST_ROOT"}
+            ${BOOST_ROOT:+--with-boost="$BOOST_ROOT"} \
+            ${ZLIB_ROOT:+--with-gzip="$ZLIB_ROOT"}
 
 if [[ $ARCHITECTURE =~ "slc5.*" ]]; then
     ln -s LHAPDF5.h include/Pythia8Plugins/LHAPDF5.cc


### PR DESCRIPTION
Multiple fixes applied: 
- madgraph.sh &rarr;  1) fix to HepMC2 path inside Pythia8 MakeFile.inc; 2) No more dummy configurations and runtime patching. Everything is done using the relative ./, which is understood by MG5.
- lhapdf.sh &rarr; I noticed `/local/workspace/etc` was set in the symlink which was clearly not right and it was causing `Failed to access python version of LHAPDF`. While digging I saw that the recipe created lib/python with `find $PWD ... ln -nfs {} python`, so with an absolute symlink frozen to the build-time INSTALLROOT. The applied fix creates a relative symlink (python -> python3.10), valid at any install prefix (tested locally and with an alice-docker fresh install).
- pythia.sh &rarr; Pythia8 is now built with zlib. Before gzipped hepmc files could not be read, making the MG5 Pythia8 interface hang indefinitely.  
@ktf let me know what you think... If we're caching by node on the GRID this solution should also work as the configuration will be the same for all the jobs in a node if they can access the /tmp folder, but please correct me if I'm wrong.