### PR TITLE
Software packages for CAD support

### DIFF
--- a/occt.sh
+++ b/occt.sh
@@ -1,0 +1,23 @@
+package: OCCT
+version: "v7.9.3"
+tag: V7_9_3
+source: https://github.com/Open-Cascade-SAS/OCCT
+license: LGPLv2.1
+build_requires:
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
+---
+#!/bin/bash -e
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT   \
+      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}
+
+# Build and install
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --bin --lib > $MODULEFILE
+

--- a/pythonocc.sh
+++ b/pythonocc.sh
@@ -1,0 +1,38 @@
+package: pythonOCC
+version: "v7.9.3"
+tag: 7.9.3
+source: https://github.com/tpaviot/pythonocc-core.git
+license: LGPLv2.1
+requires:
+  - OCCT
+build_requires:
+  - "GCC-Toolchain:(?!osx)"
+  - CMake
+  - alibuild-recipe-tools
+  - SWIG
+  - Python-modules
+  - RapidJSON
+---
+#!/bin/bash -e
+
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            \
+      ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}                                   \
+      -DPYTHONOCC_MESHDS_NUMPY=ON                                               \
+      -DCMAKE_CXX_FLAGS="-isystem ${RAPIDJSON_ROOT}/include ${CMAKE_CXX_FLAGS}"
+
+# Build and install
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# find out python package installation path
+OCC_PATH=$(find ${INSTALLROOT} -name "OCC")
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --lib > $MODULEFILE
+cat >> "$MODULEFILE" <<EOF
+# extra environment
+set PYTHONOCC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PYTHONPATH ${OCC_PATH}
+EOF

--- a/swig.sh
+++ b/swig.sh
@@ -1,5 +1,5 @@
 package: SWIG
-version: 4.2.0
+version: 4.2.1
 license: GPL-3.0
 build_requires:
   - "autotools:(slc6|slc7)"


### PR DESCRIPTION
Make OpenCascade and it's python binding PythonOCC part of the ALICE software stack, for instance used
for rapid prototyping and simulation of detector geometries.

For now, it is not part of the O2sim meta-package and not automaticically published on CVMFS. But with this recipe, users can conveniently install necessary software for local development.