### PR TITLE
PythonOCC: fix of modulefile

### DIFF
--- a/pythonocc.sh
+++ b/pythonocc.sh
@@ -5,12 +5,12 @@ source: https://github.com/tpaviot/pythonocc-core.git
 license: LGPLv2.1
 requires:
   - OCCT
+  - Python-modules
 build_requires:
   - "GCC-Toolchain:(?!osx)"
   - CMake
   - alibuild-recipe-tools
   - SWIG
-  - Python-modules
   - RapidJSON
 ---
 #!/bin/bash -e
@@ -23,8 +23,9 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT                            
 # Build and install
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
-# find out python package installation path
-OCC_PATH=$(find ${INSTALLROOT} -name "OCC")
+# find out python package installation path; PYTHONPATH needs the site-packages
+# directory that CONTAINS the OCC package, not the package directory itself
+OCC_PATH=$(dirname $(find ${INSTALLROOT} -name "OCC"))
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
`import OCC` does not work from the loaded `pythonOCC` module.

- `PYTHONPATH` was set to the `OCC` package directory itself rather than the `site-packages` directory containing it, so Python looks inside the package and never finds it.
- `Python-modules` moved from `build_requires` to `requires`: the build sets `PYTHONOCC_MESHDS_NUMPY=ON`, so numpy is needed at import time.

Verified by applying the same change to an installed modulefile: `alienv enter O2sim/latest,pythonOCC/latest` then goes from `ModuleNotFoundError: No module named 'OCC'` to a working import in one shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)