### PR TITLE
Temporarily take out TpcFecUtils to avoid CI problem

### DIFF
--- a/o2suite.sh
+++ b/o2suite.sh
@@ -13,7 +13,6 @@ requires:
   - "DataDistribution:(?!osx|.*aarch64)"
   - "ALF:(?!osx|.*aarch64)"
   - "mesos:(slc.*x86)"
-  - "TpcFecUtils:(?!osx|.*aarch64)"
 license: GPL-3.0
 valid_defaults:
   - o2


### PR DESCRIPTION
CI currently down due to access problems with TpcFecUtils. This should bring CI back to working and unblock many PRs.