### PR TITLE
TGeo2VecGeom: fix CMake relocation problem, avoid hardcoded libdir

### DIFF
--- a/tgeo2vecgeom.sh
+++ b/tgeo2vecgeom.sh
@@ -1,6 +1,6 @@
 package: TGeo2VecGeom
 version: "%(tag_basename)s"
-tag: v0.1.0
+tag: v0.1.1
 source: https://gitlab.cern.ch/VecGeom/tgeo2vecgeom.git
 requires:
   - "GCC-Toolchain:(?!osx)"
@@ -15,17 +15,26 @@ build_requires:
 
 cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT      \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-RelWithDebInfo} \
-      -DVecGeom_DIR=${VECGEOM_ROOT}/lib64/cmake/VecGeom    \
+      -DCMAKE_PREFIX_PATH="$VECGEOM_ROOT;$ROOT_ROOT"       \
+      -DCMAKE_INSTALL_LIBDIR=lib                           \
       -DTGEO2VECGEOM_BUILD_TESTS=OFF                       \
       -GNinja
 
 cmake --build . -- ${JOBS+-j $JOBS} install
 
+# aliBuild only relocates references to our own INSTALLROOT, so a hardcoded dependency
+# path breaks every consumer that gets us from the build cache. Skipped in devel mode.
+if [ "${INSTALLROOT#"$WORK_DIR/$ARCHITECTURE/"}" = "$INSTALLROOT" ] &&
+   grep -I -R -l -F "$WORK_DIR/$ARCHITECTURE/" "$INSTALLROOT"; then
+  echo "ERROR: the files above hardcode a dependency path" >&2
+  exit 1
+fi
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
 mkdir -p "$MODULEDIR"
-alibuild-generate-module --lib > $MODULEFILE
+alibuild-generate-module --lib --cmake > $MODULEFILE
 cat >> "$MODULEFILE" <<EOF
 # extra environment
 set TGEO2VECGEOM_ROOT \$::env(BASEDIR)/$PKGNAME/\$version


### PR DESCRIPTION
Bumps TGeo2VecGeom to v0.1.1 (https://gitlab.cern.ch/VecGeom/tgeo2vecgeom/-/merge_requests/3), which stops baking the build machine's ROOT/VecGeom include paths into `TGeo2VecGeomTargets.cmake`. aliBuild only relocates a package's own INSTALLROOT, so O2 builds taking TGeo2VecGeom from the build cache failed with `includes non-existent path .../ROOT/v6-36-10-alice2-2/include`.

Recipe side: a guard against the same class of bug, `CMAKE_INSTALL_LIBDIR=lib` (el9 installs to lib64, which `--lib` does not put on LD_LIBRARY_PATH), `CMAKE_PREFIX_PATH` instead of a hardcoded `lib64` path, and `--cmake` on the modulefile.