### PR TITLE
Enable ACTS alignment build option

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,6 +1,6 @@
 package: ACTS
-version: "v46.4.0"
-tag: "v46.4.0-alice"
+version: "v47.7.0"
+tag: "v47.7.0-alice"
 requires:
   - ROOT
   - pythia

--- a/acts.sh
+++ b/acts.sh
@@ -32,6 +32,7 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT       \
                  -DACTS_BUILD_FATRAS_GEANT4=ON             \
                  -DACTS_BUILD_EXAMPLES_GEANT4=ON           \
                  -DACTS_BUILD_EXAMPLES_ROOT=ON             \
+                 -DACTS_BUILD_ALIGNMENT=ON                 \
                  -DGeant4_DIR=${GEANT4_ROOT}/lib           \
                  -G Ninja 
 


### PR DESCRIPTION
Enable ACTS alignment build option - needed for ALICE 3 performance studies.
Also, picking up here PR https://github.com/alisw/alidist/pull/6301