### PR TITLE
Encoding of gpu architecture using . instead of @

### DIFF
--- a/gpu-system.sh
+++ b/gpu-system.sh
@@ -42,8 +42,8 @@ prefer_system_check: |
 
     if [[ ${ALIBUILD_O2_FORCE_GPU} == "build" ]]; then
       GPU_FEATURES=build-from-alidist
-      [[ -n $ALIBUILD_O2_FORCE_GPU_CUDA_ARCH ]] && add_feature _ cudaarch@$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${ALIBUILD_O2_FORCE_GPU_CUDA_ARCH}")@
-      [[ -n $ALIBUILD_O2_FORCE_GPU_HIP_ARCH ]] && add_feature _ rocmarch@$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${ALIBUILD_O2_FORCE_GPU_HIP_ARCH}")@
+      [[ -n $ALIBUILD_O2_FORCE_GPU_CUDA_ARCH ]] && add_feature _ cudaarch.$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${ALIBUILD_O2_FORCE_GPU_CUDA_ARCH}").
+      [[ -n $ALIBUILD_O2_FORCE_GPU_HIP_ARCH ]] && add_feature _ rocmarch.$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${ALIBUILD_O2_FORCE_GPU_HIP_ARCH}").
       break
     fi
 
@@ -177,14 +177,14 @@ prefer_system_check: |
     if [[ $GPU_CUDA_ENABLED == 1 ]]; then
       add_feature - cuda
       [[ -n $GPU_CUDA_VERSION ]] && add_feature _ ${GPU_CUDA_VERSION//-/_}
-      [[ -n $GPU_CUDA_ARCHITECTURE ]] && add_feature _ arch@$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${GPU_CUDA_ARCHITECTURE}")@
+      [[ -n $GPU_CUDA_ARCHITECTURE ]] && add_feature _ arch.$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${GPU_CUDA_ARCHITECTURE}").
       [[ -n $O2_GPU_CUDA_HOME ]] && add_feature _ "home_$(base32 -i -w0 <<< "${O2_GPU_CUDA_HOME}" | tr '=' '0')"
     fi
 
     if [[ $GPU_HIP_ENABLED == 1 ]]; then
       add_feature - rocm
       [[ -n $GPU_HIP_VERSION ]] && add_feature _ ${GPU_HIP_VERSION//-/_}
-      [[ -n $GPU_HIP_ARCHITECTURE ]] && add_feature _ arch@$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${GPU_HIP_ARCHITECTURE}")@
+      [[ -n $GPU_HIP_ARCHITECTURE ]] && add_feature _ arch.$(sed -e "s/;/#/g" -e "s/-/_/g" <<< "${GPU_HIP_ARCHITECTURE}").
       [[ -n $O2_GPU_ROCM_HOME ]] && add_feature _ "home_$(base32 -i -w0 <<< "${O2_GPU_ROCM_HOME}" | tr '=' '0')"
     fi
 
@@ -315,10 +315,10 @@ prefer_system_replacement_specs:
         echo "export O2_GPU_MIGRAPHX_AVAILABLE=\"$( ( [[ "$PKG_VERSION" =~ (^|-)migraphx(-|_|$) ]] && echo 1 ) || echo 0 )\""
         echo "export O2_GPU_TENSORRT_AVAILABLE=\"$( ( [[ "$PKG_VERSION" =~ (^|-)tensorrt(-|_|$) ]] && echo 1 ) || echo 0 )\""
 
-        [[ "$PKG_VERSION" =~ (^|-)cuda([^-]*)_home_([^@]*)(-|_|$) ]] && echo 'export O2_GPU_CUDA_HOME="'$(tr '0' '=' <<< "${BASH_REMATCH[3]}" | base32 -d 2> /dev/null)'"'
-        [[ "$PKG_VERSION" =~ (^|-)rocm([^-]*)_home_([^@]*)(-|_|$) ]] && echo 'export O2_GPU_ROCM_HOME="'$(tr '0' '=' <<< "${BASH_REMATCH[3]}" | base32 -d 2> /dev/null)'"'
-        [[ "$PKG_VERSION" =~ (^|-)cuda([^-]*)_arch@([^@]*)@(-|_|$) ]] && echo 'export O2_GPU_CUDA_AVAILABLE_ARCH="'$(sed -e 's/#/;/g' -e 's/_/-/g' <<< "${BASH_REMATCH[3]}" 2> /dev/null)'"'
-        [[ "$PKG_VERSION" =~ (^|-)rocm([^-]*)_arch@([^@]*)@(-|_|$) ]] && echo 'export O2_GPU_ROCM_AVAILABLE_ARCH="'$(sed -e 's/#/;/g' -e 's/_/-/g' <<< "${BASH_REMATCH[3]}" 2> /dev/null)'"'
+        [[ "$PKG_VERSION" =~ (^|-)cuda([^-]*)_home_([^-_]*)(-|_|$) ]] && echo 'export O2_GPU_CUDA_HOME="'$(tr '0' '=' <<< "${BASH_REMATCH[3]}" | base32 -d 2> /dev/null)'"'
+        [[ "$PKG_VERSION" =~ (^|-)rocm([^-]*)_home_([^-_]*)(-|_|$) ]] && echo 'export O2_GPU_ROCM_HOME="'$(tr '0' '=' <<< "${BASH_REMATCH[3]}" | base32 -d 2> /dev/null)'"'
+        [[ "$PKG_VERSION" =~ (^|-)cuda([^-]*)_arch\.([^.]*)\.(-|_|$) ]] && echo 'export O2_GPU_CUDA_AVAILABLE_ARCH="'$(sed -e 's/#/;/g' -e 's/_/-/g' <<< "${BASH_REMATCH[3]}" 2> /dev/null)'"'
+        [[ "$PKG_VERSION" =~ (^|-)rocm([^-]*)_arch\.([^.]*)\.(-|_|$) ]] && echo 'export O2_GPU_ROCM_AVAILABLE_ARCH="'$(sed -e 's/#/;/g' -e 's/_/-/g' <<< "${BASH_REMATCH[3]}" 2> /dev/null)'"'
         true
       } > "$INSTALLROOT"/etc/gpu-features-available.sh
 ---

--- a/gpu-system.sh
+++ b/gpu-system.sh
@@ -212,20 +212,25 @@ prefer_system_check: |
         add_feature - miopen
     fi
 
-    # MIGraphX has to be new enough for the ONNXRuntime we build, not merely
-    # present: its provider references migraphx_shape_fp4x2_type, which appears
-    # in MIGraphX 7.1 (bf16 and fp8e5m2fnuz arrived in 6.4). On anything older
-    # every other file compiles and the build then dies on three enum cases, so
-    # gate on the API itself -- this turns MIGraphX back on by itself once the
-    # host is upgraded, with no disable left behind to forget about.
+    # ONNXRuntime's MIGraphX provider references three type enums (bf16 and
+    # fp8e5m2fnuz arrived in MIGraphX 2.12 / ROCm 6.4, fp4x2 later still).
+    # onnxruntime.sh detects which ones the installed header lacks and guards
+    # those cases out of the provider, so anything from MIGraphX 2.11 (ROCm
+    # 6.3) on is usable. Older than that has never been tried: keep it off.
     #
-    # ROCm 6.x keeps these headers in a self-contained prefix under lib/, which
-    # is on no default include path; onnxruntime.sh finds the prefix and passes
+    # ROCm 6.x keeps version.h in a self-contained prefix under lib/, which is
+    # on no default include path; onnxruntime.sh finds the prefix and passes
     # it. Look in both places.
     MIGRAPHX_C_API=
-    for _hdr in /opt/rocm/lib/migraphx/include/migraphx/migraphx.h \
-                /opt/rocm/include/migraphx/migraphx.h; do
-      if [[ -f $_hdr ]] && grep -q fp4x2 "$_hdr"; then MIGRAPHX_C_API=$_hdr; break; fi
+    for _vh in /opt/rocm/lib/migraphx/include/migraphx/version.h \
+               /opt/rocm/include/migraphx/version.h; do
+      [[ -f $_vh ]] || continue
+      _mgx_major=$(grep -oP 'MIGRAPHX_VERSION_MAJOR\s+\K[0-9]+' "$_vh" || true)
+      _mgx_minor=$(grep -oP 'MIGRAPHX_VERSION_MINOR\s+\K[0-9]+' "$_vh" || true)
+      if [[ -n $_mgx_major && -n $_mgx_minor ]] && (( _mgx_major > 2 || (_mgx_major == 2 && _mgx_minor >= 11) )); then
+        MIGRAPHX_C_API=$_vh
+      fi
+      break
     done
     if [[ $ALIBUILD_O2_FORCE_GPU_MIGRAPHX == 1 ]] || [[ $GPU_FEATURES =~ (^|-)"miopen"(-|_|$) && ${ALIBUILD_O2_FORCE_GPU_MIGRAPHX} != 0 && -n $MIGRAPHX_C_API ]]; then
       add_feature - migraphx
@@ -239,7 +244,7 @@ prefer_system_check: |
       add_feature - tensorrt
     fi
 
-    # MIGraphX is gated on the C API above, so it is legitimately absent when the
+    # MIGraphX is gated on the version above, so it is legitimately absent when the
     # host ROCm is older than the ONNXRuntime needs -- demand it only when it
     # could have been enabled, otherwise FORCE_GPU=1 makes that state unreachable
     # and even ALIBUILD_O2_FORCE_GPU_MIGRAPHX=0 cannot opt out.

--- a/onnxruntime.sh
+++ b/onnxruntime.sh
@@ -114,6 +114,42 @@ if [[ "$ORT_MIGRAPHX_BUILD" == 1 ]]; then
     fi
   done
   echo "MIGRAPHX_HOME=${MIGRAPHX_HOME:-<not found>}"
+
+  # The provider maps ONNX element types onto MIGraphX enums that older
+  # MIGraphX lacks: bf16 and fp8e5m2fnuz arrived in 2.12 (ROCm 6.4), fp4x2
+  # later. Everything else in the provider is already guarded upstream by HIP
+  # version checks; only these three switch cases are not, so detect each one
+  # in the installed C header and compile the case out when it is missing.
+  # The guards are opt-out: an untouched build keeps upstream behaviour.
+  for _hdr in "${O2_GPU_ROCM_HOME:-/opt/rocm}/include/migraphx/migraphx.h" \
+              "${MIGRAPHX_HOME:-/nonexistent}/include/migraphx/migraphx.h"; do
+    [[ -f $_hdr ]] && { MIGRAPHX_C_HEADER=$_hdr; break; }
+  done
+  if [[ -n $MIGRAPHX_C_HEADER ]]; then
+    for _t in bf16 fp8e5m2fnuz fp4x2; do
+      if ! grep -q "${_t}_type" "$MIGRAPHX_C_HEADER"; then
+        echo "MIGraphX header lacks ${_t}_type: compiling that case out of the provider"
+        CXXFLAGS="$CXXFLAGS -DO2_MGX_NO_$(tr a-z A-Z <<< "$_t")_TYPE"
+      fi
+    done
+    python3 - <<'PYEOF'
+import pathlib, re
+p = pathlib.Path("onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc")
+s = p.read_text()
+for onnx_type, mgx_type in (("BFLOAT16", "bf16"), ("FLOAT8E5M2FNUZ", "fp8e5m2fnuz"), ("FLOAT4E2M1", "fp4x2")):
+    case = ("    case ONNX_TENSOR_ELEMENT_DATA_TYPE_%s:\n"
+            "      mgx_type = migraphx_shape_%s_type;\n"
+            "      break;\n") % (onnx_type, mgx_type)
+    if "#ifndef O2_MGX_NO_%s_TYPE" % mgx_type.upper() in s:
+        continue  # already patched
+    if s.count(case) != 1:
+        raise SystemExit("MIGraphX provider patch: expected exactly one %s case, found %d" % (mgx_type, s.count(case)))
+    s = s.replace(case, "#ifndef O2_MGX_NO_%s_TYPE\n%s#endif\n" % (mgx_type.upper(), case))
+p.write_text(s)
+PYEOF
+  else
+    echo "WARNING: MIGraphX C header not found, provider built unpatched"
+  fi
 fi
 
 echo "O2_GPU_ROCM_HOME=$O2_GPU_ROCM_HOME"


### PR DESCRIPTION
Since 6eafd9bc the gpu-system version string encodes the GPU architecture as
`arch@<arch>@`, e.g.

    gpu-system/rocm_6.3.42134_arch@gfx906@_home_F5XXA5BPOJXWG3IK-miopen-local2

On hosts running Environment Modules 5 (e.g. the EPN nodes, Modules 5.3.0),
`advanced_version_spec` is enabled by default and `@` is parsed as a version
specifier. `alienv enter O2PDPSuite/...` then fails with

    ERROR: Unable to locate a modulefile for 'gpu-system/rocm_6.3.42134_arch@gfx906@_home_F5XXA5BPOJXWG3IK-miopen-local2'

and every dependent module (ONNXRuntime, O2, O2PDPSuite) fails to load.
Modules 4.x is not affected, which is why this went unnoticed.

This PR replaces the `@` delimiter with `.`, which Modules 5 accepts, already
occurs in version strings, and cannot clash with the `#` / `_` used inside the
architecture list. The parser that reconstructs `O2_GPU_*_AVAILABLE_ARCH` in
`gpu-features-available.sh` is updated accordingly. The `_home_` regexes used
`[^@]*` as terminator; they now stop at `-` or `_`, which is exact for base32.
`~`, `+` and `=` were also tested and are rejected by Modules 5.

Note: this changes the gpu-system version string, so gpu-system and its
dependents get rebuilt.

Tested on epn000 (Modules 5.3.0): the new module name loads, and the regexes
reproduce `gfx906`, `86;90-real` and `/opt/rocm` from sample version strings.