### PR TITLE
Fix clang post-installation test

### DIFF
--- a/clang.sh
+++ b/clang.sh
@@ -111,14 +111,17 @@ rm "$INSTALLROOT"/lib/cmake/clang/*.bak
 # we want to resolve the environment when we run, not when we build this, to avoid
 # relocation issues in case GCC and clang are not built at the same time.
 if [ ! "X$GCC_TOOLCHAIN_ROOT" = X ]; then
-  cat > "$INSTALLROOT/bin-safe/$(clang --print-target-triple)-clang++.cfg" << \EOF
---gcc-toolchain=$GCC_TOOLCHAIN_ROOT
+  target_triple="$("$INSTALLROOT/bin-safe/clang" --print-target-triple)"
+  gcc_toolchain_root="$(eval echo "$GCC_TOOLCHAIN_ROOT")"
+
+  cat > "$INSTALLROOT/bin-safe/${target_triple}-clang++.cfg" << EOF
+--gcc-toolchain=$gcc_toolchain_root
 EOF
-  cat > "$INSTALLROOT/bin-safe/$(clang --print-target-triple)-clang.cfg" << \EOF
---gcc-toolchain=$GCC_TOOLCHAIN_ROOT
+  cat > "$INSTALLROOT/bin-safe/${target_triple}-clang.cfg" << EOF
+--gcc-toolchain=$gcc_toolchain_root
 EOF
-  cat > "$INSTALLROOT/bin-safe/$(clang --print-target-triple)-clang-cpp.cfg" << \EOF
---gcc-toolchain=$GCC_TOOLCHAIN_ROOT
+  cat > "$INSTALLROOT/bin-safe/${target_triple}-clang-cpp.cfg" << EOF
+--gcc-toolchain=$gcc_toolchain_root
 EOF
 fi
 


### PR DESCRIPTION
Suggested by codex with this explanation
```
  Clang.sh moves clang into bin-safe, then immediately runs:

  $(clang --print-target-triple)

  But plain clang is no longer in PATH, so the log shows:

  Clang.sh: line 95: clang: command not found
  Clang.sh: line 98: clang: command not found
  Clang.sh: line 101: clang: command not found

  That creates wrongly named config files:

  -clang.cfg
  -clang++.cfg
  -clang-cpp.cfg

  So bin-safe/clang++ does not load the intended --gcc-toolchain config. It falls back to system GCC 12:

  Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/12

  but this machine only has C++ headers for GCC 11 under /usr/include/c++/11, not GCC 12, so the final check fails with:
  test.cc:1:10: fatal error: 'iostream' file not found

  I also verified that using the aliBuild GCC toolchain explicitly works:

  clang++ --gcc-toolchain=/home/shahoian/alice/sw/ubuntu2204_x86-64/GCC-Toolchain/v14.2.0-alice2-1 ...

  One more issue: the generated config contains the literal text $GCC_TOOLCHAIN_ROOT; Clang config files did not expand that in my test. So the recipe likely needs both a correct clang path for --print-target-triple and a concrete GCC toolchain path, or another supported relocation mechanism.
```

The original build error was 
```
++ cat
+++ clang --print-target-triple
/home/shahoian/alice/sw/SPECS/ubuntu2204_x86-64/Clang/v20.1.7-local1/Clang.sh: line 95: clang: command not found
++ cat
+++ clang --print-target-triple
/home/shahoian/alice/sw/SPECS/ubuntu2204_x86-64/Clang/v20.1.7-local1/Clang.sh: line 98: clang: command not found
++ cat
+++ clang --print-target-triple
/home/shahoian/alice/sw/SPECS/ubuntu2204_x86-64/Clang/v20.1.7-local1/Clang.sh: line 101: clang: command not found
++ cat
++ /home/shahoian/alice/sw/INSTALLROOT/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/ubuntu2204_x86-64/Clang/v20.1.7-local1/bin-safe/clang++ -v -c test.cc
clang version 20.1.7 (https://github.com/alisw/llvm-project-reduced 9e080c5c92c6e0cbd57e0f4794cf65d844757aa6)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/shahoian/alice/sw/INSTALLROOT/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/ubuntu2204_x86-64/Clang/v20.1.7-local1/bin-safe
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/11
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/12
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/12
Candidate multilib: .;@m64
Selected multilib: .;@m64
Found CUDA installation: /usr/local/cuda-12.9, version 
 (in-process)
 "/home/shahoian/alice/sw/INSTALLROOT/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/ubuntu2204_x86-64/Clang/v20.1.7-local1/bin-safe/clang-20" -cc1 -triple x86_64-unknown-linux-gnu -emit-obj -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name test.cc -mrelocation-model pic -pic-level 2 -pic-is-pie -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -funwind-tables=2 -target-cpu x86-64 -tune-cpu generic -debugger-tuning=gdb -fdebug-compilation-dir=/home/shahoian/alice/sw/BUILD/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/Clang -v -fcoverage-compilation-dir=/home/shahoian/alice/sw/BUILD/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/Clang -resource-dir /home/shahoian/alice/sw/INSTALLROOT/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/ubuntu2204_x86-64/Clang/v20.1.7-local1/lib/clang/20 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++ -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/x86_64-linux-gnu -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/backward -internal-isystem /home/shahoian/alice/sw/INSTALLROOT/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/ubuntu2204_x86-64/Clang/v20.1.7-local1/lib/clang/20/include -internal-isystem /usr/local/include -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/12/../../../../x86_64-linux-gnu/include -internal-externc-isystem /usr/include/x86_64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -fdeprecated-macro -ferror-limit 19 -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -fcxx-exceptions -fexceptions -faddrsig -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o test.o -x c++ test.cc
clang -cc1 version 20.1.7 based upon LLVM 20.1.7 default target x86_64-unknown-linux-gnu
ignoring nonexistent directory "/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/x86_64-linux-gnu"
ignoring nonexistent directory "/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/backward"
ignoring nonexistent directory "/usr/lib/gcc/x86_64-linux-gnu/12/../../../../x86_64-linux-gnu/include"
ignoring nonexistent directory "/include"
#include "..." search starts here:
#include <...> search starts here:
 /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++
 /home/shahoian/alice/sw/INSTALLROOT/ff4019f631a062cb4f2c58b8a6a0f3c2a4039695/ubuntu2204_x86-64/Clang/v20.1.7-local1/lib/clang/20/include
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include
End of search list.
test.cc:1:10: fatal error: 'iostream' file not found
    1 | #include <iostream>
      |          ^~~~~~~~~~
1 error generated.
```